### PR TITLE
fix: stabilize e2e docker bootstrap

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   postgres:
     image: pgvector/pgvector:pg16
-    container_name: affine_test_postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${DB_USERNAME:-affine}
@@ -17,7 +16,6 @@ services:
 
   redis:
     image: redis:7
-    container_name: affine_test_redis
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
@@ -27,7 +25,6 @@ services:
 
   affine_migration:
     image: ghcr.io/toeverything/affine:${AFFINE_REVISION:-stable}
-    container_name: affine_test_migration
     command: ['node', './scripts/self-host-predeploy.js']
     environment:
       AFFINE_CONFIG_PATH: /root/.affine/config
@@ -44,7 +41,6 @@ services:
 
   affine:
     image: ghcr.io/toeverything/affine:${AFFINE_REVISION:-stable}
-    container_name: affine_test_app
     restart: unless-stopped
     ports:
       - '${PORT:-3010}:3010'

--- a/tests/generate-test-env.sh
+++ b/tests/generate-test-env.sh
@@ -29,11 +29,12 @@ export DB_USERNAME="${DB_USERNAME:-affine}"
 export DB_PASSWORD="${DB_PASSWORD:-$(rand_password)}"
 export DB_DATABASE="${DB_DATABASE:-affine}"
 export AFFINE_REVISION="${AFFINE_REVISION:-stable}"
+export PORT="${PORT:-3010}"
 
 # Write docker/.env consumed by docker-compose.yml
 cat > "$DOCKER_DIR/.env" <<EOF
 AFFINE_REVISION=$AFFINE_REVISION
-PORT=3010
+PORT=$PORT
 DB_USERNAME=$DB_USERNAME
 DB_PASSWORD=$DB_PASSWORD
 DB_DATABASE=$DB_DATABASE

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -17,8 +17,14 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DOCKER_DIR="$PROJECT_DIR/docker"
 COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml"
 
+find_free_port() {
+  node -e 'const net=require("net");const server=net.createServer();server.listen(0,"127.0.0.1",()=>{const {port}=server.address();console.log(port);server.close();});'
+}
+
 # --- Configuration ---
-export AFFINE_BASE_URL="${AFFINE_BASE_URL:-http://localhost:3010}"
+export PORT="${PORT:-$(find_free_port)}"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-affine_mcp_e2e_${PORT}_$$}"
+export AFFINE_BASE_URL="${AFFINE_BASE_URL:-http://localhost:${PORT}}"
 export AFFINE_HEALTH_MAX_RETRIES="${AFFINE_HEALTH_MAX_RETRIES:-90}"
 export AFFINE_HEALTH_INTERVAL_MS="${AFFINE_HEALTH_INTERVAL_MS:-5000}"
 export AFFINE_HEALTH_REQUEST_TIMEOUT_MS="${AFFINE_HEALTH_REQUEST_TIMEOUT_MS:-3000}"
@@ -26,6 +32,8 @@ export AFFINE_CREDENTIAL_ACQUIRE_RETRIES="${AFFINE_CREDENTIAL_ACQUIRE_RETRIES:-3
 export AFFINE_CREDENTIAL_RETRY_DELAY_SECONDS="${AFFINE_CREDENTIAL_RETRY_DELAY_SECONDS:-5}"
 export AFFINE_AUTH_READY_MAX_RETRIES="${AFFINE_AUTH_READY_MAX_RETRIES:-30}"
 export AFFINE_AUTH_READY_INTERVAL_SECONDS="${AFFINE_AUTH_READY_INTERVAL_SECONDS:-3}"
+export AFFINE_DOCKER_START_RETRIES="${AFFINE_DOCKER_START_RETRIES:-3}"
+export AFFINE_DOCKER_RETRY_DELAY_SECONDS="${AFFINE_DOCKER_RETRY_DELAY_SECONDS:-5}"
 
 # Generate random credentials (writes docker/.env, exports env vars)
 echo "=== Generating test credentials ==="
