### PR TITLE
fix: use flat-key Y.Text structure for table cells

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { GraphQLClient } from "../graphqlClient.js";
 import { text } from "../util/mcp.js";
+import { makeText, richTextValueToString, mapEntries, extractTableData } from "../util/table.js";
 import { wsUrlFromGraphQLEndpoint, connectWorkspaceSocket, joinWorkspace, loadDoc, pushDocUpdate, deleteDoc as wsDeleteDoc } from "../ws.js";
 import * as Y from "yjs";
 import { parseMarkdownToOperations } from "../markdown/parse.js";
@@ -177,14 +178,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const cookie = gql.cookie;
     const bearer = gql.bearer;
     return { endpoint, cookie, bearer };
-  }
-
-  function makeText(content: string): Y.Text {
-    const yText = new Y.Text();
-    if (content.length > 0) {
-      yText.insert(0, content);
-    }
-    return yText;
   }
 
   function asText(value: unknown): string {
@@ -1223,21 +1216,22 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         setSysFields(block, blockId, "affine:table");
         block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
-        const rows: Record<string, { rowId: string; order: string; backgroundColor?: string }> = {};
-        const columns: Record<string, { columnId: string; order: string; backgroundColor?: string; width?: number }> = {};
-        const cells: Record<string, { text: string }> = {};
         const rowIds: string[] = [];
         const columnIds: string[] = [];
         const tableData = normalized.tableData ?? [];
 
         for (let i = 0; i < normalized.rows; i++) {
           const rowId = generateId();
-          rows[rowId] = { rowId, order: `r${String(i).padStart(4, "0")}` };
+          // rowId key is written for AFFiNE's native client; extractTableData only reads order.
+          block.set(`prop:rows.${rowId}.rowId`, rowId);
+          block.set(`prop:rows.${rowId}.order`, `r${String(i).padStart(4, "0")}`);
           rowIds.push(rowId);
         }
         for (let i = 0; i < normalized.columns; i++) {
           const columnId = generateId();
-          columns[columnId] = { columnId, order: `c${String(i).padStart(4, "0")}` };
+          // columnId key is written for AFFiNE's native client; extractTableData only reads order.
+          block.set(`prop:columns.${columnId}.columnId`, columnId);
+          block.set(`prop:columns.${columnId}.order`, `c${String(i).padStart(4, "0")}`);
           columnIds.push(columnId);
         }
         for (let rowIndex = 0; rowIndex < rowIds.length; rowIndex += 1) {
@@ -1245,13 +1239,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           for (let columnIndex = 0; columnIndex < columnIds.length; columnIndex += 1) {
             const columnId = columnIds[columnIndex];
             const cellText = tableData[rowIndex]?.[columnIndex] ?? "";
-            cells[`${rowId}:${columnId}`] = { text: cellText };
+            block.set(`prop:cells.${rowId}:${columnId}.text`, makeText(cellText));
           }
         }
 
-        block.set("prop:rows", rows);
-        block.set("prop:columns", columns);
-        block.set("prop:cells", cells);
         block.set("prop:comments", undefined);
         block.set("prop:textAlign", undefined);
         return { blockId, block, flavour: "affine:table" };
@@ -1735,98 +1726,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       return value;
     }
     return null;
