### PR TITLE
chore(deps): target dependabot PRs to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
# TL;DR
Route Dependabot PRs to `develop` instead of `main`.

# Context
This repository uses Git Flow and regular dependency or workflow maintenance changes should land on `develop`, not directly on `main`. Without an explicit `target-branch`, Dependabot is currently opening update PRs against `main` by default.

# Changes
- set the npm Dependabot target branch to `develop`
- set the GitHub Actions Dependabot target branch to `develop`
