### PR TITLE
merge: sync main into develop after v1.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-03-03
+
+### Changed
+- MCP-created document block hierarchy now follows AFFiNE UI parity by writing `sys:parent` as `null` and relying on `sys:children` relationships.
+- Placement resolution for `append_block` (`beforeBlockId` / `afterBlockId`) now resolves parent context from child links when `sys:parent` is null.
+- Workspace bootstrap document blocks were aligned to the same null-parent shape for consistency.
+
+### Fixed
+- Resolved UI invisibility/inconsistency risk for MCP-created docs caused by parent linkage mismatch versus UI-created docs.
+- Fixed callout rendering parity by creating/storing callout text in a child paragraph block so text is visible in AFFiNE UI.
+- Added regression assertions in Docker E2E scripts to verify null-parent structure after `create_doc`, `append_paragraph`, and `create_doc_from_markdown`.
+
 ## [1.7.0] - 2026-02-27
 
 ### Added
@@ -188,6 +200,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[1.7.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.7.1
 [1.7.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.7.0
 [1.2.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.2.2
 [1.2.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.2.1
@@ -198,4 +211,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.7.1...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted or cloud). It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`).
 
-[![Version](https://img.shields.io/badge/version-1.7.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-1.7.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -19,7 +19,7 @@ A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted
 - Tools: 43 focused tools with WebSocket-based document editing
 - Status: Active
  
-> New in v1.7.0: Added remote HTTP MCP support (`/mcp`) with token/CORS controls, while retaining legacy SSE compatibility (`/sse`, `/messages`) for older clients.
+> New in v1.7.1: Fixed MCP-created document structure parity with AFFiNE UI (`sys:parent` handling) and callout text rendering, plus regression coverage for UI visibility paths.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## Version 1.7.1 (2026-03-03)
+
+### Highlights
+- Fixed MCP-created doc structure to match AFFiNE UI parent-link expectations.
+- Fixed callout block text rendering so MCP-created callouts display content in AFFiNE UI.
+- Added regression checks for document-visibility-sensitive creation paths.
+
+### What Changed
+- `src/tools/docs.ts`
+  - `sys:parent` writes for MCP-created blocks were aligned to UI parity (`null`).
+  - Placement context resolution now falls back to parent discovery from `sys:children` when parent fields are null.
+  - Callout creation now emits a child paragraph block and stores text there for UI-compatible rendering.
+- `src/tools/workspaces.ts`
+  - Workspace bootstrap document blocks now use the same null-parent structure for consistency.
+- `tests/test-database-creation.mjs`, `tests/test-bearer-auth.mjs`
+  - Added explicit regression assertions for parent-shape parity after `create_doc`, `append_paragraph`, and `create_doc_from_markdown`.
+
+### Validation Evidence
+- Local Docker AFFiNE validation passed for one-document full block coverage:
+  - Created one document and appended all currently supported MCP block types.
+  - Verified the document appears in `/workspace/{workspaceId}/all`.
+  - Verified direct document open path has no `Unexpected Application Error` / not-found state.
+  - Verified callout marker text renders in UI after the structural fix.
+- `npm run test:e2e` passed (`4 passed`) after the fix.
+- `npm run test:comprehensive` passed (`calledTools: 43`, `failed: 0`).
+
 ## Version 1.7.0 (2026-02-27)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -342,7 +342,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const noteId = generateId();
     const note = new Y.Map<any>();
     setSysFields(note, noteId, "affine:note");
-    note.set("sys:parent", pageId);
+    note.set("sys:parent", null);
     note.set("sys:children", new Y.Array<string>());
     note.set("prop:xywh", "[0,0,800,95]");
     note.set("prop:index", "a0");
@@ -378,7 +378,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const surfaceId = generateId();
     const surface = new Y.Map<any>();
     setSysFields(surface, surfaceId, "affine:surface");
-    surface.set("sys:parent", pageId);
+    surface.set("sys:parent", null);
     surface.set("sys:children", new Y.Array<string>());
     const elements = new Y.Map<any>();
     elements.set("type", "$blocksuite:internal:native$");
@@ -744,6 +744,32 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return index;
   }
 
+  function findParentIdByChild(blocks: Y.Map<any>, childId: string): string | null {
+    for (const [id, value] of blocks) {
+      if (!(value instanceof Y.Map)) {
+        continue;
+      }
+      const childIds = childIdsFrom(value.get("sys:children"));
+      if (childIds.includes(childId)) {
+        return String(id);
+      }
+    }
+    return null;
+  }
+
+  function resolveBlockParentId(blocks: Y.Map<any>, blockId: string): string | null {
+    const block = findBlockById(blocks, blockId);
+    if (!block) {
+      return null;
+    }
+    const rawParentId = block.get("sys:parent");
+    if (typeof rawParentId === "string" && rawParentId.trim().length > 0) {
+      return rawParentId;
+    }
+    // AFFiNE UI commonly stores sys:parent as null and derives hierarchy from sys:children.
+    return findParentIdByChild(blocks, blockId);
+  }
+
   function resolveInsertContext(blocks: Y.Map<any>, normalized: NormalizedAppendBlockInput): {
     parentId: string;
     parentBlock: Y.Map<any>;
@@ -760,8 +786,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       referenceBlockId = placement.afterBlockId;
       const referenceBlock = findBlockById(blocks, referenceBlockId);
       if (!referenceBlock) throw new Error(`placement.afterBlockId '${referenceBlockId}' was not found.`);
-      const refParentId = referenceBlock.get("sys:parent");
-      if (typeof refParentId !== "string" || !refParentId) {
+      const refParentId = resolveBlockParentId(blocks, referenceBlockId);
+      if (!refParentId) {
         throw new Error(`Block '${referenceBlockId}' has no parent.`);
       }
       parentId = refParentId;
@@ -770,8 +796,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       referenceBlockId = placement.beforeBlockId;
       const referenceBlock = findBlockById(blocks, referenceBlockId);
       if (!referenceBlock) throw new Error(`placement.beforeBlockId '${referenceBlockId}' was not found.`);
-      const refParentId = referenceBlock.get("sys:parent");
-      if (typeof refParentId !== "string" || !refParentId) {
+      const refParentId = resolveBlockParentId(blocks, referenceBlockId);
+      if (!refParentId) {
         throw new Error(`Block '${referenceBlockId}' has no parent.`);
       }
       parentId = refParentId;
@@ -838,20 +864,24 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return { parentId, parentBlock, children, insertIndex };
   }
 
-  function createBlock(
-    parentId: string,
-    normalized: NormalizedAppendBlockInput
-  ): { blockId: string; block: Y.Map<any>; flavour: string; blockType?: string } {
+  function createBlock(normalized: NormalizedAppendBlockInput): {
+    blockId: string;
+    block: Y.Map<any>;
+    flavour: string;
+    blockType?: string;
+    extraBlocks?: Array<{ blockId: string; block: Y.Map<any> }>;
+  } {
     const blockId = generateId();
     const block = new Y.Map<any>();
     const content = normalized.text;
+    // Keep parity with AFFiNE UI-created docs: sys:parent stays null and hierarchy is represented by sys:children.
 
     switch (normalized.type) {
       case "paragraph":
       case "heading":
       case "quote": {
         setSysFields(block, blockId, "affine:paragraph");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         const blockType =
           normalized.type === "heading"
@@ -865,7 +895,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "list": {
         setSysFields(block, blockId, "affine:list");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:type", normalized.listStyle);
         block.set("prop:checked", normalized.listStyle === "todo" ? normalized.checked : false);
@@ -874,7 +904,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "code": {
         setSysFields(block, blockId, "affine:code");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:language", normalized.language);
         if (normalized.caption) {
@@ -885,22 +915,35 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "divider": {
         setSysFields(block, blockId, "affine:divider");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         return { blockId, block, flavour: "affine:divider" };
       }
       case "callout": {
         setSysFields(block, blockId, "affine:callout");
-        block.set("sys:parent", parentId);
-        block.set("sys:children", new Y.Array<string>());
+        block.set("sys:parent", null);
+        const calloutChildren = new Y.Array<string>();
+        const textBlockId = generateId();
+        const textBlock = new Y.Map<any>();
+        setSysFields(textBlock, textBlockId, "affine:paragraph");
+        textBlock.set("sys:parent", null);
+        textBlock.set("sys:children", new Y.Array<string>());
+        textBlock.set("prop:type", "text");
+        textBlock.set("prop:text", makeText(content));
+        calloutChildren.push([textBlockId]);
+        block.set("sys:children", calloutChildren);
         block.set("prop:icon", { type: "emoji", unicode: "💡" });
         block.set("prop:backgroundColorName", "grey");
-        block.set("prop:text", makeText(content));
-        return { blockId, block, flavour: "affine:callout" };
+        return {
+          blockId,
+          block,
+          flavour: "affine:callout",
+          extraBlocks: [{ blockId: textBlockId, block: textBlock }],
+        };
       }
       case "latex": {
         setSysFields(block, blockId, "affine:latex");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:xywh", "[0,0,16,16]");
         block.set("prop:index", "a0");
@@ -912,7 +955,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "table": {
         setSysFields(block, blockId, "affine:table");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         const rows: Record<string, { rowId: string; order: string; backgroundColor?: string }> = {};
         const columns: Record<string, { columnId: string; order: string; backgroundColor?: string; width?: number }> = {};
@@ -949,7 +992,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "bookmark": {
         setSysFields(block, blockId, "affine:bookmark");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:style", normalized.bookmarkStyle);
         block.set("prop:url", normalized.url);
@@ -967,7 +1010,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "image": {
         setSysFields(block, blockId, "affine:image");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:caption", normalized.caption ?? "");
         block.set("prop:sourceId", normalized.sourceId);
@@ -982,7 +1025,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "attachment": {
         setSysFields(block, blockId, "affine:attachment");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:name", normalized.name);
         block.set("prop:size", normalized.size);
@@ -1000,7 +1043,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_youtube": {
         setSysFields(block, blockId, "affine:embed-youtube");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1020,7 +1063,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_github": {
         setSysFields(block, blockId, "affine:embed-github");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1044,7 +1087,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_figma": {
         setSysFields(block, blockId, "affine:embed-figma");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1059,7 +1102,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_loom": {
         setSysFields(block, blockId, "affine:embed-loom");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1076,7 +1119,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_html": {
         setSysFields(block, blockId, "affine:embed-html");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1090,7 +1133,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_linked_doc": {
         setSysFields(block, blockId, "affine:embed-linked-doc");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1106,7 +1149,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_synced_doc": {
         setSysFields(block, blockId, "affine:embed-synced-doc");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,800,100]");
@@ -1123,7 +1166,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "embed_iframe": {
         setSysFields(block, blockId, "affine:embed-iframe");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:index", "a0");
         block.set("prop:xywh", "[0,0,0,0]");
@@ -1140,7 +1183,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "database": {
         setSysFields(block, blockId, "affine:database");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         // Create a default table view so AFFiNE UI renders the database
         const defaultView = new Y.Map<any>();
@@ -1165,7 +1208,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         // AFFiNE 0.26.x currently crashes on raw affine:data-view render path.
         // Keep API compatibility for type="data_view" by mapping it to the stable database block.
         setSysFields(block, blockId, "affine:database");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         const dvDefaultView = new Y.Map<any>();
         dvDefaultView.set("id", generateId());
@@ -1187,7 +1230,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "surface_ref": {
         setSysFields(block, blockId, "affine:surface-ref");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:reference", normalized.reference);
         block.set("prop:caption", normalized.caption ?? "");
@@ -1197,7 +1240,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "frame": {
         setSysFields(block, blockId, "affine:frame");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:title", makeText(content || "Frame"));
         block.set("prop:background", normalized.background);
@@ -1210,7 +1253,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "edgeless_text": {
         setSysFields(block, blockId, "affine:edgeless-text");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:xywh", `[0,0,${normalized.width},${normalized.height}]`);
         block.set("prop:index", "a0");
@@ -1228,7 +1271,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
       case "note": {
         setSysFields(block, blockId, "affine:note");
-        block.set("sys:parent", parentId);
+        block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:xywh", `[0,0,${normalized.width},${normalized.height}]`);
         block.set("prop:background", normalized.background);
@@ -1270,9 +1313,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const prevSV = Y.encodeStateVector(doc);
       const blocks = doc.getMap("blocks") as Y.Map<any>;
       const context = resolveInsertContext(blocks, normalized);
-      const { blockId, block, flavour, blockType } = createBlock(context.parentId, normalized);
+      const { blockId, block, flavour, blockType, extraBlocks } = createBlock(normalized);
 
       blocks.set(blockId, block);
+      if (Array.isArray(extraBlocks)) {
+        for (const extra of extraBlocks) {
+          blocks.set(extra.blockId, extra.block);
+        }
+      }
       if (context.insertIndex >= context.children.length) {
         context.children.push([blockId]);
       } else {
@@ -1667,8 +1715,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         try {
           const normalized = normalizeAppendBlockInput(appendInput);
           const context = resolveInsertContext(blocks, normalized);
-          const { blockId, block } = createBlock(context.parentId, normalized);
+          const { blockId, block, extraBlocks } = createBlock(normalized);
           blocks.set(blockId, block);
+          if (Array.isArray(extraBlocks)) {
+            for (const extra of extraBlocks) {
+              blocks.set(extra.blockId, extra.block);
+            }
+          }
           if (context.insertIndex >= context.children.length) {
             context.children.push([blockId]);
           } else {
@@ -1723,7 +1776,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const surfaceId = generateId();
       const surface = new Y.Map();
       setSysFields(surface, surfaceId, "affine:surface");
-      surface.set("sys:parent", pageId);
+      surface.set("sys:parent", null);
       surface.set("sys:children", new Y.Array());
       const elements = new Y.Map<any>();
       elements.set("type", "$blocksuite:internal:native$");
@@ -1735,7 +1788,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const noteId = generateId();
       const note = new Y.Map();
       setSysFields(note, noteId, "affine:note");
-      note.set("sys:parent", pageId);
+      note.set("sys:parent", null);
       note.set("prop:displayMode", "both");
       note.set("prop:xywh", "[0,0,800,95]");
       note.set("prop:index", "a0");
@@ -1753,7 +1806,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const paraId = generateId();
         const para = new Y.Map();
         setSysFields(para, paraId, "affine:paragraph");
-        para.set("sys:parent", noteId);
+        para.set("sys:parent", null);
         para.set("sys:children", new Y.Array());
         para.set("prop:type", "text");
         const paragraphText = new Y.Text();

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -74,7 +74,7 @@ function createInitialWorkspaceData(workspaceName: string = 'New Workspace', ava
   const surfaceBlock = new Y.Map();
   surfaceBlock.set('sys:id', surfaceId);
   surfaceBlock.set('sys:flavour', 'affine:surface');
-  surfaceBlock.set('sys:parent', pageId);
+  surfaceBlock.set('sys:parent', null);
   surfaceBlock.set('sys:children', new Y.Array());
   
   blocks.set(surfaceId, surfaceBlock);
@@ -85,7 +85,7 @@ function createInitialWorkspaceData(workspaceName: string = 'New Workspace', ava
   const noteBlock = new Y.Map();
   noteBlock.set('sys:id', noteId);
   noteBlock.set('sys:flavour', 'affine:note');
-  noteBlock.set('sys:parent', pageId);
+  noteBlock.set('sys:parent', null);
   noteBlock.set('prop:displayMode', 'DocAndEdgeless');
   noteBlock.set('prop:xywh', '[0,0,800,600]');
   noteBlock.set('prop:index', 'a0');
@@ -102,7 +102,7 @@ function createInitialWorkspaceData(workspaceName: string = 'New Workspace', ava
   const paragraphBlock = new Y.Map();
   paragraphBlock.set('sys:id', paragraphId);
   paragraphBlock.set('sys:flavour', 'affine:paragraph');
-  paragraphBlock.set('sys:parent', noteId);
+  paragraphBlock.set('sys:parent', null);
   paragraphBlock.set('sys:children', new Y.Array());
   paragraphBlock.set('prop:type', 'text');
   

--- a/tests/test-bearer-auth.mjs
+++ b/tests/test-bearer-auth.mjs
@@ -76,6 +76,21 @@ async function call(client, toolName, args = {}) {
   return parsed;
 }
 
+function assertParentIdsAreNull(readDocPayload, context) {
+  const blocks = Array.isArray(readDocPayload?.blocks) ? readDocPayload.blocks : [];
+  const trackedFlavours = new Set(["affine:page", "affine:surface", "affine:note", "affine:paragraph"]);
+  for (const block of blocks) {
+    if (!trackedFlavours.has(block?.flavour)) {
+      continue;
+    }
+    if (block.parentId !== null) {
+      throw new Error(
+        `${context}: expected parentId=null for ${block.flavour} block ${block.id}, got ${JSON.stringify(block.parentId)}`
+      );
+    }
+  }
+}
+
 async function main() {
   console.log('=== Bearer Token Auth Test ===');
   console.log(`Base URL: ${BASE_URL}`);
@@ -158,6 +173,39 @@ async function main() {
     state.docId = doc?.docId;
     if (!state.docId) throw new Error('create_doc did not return docId');
     console.log(`  Doc ID: ${state.docId}`);
+
+    // Regression guard: keep AFFiNE-compatible parentId (null) shape.
+    const readAfterCreate = await call(bearerClient, 'read_doc', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+    });
+    assertParentIdsAreNull(readAfterCreate, 'after create_doc');
+
+    const appendedParagraph = await call(bearerClient, 'append_paragraph', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      text: 'ParentId null structure check',
+    });
+    if (!appendedParagraph?.paragraphId) throw new Error('append_paragraph did not return paragraphId');
+
+    const readAfterAppendParagraph = await call(bearerClient, 'read_doc', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+    });
+    assertParentIdsAreNull(readAfterAppendParagraph, 'after append_paragraph');
+
+    const markdownDoc = await call(bearerClient, 'create_doc_from_markdown', {
+      workspaceId: state.workspaceId,
+      title: 'ParentId Markdown Structure Check',
+      markdown: '# Heading from markdown\n\nBody from markdown import.',
+    });
+    if (!markdownDoc?.docId) throw new Error('create_doc_from_markdown did not return docId');
+
+    const readMarkdownDoc = await call(bearerClient, 'read_doc', {
+      workspaceId: state.workspaceId,
+      docId: markdownDoc.docId,
+    });
+    assertParentIdsAreNull(readMarkdownDoc, 'after create_doc_from_markdown');
 
     // Create database block
     const dbBlock = await call(bearerClient, 'append_block', {

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -109,6 +109,21 @@ async function main() {
     return parsed;
   }
 
+  function assertParentIdsAreNull(readDocPayload, context) {
+    const blocks = Array.isArray(readDocPayload?.blocks) ? readDocPayload.blocks : [];
+    const trackedFlavours = new Set(["affine:page", "affine:surface", "affine:note", "affine:paragraph"]);
+    for (const block of blocks) {
+      if (!trackedFlavours.has(block?.flavour)) {
+        continue;
+      }
+      if (block.parentId !== null) {
+        throw new Error(
+          `${context}: expected parentId=null for ${block.flavour} block ${block.id}, got ${JSON.stringify(block.parentId)}`
+        );
+      }
+    }
+  }
+
   try {
     // Authentication already happened at startup via AFFINE_LOGIN_AT_START=sync.
     // No explicit sign_in call needed — this test verifies the email/password
@@ -132,6 +147,39 @@ async function main() {
     state.docId = doc?.docId;
     if (!state.docId) throw new Error('create_doc did not return docId');
     console.log(`  Doc ID: ${state.docId}`);
+
+    // Regression guard: keep AFFiNE-compatible parentId (null) shape.
+    const readAfterCreate = await call('read_doc', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+    });
+    assertParentIdsAreNull(readAfterCreate, 'after create_doc');
+
+    const appendedParagraph = await call('append_paragraph', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      text: 'ParentId null structure check',
+    });
+    if (!appendedParagraph?.paragraphId) throw new Error('append_paragraph did not return paragraphId');
+
+    const readAfterAppendParagraph = await call('read_doc', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+    });
+    assertParentIdsAreNull(readAfterAppendParagraph, 'after append_paragraph');
+
+    const markdownDoc = await call('create_doc_from_markdown', {
+      workspaceId: state.workspaceId,
+      title: 'ParentId Markdown Structure Check',
+      markdown: '# Heading from markdown\n\nBody from markdown import.',
+    });
+    if (!markdownDoc?.docId) throw new Error('create_doc_from_markdown did not return docId');
+
+    const readMarkdownDoc = await call('read_doc', {
+      workspaceId: state.workspaceId,
+      docId: markdownDoc.docId,
+    });
+    assertParentIdsAreNull(readMarkdownDoc, 'after create_doc_from_markdown');
 
     // 3. Create database block
     const dbBlock = await call('append_block', {

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.7.1",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
# TL;DR
Sync `main` back into `develop` after merging the v1.7.1 release PR.

# Context
`main` now includes the v1.7.1 release commit from PR #43.
This back-merge keeps `develop` aligned with production history and release metadata.

# Changes
- Bring the v1.7.1 release commit (`e716f05`) from `main` into `develop`
- Sync release metadata updates (`CHANGELOG.md`, `RELEASE_NOTES.md`, README, and version files)