-  }
-
-  function richTextValueToString(value: unknown): string {
-    if (value instanceof Y.Text) {
-      return value.toString();
-    }
-    if (typeof value === "string") {
-      return value;
-    }
-    if (Array.isArray(value)) {
-      return value
-        .map((entry) => {
-          if (typeof entry === "string") {
-            return entry;
-          }
-          if (entry && typeof entry === "object" && typeof (entry as any).insert === "string") {
-            return (entry as any).insert as string;
-          }
-          return "";
-        })
-        .join("");
-    }
-    if (value && typeof value === "object" && typeof (value as any).insert === "string") {
-      return (value as any).insert as string;
-    }
-    return "";
-  }
-
-  function mapEntries(value: unknown): Array<[string, any]> {
-    if (value instanceof Y.Map) {
-      const entries: Array<[string, any]> = [];
-      value.forEach((mapValue: unknown, key: string) => {
-        entries.push([key, mapValue]);
-      });
-      return entries;
-    }
-    if (value && typeof value === "object") {
-      return Object.entries(value as Record<string, any>);
-    }
-    return [];
-  }
-
-  function extractTableData(block: Y.Map<any>): string[][] | null {
-    const rowsValue = block.get("prop:rows");
-    const columnsValue = block.get("prop:columns");
-    const cellsValue = block.get("prop:cells");
-
-    const rowEntries = mapEntries(rowsValue)
-      .map(([rowId, payload]) => ({
-        rowId,
-        order:
-          payload && typeof payload === "object" && typeof (payload as any).order === "string"
-            ? (payload as any).order
-            : rowId,
-      }))
-      .sort((a, b) => a.order.localeCompare(b.order));
-
-    const columnEntries = mapEntries(columnsValue)
-      .map(([columnId, payload]) => ({
-        columnId,
-        order:
-          payload && typeof payload === "object" && typeof (payload as any).order === "string"
-            ? (payload as any).order
-            : columnId,
-      }))
-      .sort((a, b) => a.order.localeCompare(b.order));
-
-    if (rowEntries.length === 0 || columnEntries.length === 0) {
-      return null;
-    }
-
-    const cells = new Map<string, string>();
-    for (const [cellKey, payload] of mapEntries(cellsValue)) {
-      if (payload instanceof Y.Map) {
-        cells.set(cellKey, richTextValueToString(payload.get("text")));
-        continue;
-      }
-      if (payload && typeof payload === "object" && "text" in payload) {
-        cells.set(cellKey, richTextValueToString((payload as any).text));
-      }
-    }
-
-    const tableData: string[][] = [];
-    for (const { rowId } of rowEntries) {
-      const row: string[] = [];
-      for (const { columnId } of columnEntries) {
-        row.push(cells.get(`${rowId}:${columnId}`) ?? "");
-      }
-      tableData.push(row);
-    }
-
-    return tableData;
   }
 
   function collectDocForMarkdown(

--- a/src/util/table.ts
+++ b/src/util/table.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure utility functions for AFFiNE table block handling.
+ *
+ * Extracted so that both the production tool code (src/tools/docs.ts)
+ * and the regression tests (tests/test-table-format.mjs) share the
+ * same implementation.
+ */
+import * as Y from "yjs";
+
+export function makeText(content: string): Y.Text {
+  const yText = new Y.Text();
+  if (content.length > 0) {
+    yText.insert(0, content);
+  }
+  return yText;
+}
+
+export function richTextValueToString(value: unknown): string {
+  if (value instanceof Y.Text) {
+    return value.toString();
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => {
+        if (typeof entry === "string") {
+          return entry;
+        }
+        if (entry && typeof entry === "object" && typeof (entry as any).insert === "string") {
+          return (entry as any).insert as string;
+        }
+        return "";
+      })
+      .join("");
+  }
+  if (value && typeof value === "object" && typeof (value as any).insert === "string") {
+    return (value as any).insert as string;
+  }
+  return "";
+}
+
+export function mapEntries(value: unknown): Array<[string, any]> {
+  if (value instanceof Y.Map) {
+    const entries: Array<[string, any]> = [];
+    value.forEach((mapValue: unknown, key: string) => {
+      entries.push([key, mapValue]);
+    });
+    return entries;
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, any>);
+  }
+  return [];
+}
+
+/**
+ * Extract a 2D string table from an AFFiNE table block.
+ *
+ * Reads the flat-key format first (prop:rows.{id}.order, etc.) and
+ * then merges any legacy nested properties (prop:rows as a single
+ * object).  Flat-key values take precedence when both formats are
+ * present for the same ID.
+ */
+export function extractTableData(block: Y.Map<any>): string[][] | null {
+  const rowMap = new Map<string, string>(); // rowId → order
+  const colMap = new Map<string, string>(); // columnId → order
+  const cells = new Map<string, string>();  // "rowId:columnId" → text
+
+  // Note: generateId() only produces [A-Za-z0-9_-], so dots and colons
+  // in the flat-key delimiter positions are unambiguous.
+  for (const key of block.keys()) {
+    // Flat key format: prop:rows.{rowId}.order
+    const rowMatch = key.match(/^prop:rows\.([^.]+)\.order$/);
+    if (rowMatch) {
+      const rowId = rowMatch[1];
+      const order = block.get(key);
+      rowMap.set(rowId, typeof order === "string" ? order : String(order ?? rowId));
+      continue;
+    }
+    // Flat key format: prop:columns.{colId}.order
+    const colMatch = key.match(/^prop:columns\.([^.]+)\.order$/);
+    if (colMatch) {
+      const colId = colMatch[1];
+      const order = block.get(key);
+      colMap.set(colId, typeof order === "string" ? order : String(order ?? colId));
+      continue;
+    }
+    // Flat key format: prop:cells.{rowId}:{colId}.text
+    const cellMatch = key.match(/^prop:cells\.([^.]+)\.text$/);
+    if (cellMatch) {
+      const cellKey = cellMatch[1]; // "rowId:colId"
+      const textVal = block.get(key);
+      cells.set(cellKey, richTextValueToString(textVal));
+      continue;
+    }
+  }
+
+  // Merge legacy nested format (prop:rows, prop:columns, prop:cells as objects)
+  // so that mixed old/new table structures are handled safely.
+  {
+    const rowsValue = block.get("prop:rows");
+    for (const [rowId, payload] of mapEntries(rowsValue)) {
+      if (rowMap.has(rowId)) continue; // flat-key takes precedence
+      const order = payload && typeof payload === "object" && typeof (payload as any).order === "string"
+        ? (payload as any).order : rowId;
+      rowMap.set(rowId, order);
+    }
+  }
+  {
+    const columnsValue = block.get("prop:columns");
+    for (const [colId, payload] of mapEntries(columnsValue)) {
+      if (colMap.has(colId)) continue; // flat-key takes precedence
+      const order = payload && typeof payload === "object" && typeof (payload as any).order === "string"
+        ? (payload as any).order : colId;
+      colMap.set(colId, order);
+    }
+  }
+  {
+    const cellsValue = block.get("prop:cells");
+    for (const [cellKey, payload] of mapEntries(cellsValue)) {
+      if (cells.has(cellKey)) continue; // flat-key takes precedence
+      if (payload instanceof Y.Map) {
+        cells.set(cellKey, richTextValueToString(payload.get("text")));
+        continue;
+      }
+      if (payload && typeof payload === "object" && "text" in payload) {
+        cells.set(cellKey, richTextValueToString((payload as any).text));
+      }
+    }
+  }
+
+  const rowEntries = [...rowMap.entries()]
+    .map(([rowId, order]) => ({ rowId, order }))
+    .sort((a, b) => a.order.localeCompare(b.order));
+
+  const columnEntries = [...colMap.entries()]
+    .map(([columnId, order]) => ({ columnId, order }))
+    .sort((a, b) => a.order.localeCompare(b.order));
+
+  if (rowEntries.length === 0 || columnEntries.length === 0) {
+    return null;
+  }
+
+  const tableData: string[][] = [];
+  for (const { rowId } of rowEntries) {
+    const row: string[] = [];
+    for (const { columnId } of columnEntries) {
+      row.push(cells.get(`${rowId}:${columnId}`) ?? "");
+    }
+    tableData.push(row);
+  }
+
+  return tableData;
+}

