### PR TITLE
feat(cli): add version flag support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start": "node dist/index.js",
     "start:http": "MCP_TRANSPORT=http node dist/index.js",
     "test": "npm run test:tool-manifest",
+    "test:cli-version": "node tests/test-cli-version.mjs",
     "test:tool-manifest": "node scripts/verify-tool-manifest.mjs",
     "test:comprehensive": "node test-comprehensive.mjs",
     "test:e2e": "bash tests/run-e2e.sh",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,13 @@ import { registerAuthTools } from "./tools/auth.js";
 import { runCli } from "./cli.js";
 import { startHttpMcpServer } from "./sse.js";
 
-// CLI subcommands: affine-mcp login|status|logout
-const subcommand = process.argv[2];
+// CLI commands: affine-mcp login|status|logout|version
+const rawArgs = process.argv.slice(2);
+const subcommand = rawArgs[0] === "--" ? rawArgs[1] : rawArgs[0];
+if (subcommand === "--version" || subcommand === "-v" || subcommand === "version") {
+  console.log(VERSION);
+  process.exit(0);
+}
 if (subcommand && await runCli(subcommand)) {
   process.exit(0);
 }

--- a/tests/test-cli-version.mjs
+++ b/tests/test-cli-version.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const DIST_ENTRY = path.join(ROOT, "dist", "index.js");
+const BIN_ENTRY = path.join(ROOT, "bin", "affine-mcp");
+const expectedVersion = JSON.parse(readFileSync(path.join(ROOT, "package.json"), "utf8")).version;
+
+function runVersionCheck(label, args) {
+  const result = spawnSync("node", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${label} exited with ${result.status}: ${result.stderr || result.stdout}`);
+  }
+
+  const stdout = result.stdout.trim();
+  if (stdout !== expectedVersion) {
+    throw new Error(`${label} stdout mismatch: expected ${expectedVersion}, got ${JSON.stringify(stdout)}`);
+  }
+
+  if (result.stderr.trim()) {
+    throw new Error(`${label} wrote unexpected stderr: ${result.stderr}`);
+  }
+}
+
+runVersionCheck("dist --version", [DIST_ENTRY, "--version"]);
+runVersionCheck("dist -v", [DIST_ENTRY, "-v"]);
+runVersionCheck("dist version", [DIST_ENTRY, "version"]);
+runVersionCheck("dist -- --version", [DIST_ENTRY, "--", "--version"]);
+runVersionCheck("bin --version", [BIN_ENTRY, "--version"]);
+runVersionCheck("bin -v", [BIN_ENTRY, "-v"]);
+runVersionCheck("bin version", [BIN_ENTRY, "version"]);
+runVersionCheck("bin -- --version", [BIN_ENTRY, "--", "--version"]);
+
+console.log(JSON.stringify({
+  ok: true,
+  version: expectedVersion,
+  cases: [
+    "dist --version",
+    "dist -v",
+    "dist version",
+    "dist -- --version",
+    "bin --version",
+    "bin -v",
+    "bin version",
+    "bin -- --version",
+  ],
+}, null, 2));


### PR DESCRIPTION
# TL;DR
Add CLI version flag support so the package can print its version without starting the MCP server.

# Context
The README already documented `affine-mcp -- --version`, but the CLI did not actually support it. This change makes the documented version paths work consistently for direct execution and packaged CLI usage.

# Changes
- handle `--version`, `-v`, and `version` before server startup
- support the packaged `affine-mcp -- --version` invocation by ignoring a leading `--` separator
- add a dedicated CLI regression script covering direct, wrapper, and packaged version invocations