@@ -36,16 +44,139 @@ echo "=== Generating test credentials ==="
 cleanup() {
   echo ""
   echo "=== Tearing down Docker containers ==="
-  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
+
+compose_container_id() {
+  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" ps -aq "$1" 2>/dev/null || true
+}
 
 docker_diagnostics() {
   echo ""
   echo "=== Docker diagnostics (on failure) ==="
-  docker compose -f "$COMPOSE_FILE" ps || true
+  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" ps || true
   echo ""
-  docker compose -f "$COMPOSE_FILE" logs --no-color --tail=200 affine affine_migration postgres redis || true
+  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" logs --no-color --tail=200 affine affine_migration postgres redis || true
+}
+
+docker_compose_with_retry() {
+  local description="$1"
+  shift
+  local attempt
+  local output_file
+  output_file="$(mktemp)"
+
+  for ((attempt = 1; attempt <= AFFINE_DOCKER_START_RETRIES; attempt++)); do
+    if docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" "$@" >"$output_file" 2>&1; then
+      cat "$output_file"
+      rm -f "$output_file"
+      return 0
+    fi
+
+    echo "[e2e] ${description} failed (attempt ${attempt}/${AFFINE_DOCKER_START_RETRIES})"
+    cat "$output_file"
+    docker_diagnostics
+    docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+
+    if ((attempt < AFFINE_DOCKER_START_RETRIES)); then
+      echo "[e2e] Retrying ${description} in ${AFFINE_DOCKER_RETRY_DELAY_SECONDS}s..."
+      sleep "$AFFINE_DOCKER_RETRY_DELAY_SECONDS"
+    fi
+  done
+
+  rm -f "$output_file"
+  return 1
+}
+
+wait_for_container_health() {
+  local service_name="$1"
+  local max_attempts="${2:-30}"
+  local sleep_seconds="${3:-2}"
+  local attempt
+  local container_id
+  local status
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    container_id="$(compose_container_id "$service_name")"
+    status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)"
+    if [[ "$status" == "healthy" || "$status" == "running" ]]; then
+      echo "[e2e] Service ${service_name} ready after ${attempt} attempt(s) (status=${status})"
+      return 0
+    fi
+
+    echo "[e2e] Waiting for ${service_name}: attempt ${attempt}/${max_attempts} (status=${status:-missing})"
+    sleep "$sleep_seconds"
+  done
+
+  echo "[e2e] ERROR: service ${service_name} did not become ready"
+  docker_diagnostics
+  return 1
+}
+
+wait_for_container_running() {
+  local service_name="$1"
+  local max_attempts="${2:-30}"
+  local sleep_seconds="${3:-2}"
+  local attempt
+  local container_id
+  local status
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    container_id="$(compose_container_id "$service_name")"
+    status="$(docker inspect -f '{{.State.Status}}' "$container_id" 2>/dev/null || true)"
+    if [[ "$status" == "running" ]]; then
+      echo "[e2e] Service ${service_name} container running after ${attempt} attempt(s)"
+      return 0
+    fi
+
+    echo "[e2e] Waiting for ${service_name} container: attempt ${attempt}/${max_attempts} (status=${status:-missing})"
+    sleep "$sleep_seconds"
+  done
+
+  echo "[e2e] ERROR: service ${service_name} container did not reach running state"
+  docker_diagnostics
+  return 1
+}
+
+wait_for_container_exit_zero() {
+  local service_name="$1"
+  local max_attempts="${2:-30}"
+  local sleep_seconds="${3:-2}"
+  local attempt
+  local container_id
+  local status
+  local exit_code
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    container_id="$(compose_container_id "$service_name")"
+    status="$(docker inspect -f '{{.State.Status}}' "$container_id" 2>/dev/null || true)"
+    exit_code="$(docker inspect -f '{{.State.ExitCode}}' "$container_id" 2>/dev/null || true)"
+
+    if [[ "$status" == "exited" && "$exit_code" == "0" ]]; then
+      echo "[e2e] Service ${service_name} completed successfully after ${attempt} attempt(s)"
+      return 0
+    fi
+
+    echo "[e2e] Waiting for ${service_name} completion: attempt ${attempt}/${max_attempts} (status=${status:-missing}, exit=${exit_code:-missing})"
+    sleep "$sleep_seconds"
+  done
+
+  echo "[e2e] ERROR: service ${service_name} did not complete successfully"
+  docker_diagnostics
+  return 1
+}
+
+start_docker_stack() {
+  docker_compose_with_retry "base service startup" up -d postgres redis
+  wait_for_container_health postgres 30 2
+  wait_for_container_health redis 30 2
+
+  docker_compose_with_retry "migration startup" up -d --no-deps affine_migration
+  wait_for_container_exit_zero affine_migration 45 2
+
+  docker_compose_with_retry "app startup" up -d --no-deps affine
+  wait_for_container_running affine 45 2
 }
 
 acquire_credentials_with_retry() {
@@ -114,12 +245,28 @@ wait_for_auth_ready() {
   return 1
 }
 
+ensure_affine_ui_ready() {
+  local base_url="${AFFINE_BASE_URL%/}"
+
+  if curl -fsS --max-time "$((AFFINE_HEALTH_REQUEST_TIMEOUT_MS / 1000))" "$base_url/" >/dev/null 2>&1; then
+    echo "[e2e] AFFiNE UI already reachable for Playwright"
+    return 0
+  fi
+
+  echo "[e2e] AFFiNE UI is not reachable before Playwright; attempting service recovery..."
+  docker_diagnostics
+
+  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" up -d --no-deps affine
+  acquire_credentials_with_retry
+  wait_for_auth_ready
+}
+
 # --- Step 0: Clean up any stale containers from previous runs ---
-docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
 
 # --- Step 1: Start Docker ---
 echo "=== Starting AFFiNE via Docker Compose ==="
-docker compose -f "$COMPOSE_FILE" up -d
+start_docker_stack
 
 # --- Step 2: Wait for health + verify credentials ---
 echo ""
@@ -153,6 +300,7 @@ node "$SCRIPT_DIR/test-tag-visibility.mjs"
 # --- Step 7: Run Playwright verification ---
 echo ""
 echo "=== Running Playwright UI verification ==="
+ensure_affine_ui_ready
 npx playwright test --config "$SCRIPT_DIR/playwright/playwright.config.ts"
 
 echo ""


### PR DESCRIPTION
# TL;DR
Stabilize `npm run test:e2e` by isolating each Docker stack and replacing the one-shot Compose bootstrap with staged startup, retries, and readiness checks.

# Context
The E2E pipeline was intermittently failing before the MCP assertions even began. The failures came from Docker Compose dependency orchestration and shared stack state: fixed container names, a shared default network, and a fixed port made repeated or overlapping runs fragile.

# Changes
- remove fixed `container_name` usage from the E2E Compose stack so runs no longer fight over the same containers
- generate a unique Compose project name and free host port per E2E run, and propagate that port through the generated `.env`
- stage startup into base services, migration, and app startup with explicit health/running/exit checks instead of a single `docker compose up -d`
- add retry and diagnostic handling around Docker startup and keep the Playwright phase guarded by a final UI readiness check
- verification:
  - `npm run test:e2e`