--- a/tests/test-table-format.mjs
+++ b/tests/test-table-format.mjs
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for table creation and extraction (flat-key format).
+ *
+ * Exercises the real production code from dist/util/table.js.
+ * Run `npm run build` first, then: node tests/test-table-format.mjs
+ *
+ * Covers:
+ *   1. New flat-key format creation & extraction
+ *   2. Flat-key format survives Y.js encode/decode
+ *   3. Legacy nested format reading
+ *   4. Mixed old/new format reading (merges both)
+ *   5. Empty table returns null
+ *   6. Flat-key takes precedence over legacy
+ *   7. Non-string order values are coerced
+ */
+import * as Y from "yjs";
+import { makeText, extractTableData } from "../dist/util/table.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${message}`);
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${message}`);
+    console.error(`    expected: ${JSON.stringify(expected)}`);
+    console.error(`    actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ── Helper: build flat-key table block ─────────────────────────────
+
+function buildFlatKeyBlock(tableData) {
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+  const blockId = "flat-test";
+
+  block.set("sys:id", blockId);
+  block.set("sys:flavour", "affine:table");
+  block.set("sys:children", new Y.Array());
+
+  const rowIds = [];
+  const colIds = [];
+  const numRows = tableData.length;
+  const numCols = tableData[0].length;
+
+  for (let i = 0; i < numRows; i++) {
+    const rowId = `r_${i}`;
+    block.set(`prop:rows.${rowId}.rowId`, rowId);
+    block.set(`prop:rows.${rowId}.order`, `r${String(i).padStart(4, "0")}`);
+    rowIds.push(rowId);
+  }
+  for (let j = 0; j < numCols; j++) {
+    const colId = `c_${j}`;
+    block.set(`prop:columns.${colId}.columnId`, colId);
+    block.set(`prop:columns.${colId}.order`, `c${String(j).padStart(4, "0")}`);
+    colIds.push(colId);
+  }
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      block.set(`prop:cells.${rowIds[r]}:${colIds[c]}.text`, makeText(tableData[r][c]));
+    }
+  }
+
+  blocks.set(blockId, block);
+  return { doc, block: blocks.get(blockId) };
+}
+
+// ── Helper: build legacy nested table block ────────────────────────
+
+function buildLegacyBlock(tableData) {
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+  const blockId = "legacy-test";
+
+  block.set("sys:id", blockId);
+  block.set("sys:flavour", "affine:table");
+
+  const rows = {};
+  const columns = {};
+  const cells = {};
+  const numRows = tableData.length;
+  const numCols = tableData[0].length;
+  const rowIds = [];
+  const colIds = [];
+
+  for (let i = 0; i < numRows; i++) {
+    const rowId = `r_${i}`;
+    rows[rowId] = { rowId, order: `r${String(i).padStart(4, "0")}` };
+    rowIds.push(rowId);
+  }
+  for (let j = 0; j < numCols; j++) {
+    const colId = `c_${j}`;
+    columns[colId] = { columnId: colId, order: `c${String(j).padStart(4, "0")}` };
+    colIds.push(colId);
+  }
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      cells[`${rowIds[r]}:${colIds[c]}`] = { text: tableData[r][c] };
+    }
+  }
+
+  block.set("prop:rows", rows);
+  block.set("prop:columns", columns);
+  block.set("prop:cells", cells);
+
+  blocks.set(blockId, block);
+  return { doc, block: blocks.get(blockId) };
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 1: New flat-key format creation & extraction
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 1: Flat-key format creation & extraction ===");
+{
+  const data = [
+    ["Header1", "Header2", "Header3"],
+    ["A", "B", "C"],
+    ["D", "E", "F"],
+  ];
+  const { block } = buildFlatKeyBlock(data);
+  const result = extractTableData(block);
+
+  assert(result !== null, "extractTableData should return non-null for flat-key block");
+  assertEqual(result, data, "extractTableData should return correct table data");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 2: Flat-key format survives Y.js encode/decode
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 2: Flat-key format survives encode/decode ===");
+{
+  const data = [
+    ["Name", "Score"],
+    ["Alice", "100"],
+    ["Bob", "95"],
+  ];
+  const { doc } = buildFlatKeyBlock(data);
+
+  const update = Y.encodeStateAsUpdate(doc);
+  const doc2 = new Y.Doc();
+  Y.applyUpdate(doc2, update);
+  const block2 = doc2.getMap("blocks").get("flat-test");
+
+  let cellCount = 0;
+  let allYText = true;
+  for (const key of block2.keys()) {
+    if (key.startsWith("prop:cells.") && key.endsWith(".text")) {
+      cellCount++;
+      if (!(block2.get(key) instanceof Y.Text)) allYText = false;
+    }
+  }
+  assert(cellCount === 6, `Expected 6 cells, got ${cellCount}`);
+  assert(allYText, "All cell values should be Y.Text after encode/decode");
+
+  const result = extractTableData(block2);
+  assertEqual(result, data, "extractTableData should work after encode/decode");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 3: Legacy nested format reading
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 3: Legacy nested format reading ===");
+{
+  const data = [
+    ["Old1", "Old2"],
+    ["X", "Y"],
+  ];
+  const { block } = buildLegacyBlock(data);
+  const result = extractTableData(block);
+
+  assert(result !== null, "extractTableData should return non-null for legacy block");
+  assertEqual(result, data, "extractTableData should correctly read legacy format");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 4: Mixed old/new format reading (merges both)
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 4: Mixed old/new format (merges both) ===");
+{
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+  const blockId = "mixed-test";
+
+  block.set("sys:id", blockId);
+  block.set("sys:flavour", "affine:table");
+
+  block.set("prop:rows.r_0.rowId", "r_0");
+  block.set("prop:rows.r_0.order", "r0000");
+  block.set("prop:rows", { r_1: { rowId: "r_1", order: "r0001" } });
+
+  block.set("prop:columns.c_0.columnId", "c_0");
+  block.set("prop:columns.c_0.order", "c0000");
+  block.set("prop:columns", { c_1: { columnId: "c_1", order: "c0001" } });
+
+  block.set("prop:cells.r_0:c_0.text", makeText("flat"));
+  block.set("prop:cells", {
+    "r_1:c_0": { text: "legacy-r1c0" },
+    "r_0:c_1": { text: "legacy-r0c1" },
+    "r_1:c_1": { text: "legacy-r1c1" },
+  });
+
+  blocks.set(blockId, block);
+  const b = blocks.get(blockId);
+  const result = extractTableData(b);
+
+  assert(result !== null, "extractTableData should return non-null for mixed block");
+  assert(result.length === 2, `Expected 2 rows, got ${result?.length}`);
+  assert(result[0].length === 2, `Expected 2 cols, got ${result?.[0]?.length}`);
+  assertEqual(result[0][0], "flat", "flat-key cell should be 'flat'");
+  assertEqual(result[0][1], "legacy-r0c1", "legacy cell (r0,c1) should be 'legacy-r0c1'");
+  assertEqual(result[1][0], "legacy-r1c0", "legacy cell (r1,c0) should be 'legacy-r1c0'");
+  assertEqual(result[1][1], "legacy-r1c1", "legacy cell (r1,c1) should be 'legacy-r1c1'");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 5: Empty table returns null
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 5: Empty table returns null ===");
+{
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+  block.set("sys:flavour", "affine:table");
+  blocks.set("empty", block);
+  const result = extractTableData(blocks.get("empty"));
+  assert(result === null, "extractTableData should return null for empty table");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 6: Flat-key takes precedence over legacy
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 6: Flat-key takes precedence over legacy ===");
+{
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+
+  block.set("sys:flavour", "affine:table");
+
+  block.set("prop:rows.r_0.rowId", "r_0");
+  block.set("prop:rows.r_0.order", "r0000");
+  block.set("prop:rows", { r_0: { rowId: "r_0", order: "r9999" } });
+
+  block.set("prop:columns.c_0.columnId", "c_0");
+  block.set("prop:columns.c_0.order", "c0000");
+  block.set("prop:columns", { c_0: { columnId: "c_0", order: "c9999" } });
+
+  block.set("prop:cells.r_0:c_0.text", makeText("flat-wins"));
+  block.set("prop:cells", { "r_0:c_0": { text: "legacy-loses" } });
+
+  blocks.set("precedence", block);
+  const result = extractTableData(blocks.get("precedence"));
+
+  assert(result !== null, "result should not be null");
+  assertEqual(result[0][0], "flat-wins", "flat-key cell value should take precedence");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test 7: Non-string order values are coerced instead of dropped
+// ════════════════════════════════════════════════════════════════════
+console.log("=== Test 7: Non-string order values coerced ===");
+{
+  const doc = new Y.Doc();
+  const blocks = doc.getMap("blocks");
+  const block = new Y.Map();
+
+  block.set("sys:flavour", "affine:table");
+
+  block.set("prop:rows.r_0.rowId", "r_0");
+  block.set("prop:rows.r_0.order", 0);
+
+  block.set("prop:columns.c_0.columnId", "c_0");
+  block.set("prop:columns.c_0.order", 0);
+
+  block.set("prop:cells.r_0:c_0.text", makeText("coerced"));
+
+  blocks.set("coerce-test", block);
+  const result = extractTableData(blocks.get("coerce-test"));
+
+  assert(result !== null, "result should not be null when order is numeric");
+  assertEqual(result[0][0], "coerced", "cell value should be readable despite numeric order");
+}
+
+// ── Summary ────────────────────────────────────────────────────────
+console.log(`\n${"=".repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed === 0) {
+  console.log("✅ All tests passed!");
+  process.exit(0);
+} else {
+  console.log("❌ Some tests failed.");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Table cells created via MCP appeared **empty in AFFiNE's UI** despite data being stored correctly in Y.js
- Root cause: The MCP stored table properties as nested plain objects (`prop:cells` → `{ "r1:c1": { text: "value" } }`), but AFFiNE's BlockSuite frontend expects **flat Y.Map keys with Y.Text values** (`prop:cells.r1:c1.text` → `Y.Text("value")`)
- Fixed `createBlock` (table case) to use flat keys matching AFFiNE's native format
- Updated `extractTableData` to read both flat-key (primary) and legacy nested (fallback) formats, merging both when a mixed structure is present
- Extracted table helpers (`extractTableData`, `makeText`, `richTextValueToString`, `mapEntries`) to `src/util/table.ts` so that tests exercise the real production code

## Changes

| File | Description |
|------|-------------|
| `src/tools/docs.ts` | Use flat-key Y.Map structure for table creation; import helpers from `util/table` |
| `src/util/table.ts` | Extracted pure table utility functions (single source of truth for both production and tests) |
| `tests/test-table-format.mjs` | 7 test cases / 19 assertions importing from `dist/util/table.js` |

## Root Cause Analysis

By inspecting the Y.js structure of a table created manually in AFFiNE's UI vs one created via MCP, the key difference was discovered:

**AFFiNE native (works):**
```
block.set("prop:rows.{rowId}.rowId", rowId)
block.set("prop:rows.{rowId}.order", orderStr)
block.set("prop:cells.{rowId}:{colId}.text", Y.Text("value"))
```

**MCP before fix (broken):**
```
block.set("prop:rows", { rowId: { rowId, order } })
block.set("prop:cells", { "rowId:colId": { text: "value" } })
```

## Before / After
### Before
<img width="851" height="913" alt="Screenshot 2026-03-09 at 1 04 20 PM" src="https://github.com/user-attachments/assets/3a0cb3ba-7974-458b-a4b1-876239825f43" />
<img width="825" height="648" alt="Screenshot 2026-03-09 at 1 04 26 PM" src="https://github.com/user-attachments/assets/91462787-51ba-4432-8745-02a7f7682109" />

### After
<img width="843" height="874" alt="Screenshot 2026-03-09 at 1 50 18 PM" src="https://github.com/user-attachments/assets/71cf1289-5eba-4ef0-9a6b-712621f7e028" />
<img width="732" height="696" alt="Screenshot 2026-03-09 at 1 50 22 PM" src="https://github.com/user-attachments/assets/f754a8ae-249a-428f-8e8c-731bada277ad" />

## Test plan

Run `npm run build` first, then:
```bash
node tests/test-table-format.mjs
```

| Test | Description |
|------|-------------|
| 1 | New flat-key format creation & extraction |
| 2 | Flat-key format survives Y.js encode/decode round-trip (Y.Text integrity) |
| 3 | Legacy nested format reading |
| 4 | Mixed old/new format merging |
| 5 | Empty table returns null |
| 6 | Flat-key takes precedence over legacy |
| 7 | Non-string order values are coerced (not dropped) |

Manual verification:
- [x] Created table via `create_doc_from_markdown` — cells render correctly in AFFiNE UI
- [x] `export_doc_markdown` correctly reads tables in both new and legacy format
- [x] Existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)