### PR TITLE
fix: add database schema discovery for empty databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ comprehensive-test-results-*.json
 
 # E2E test artifacts
 tests/test-database-state.json
+tests/test-database-cells-state.json
 tests/test-bearer-state.json
 tests/test-tag-visibility-state.json
 tests/playwright-auth-state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `read_database_columns` to expose database schema metadata for empty or sparsely populated AFFiNE databases.
+
+### Fixed
+- Empty database workflows no longer depend on existing rows to discover column names, IDs, types, and view mappings.
+
 ## [1.8.0] - 2026-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted
 
 - Workspace: create (with initial doc), read, update, delete
 - Documents: list/get/read/publish/revoke + create/append/replace/delete + markdown import/export + tags (WebSocket‑based)
-- Database workflows: create database blocks, add columns and rows, and read or update cell values via MCP tools
+- Database workflows: create database blocks, inspect schema, add columns and rows, and read or update cell values via MCP tools
 - Comments: full CRUD and resolve
 - Version History: list
 - Users & Tokens: current user, sign in, profile/settings, and personal access tokens
@@ -328,6 +328,7 @@ Endpoints currently available:
 - `append_block` – append canonical block types (text/list/code/media/embed/database/edgeless) with strict validation and placement control (`data_view` currently falls back to database)
 - `add_database_column` – add a column to a database block (`rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, `date`)
 - `add_database_row` – add a row to a database block with values mapped by column name/ID (`title` / `Title` updates the built-in row title)
+- `read_database_columns` – read database schema metadata including column IDs/types, select options, and table view column mappings
 - `read_database_cells` – read row titles plus decoded database cell values with optional row / column filters
 - `update_database_cell` – update a single database cell or the built-in row title (`createOption` defaults to `true` for select fields)
 - `update_database_row` – batch update multiple cells on a database row (`createOption` defaults to `true` for select fields)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e": "bash tests/run-e2e.sh",
     "test:db-create": "node tests/test-database-creation.mjs",
     "test:db-cells": "node tests/test-database-cells.mjs",
+    "test:db-schema": "node tests/test-database-schema.mjs",
     "test:bearer": "node tests/test-bearer-auth.mjs",
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3212,6 +3212,21 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     raw: any;
   };
 
+  type DatabaseViewColumnDef = {
+    id: string;
+    name: string | null;
+    hidden: boolean;
+    width: number | null;
+  };
+
+  type DatabaseViewDef = {
+    id: string;
+    name: string;
+    mode: string;
+    columns: DatabaseViewColumnDef[];
+    columnIds: string[];
+  };
+
   type DatabaseColumnLookup = {
     columnDefs: DatabaseColumnDef[];
     colById: Map<string, DatabaseColumnDef>;
@@ -3262,6 +3277,52 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       if (id) defs.push({ id: String(id), name: String(name || ""), type: String(type || "rich-text"), options, raw: col });
     });
     return defs;
+  }
+
+  function readDatabaseViewDefs(dbBlock: Y.Map<any>, lookup: DatabaseColumnLookup): DatabaseViewDef[] {
+    const viewsRaw = dbBlock.get("prop:views");
+    const views: DatabaseViewDef[] = [];
+    if (!(viewsRaw instanceof Y.Array)) {
+      return views;
+    }
+
+    viewsRaw.forEach((view: any) => {
+      const id = view instanceof Y.Map ? view.get("id") : view?.id;
+      if (!id) {
+        return;
+      }
+
+      const columnsRaw = view instanceof Y.Map ? view.get("columns") : view?.columns;
+      const columns: DatabaseViewColumnDef[] = databaseArrayValues(columnsRaw)
+        .map((entry: any) => {
+          const columnId = entry instanceof Y.Map ? entry.get("id") : entry?.id;
+          if (!columnId || typeof columnId !== "string") {
+            return null;
+          }
+
+          const columnDef = lookup.colById.get(columnId) || null;
+          const hidden = entry instanceof Y.Map ? entry.get("hide") : entry?.hide;
+          const width = entry instanceof Y.Map ? entry.get("width") : entry?.width;
+
+          return {
+            id: columnId,
+            name: columnDef?.name || null,
+            hidden: hidden === true,
+            width: typeof width === "number" ? width : null,
+          };
+        })
+        .filter((entry): entry is DatabaseViewColumnDef => entry !== null);
+
+      views.push({
+        id: String(id),
+        name: String((view instanceof Y.Map ? view.get("name") : view?.name) || ""),
+        mode: String((view instanceof Y.Map ? view.get("mode") : view?.mode) || ""),
+        columns,
+        columnIds: columns.map(column => column.id),
+      });
+    });
+
+    return views;
   }
 
   function isTitleAliasKey(value: string): boolean {
@@ -3738,6 +3799,49 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       },
     },
     readDatabaseCellsHandler as any
+  );
+
+  const readDatabaseColumnsHandler = async (parsed: {
+    workspaceId?: string;
+    docId: string;
+    databaseBlockId: string;
+  }) => {
+    const workspaceId = parsed.workspaceId || defaults.workspaceId;
+    if (!workspaceId) throw new Error("workspaceId is required");
+    const ctx = await loadDatabaseDocContext(workspaceId, parsed.docId, parsed.databaseBlockId);
+    try {
+      const columns = ctx.columnDefs.map(col => ({
+        id: col.id,
+        name: col.name || null,
+        type: col.type,
+        options: col.options,
+      }));
+
+      return text({
+        databaseBlockId: parsed.databaseBlockId,
+        title: richTextValueToString(ctx.dbBlock.get("prop:title")) || null,
+        rowCount: getDatabaseRowIds(ctx.dbBlock).length,
+        columnCount: columns.length,
+        titleColumnId: ctx.titleCol?.id || null,
+        columns,
+        views: readDatabaseViewDefs(ctx.dbBlock, ctx),
+      });
+    } finally {
+      ctx.socket.disconnect();
+    }
+  };
+  server.registerTool(
+    "read_database_columns",
+    {
+      title: "Read Database Columns",
+      description: "Read schema metadata for an AFFiNE database block, including columns, select options, and view column mappings. Useful for empty databases before any rows exist.",
+      inputSchema: {
+        workspaceId: z.string().optional().describe("Workspace ID (optional if default set)"),
+        docId: DocId.describe("Document ID containing the database"),
+        databaseBlockId: z.string().min(1).describe("Block ID of the affine:database block"),
+      },
+    },
+    readDatabaseColumnsHandler as any
   );
 
   const updateDatabaseCellHandler = async (parsed: {

--- a/test-comprehensive.mjs
+++ b/test-comprehensive.mjs
@@ -235,6 +235,7 @@ class ComprehensiveRunner {
       throw new Error('append_block(database) did not return blockId');
     }
     const databaseColumnName = `Status-${Date.now()}`;
+    let databaseRowBlockId = null;
     await this.callTool('add_database_column', {
       workspaceId,
       docId,
@@ -243,6 +244,22 @@ class ComprehensiveRunner {
       type: 'select',
       options: ['Todo', 'Done'],
     });
+    await this.callTool('read_database_columns', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+    }, parsed => {
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('read_database_columns did not return JSON payload');
+      }
+      if (!Array.isArray(parsed.columns) || parsed.columns.length === 0) {
+        throw new Error('read_database_columns returned no columns');
+      }
+      const schemaColumn = parsed.columns.find(entry => entry?.name === databaseColumnName);
+      if (!schemaColumn) {
+        throw new Error('read_database_columns did not include the created column');
+      }
+    });
     await this.callTool('add_database_row', {
       workspaceId,
       docId,
@@ -250,6 +267,59 @@ class ComprehensiveRunner {
       cells: {
         [databaseColumnName]: 'Todo',
       },
+    }, parsed => {
+      databaseRowBlockId = parsed?.rowBlockId || null;
+    });
+    if (!databaseRowBlockId) {
+      throw new Error('add_database_row did not return rowBlockId');
+    }
+    await this.callTool('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+    }, parsed => {
+      if (!Array.isArray(parsed?.rows) || parsed.rows.length !== 1) {
+        throw new Error('read_database_cells did not return the expected single row');
+      }
+      if (parsed.rows[0]?.cells?.[databaseColumnName]?.value !== 'Todo') {
+        throw new Error('read_database_cells did not expose the created row value');
+      }
+    });
+    await this.callTool('update_database_cell', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockId: databaseRowBlockId,
+      column: databaseColumnName,
+      value: 'Done',
+      createOption: false,
+    });
+    await this.callTool('update_database_row', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockId: databaseRowBlockId,
+      cells: {
+        title: 'Comprehensive Row',
+        [databaseColumnName]: 'Todo',
+      },
+      createOption: false,
+    });
+    await this.callTool('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockIds: [databaseRowBlockId],
+    }, parsed => {
+      if (!Array.isArray(parsed?.rows) || parsed.rows.length !== 1) {
+        throw new Error('read_database_cells row filter did not return the updated row');
+      }
+      if (parsed.rows[0]?.title !== 'Comprehensive Row') {
+        throw new Error('update_database_row did not persist the row title');
+      }
+      if (parsed.rows[0]?.cells?.[databaseColumnName]?.value !== 'Todo') {
+        throw new Error('update_database_row did not persist the cell value');
+      }
     });
     await this.callTool('append_markdown', {
       workspaceId,

--- a/tests/test-database-schema.mjs
+++ b/tests/test-database-schema.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Focused integration test for database schema discovery on empty databases.
+ *
+ * Verifies that `read_database_columns` returns column metadata before any row
+ * exists, so agents can discover schema without relying on cell data.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
+
+const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectTruthy(value, message) {
+  if (!value) {
+    throw new Error(`${message}: expected truthy value, got ${JSON.stringify(value)}`);
+  }
+}
+
+async function main() {
+  console.log('=== Database Schema Integration Test ===');
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Server: ${MCP_SERVER_PATH}`);
+  console.log();
+
+  const client = new Client({ name: 'affine-mcp-db-schema-test', version: '1.0.0' });
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, '..'),
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: 'sync',
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+    },
+    stderr: 'pipe',
+  });
+
+  transport.stderr?.on('data', chunk => {
+    process.stderr.write(`[mcp-server] ${chunk}`);
+  });
+
+  const settle = (ms = 800) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function call(toolName, args = {}) {
+    console.log(`  → ${toolName}(${JSON.stringify(args)})`);
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    if (result?.isError) {
+      throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || 'unknown'}`);
+    }
+    const parsed = parseContent(result);
+    if (parsed && typeof parsed === 'object' && parsed.error) {
+      throw new Error(`${toolName} failed: ${parsed.error}`);
+    }
+    console.log('    ✓ OK');
+    return parsed;
+  }
+
+  await client.connect(transport);
+
+  try {
+    const tools = await client.listTools();
+    if (!tools.tools.some(tool => tool.name === 'read_database_columns')) {
+      throw new Error('Expected tool "read_database_columns" to be registered');
+    }
+
+    const workspace = await call('create_workspace', { name: `db-schema-test-${Date.now()}` });
+    const workspaceId = workspace?.id;
+    if (!workspaceId) throw new Error('create_workspace did not return workspace id');
+
+    const doc = await call('create_doc', {
+      workspaceId,
+      title: 'Database Schema Test',
+      content: '',
+    });
+    const docId = doc?.docId;
+    if (!docId) throw new Error('create_doc did not return docId');
+
+    const dbBlock = await call('append_block', {
+      workspaceId,
+      docId,
+      type: 'database',
+    });
+    const databaseBlockId = dbBlock?.blockId;
+    if (!databaseBlockId) throw new Error('append_block(database) did not return blockId');
+    await settle();
+
+    const columnDefinitions = [
+      { name: 'Name', type: 'rich-text' },
+      { name: 'Status', type: 'select', options: ['Todo', 'Doing', 'Done'] },
+      { name: 'Estimate', type: 'number' },
+    ];
+
+    const expectedColumnIds = new Map();
+    for (const column of columnDefinitions) {
+      const result = await call('add_database_column', {
+        workspaceId,
+        docId,
+        databaseBlockId,
+        name: column.name,
+        type: column.type,
+        ...(column.options ? { options: column.options } : {}),
+      });
+      expectTruthy(result?.columnId, `${column.name} columnId`);
+      expectedColumnIds.set(column.name, result.columnId);
+      await settle();
+    }
+
+    const schema = await call('read_database_columns', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+    });
+    expectEqual(schema?.databaseBlockId, databaseBlockId, 'schema databaseBlockId');
+    expectEqual(schema?.rowCount, 0, 'schema rowCount');
+    expectEqual(schema?.columnCount, 3, 'schema columnCount');
+    expectEqual(schema?.titleColumnId, null, 'schema titleColumnId');
+    expectTruthy(Array.isArray(schema?.columns), 'schema columns array');
+    expectTruthy(Array.isArray(schema?.views), 'schema views array');
+    expectTruthy(schema.views.length >= 1, 'schema view count');
+
+    const schemaByName = new Map(schema.columns.map(column => [column.name, column]));
+    for (const column of columnDefinitions) {
+      const schemaColumn = schemaByName.get(column.name);
+      if (!schemaColumn) {
+        throw new Error(`Schema missing column ${column.name}`);
+      }
+      expectEqual(schemaColumn.id, expectedColumnIds.get(column.name), `${column.name} schema columnId`);
+      expectEqual(schemaColumn.type, column.type, `${column.name} schema type`);
+      if (column.type === 'select') {
+        expectEqual(schemaColumn.options.length, column.options.length, `${column.name} options length`);
+        expectEqual(schemaColumn.options[0].value, column.options[0], `${column.name} first option`);
+      } else {
+        expectEqual(schemaColumn.options.length, 0, `${column.name} options length`);
+      }
+    }
+
+    const tableView = schema.views.find(view => view.mode === 'table');
+    if (!tableView) {
+      throw new Error('Schema missing table view');
+    }
+    expectEqual(tableView.columnIds.length, 3, 'table view column count');
+    for (const column of columnDefinitions) {
+      if (!tableView.columnIds.includes(expectedColumnIds.get(column.name))) {
+        throw new Error(`Table view missing column ${column.name}`);
+      }
+    }
+
+    const cells = await call('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+    });
+    expectEqual(cells?.rows?.length, 0, 'read_database_cells empty row count');
+
+    console.log();
+    console.log('=== Database schema integration test passed ===');
+  } finally {
+    await transport.close();
+  }
+}
+
+main().catch(err => {
+  console.error();
+  console.error(`FAILED: ${err.message}`);
+  process.exit(1);
+});

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -33,6 +33,7 @@
     "publish_doc",
     "read_all_notifications",
     "read_database_cells",
+    "read_database_columns",
     "read_doc",
     "remove_tag_from_doc",
     "replace_doc_with_markdown",


### PR DESCRIPTION
# TL;DR
Adds `read_database_columns` so agents can discover AFFiNE database schema before any row exists. This closes the empty-database discovery gap reported in #57 and was validated with local CI, targeted Docker integrations, comprehensive MCP surface checks, and the full Docker + Playwright E2E pipeline.

# Context
Issue #57 reported that empty AFFiNE databases expose columns in the UI, but the MCP surface could only reveal schema indirectly through existing row data. The server already parsed column definitions internally for row and cell operations, but that metadata was not exposed as a public tool.

# Changes
- add `read_database_columns` to return database title, row and column counts, column IDs, names, types, select options, and view column mappings
- add focused empty-database schema coverage and extend the comprehensive runner so every database tool is exercised
- update docs, manifest metadata, changelog, and generated-artifact ignore rules for the expanded database workflow surface
