### PR TITLE
feat: support preset-backed data_view creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ comprehensive-test-results-*.json
 # E2E test artifacts
 tests/test-database-state.json
 tests/test-database-cells-state.json
+tests/test-data-view-state.json
 tests/test-bearer-state.json
 tests/test-tag-visibility-state.json
 tests/playwright-auth-state.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `read_database_columns` to expose database schema metadata for empty or sparsely populated AFFiNE databases.
+- Preset-backed `data_view` creation for kanban-oriented AFFiNE database views.
 
 ### Fixed
 - Empty database workflows no longer depend on existing rows to discover column names, IDs, types, and view mappings.

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Endpoints currently available:
 - `add_tag_to_doc` – attach a tag to a document
 - `remove_tag_from_doc` – detach a tag from a document
 - `append_paragraph` – append a paragraph block (WebSocket)
-- `append_block` – append canonical block types (text/list/code/media/embed/database/edgeless) with strict validation and placement control (`data_view` currently falls back to database)
+- `append_block` – append canonical block types (text/list/code/media/embed/database/edgeless) with strict validation and placement control (`viewMode=kanban` enables preset-backed data views; `data_view` defaults to kanban)
 - `add_database_column` – add a column to a database block (`rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, `date`)
 - `add_database_row` – add a row to a database block with values mapped by column name/ID (`title` / `Title` updates the built-in row title)
 - `read_database_columns` – read database schema metadata including column IDs/types, select options, and table view column mappings

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "test:db-create": "node tests/test-database-creation.mjs",
     "test:db-cells": "node tests/test-database-cells.mjs",
     "test:db-schema": "node tests/test-database-schema.mjs",
+    "test:data-view": "node tests/test-data-view.mjs",
+    "test:data-view-ui": "npx playwright test tests/playwright/verify-data-view.pw.ts --config tests/playwright/playwright.config.ts",
     "test:bearer": "node tests/test-bearer-auth.mjs",
     "test:supporting-tools": "node tests/test-supporting-tools.mjs",
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -63,6 +63,9 @@ const APPEND_BLOCK_BOOKMARK_STYLE_VALUES = [
 ] as const;
 type AppendBlockBookmarkStyle = typeof APPEND_BLOCK_BOOKMARK_STYLE_VALUES[number];
 const AppendBlockBookmarkStyle = z.enum(APPEND_BLOCK_BOOKMARK_STYLE_VALUES);
+const APPEND_BLOCK_DATA_VIEW_MODE_VALUES = ["table", "kanban"] as const;
+type AppendBlockDataViewMode = typeof APPEND_BLOCK_DATA_VIEW_MODE_VALUES[number];
+const AppendBlockDataViewMode = z.enum(APPEND_BLOCK_DATA_VIEW_MODE_VALUES);
 
 type AppendPlacement = {
   parentId?: string;
@@ -100,6 +103,7 @@ type AppendBlockInput = {
   level?: number;
   style?: AppendBlockListStyle;
   bookmarkStyle?: AppendBlockBookmarkStyle;
+  viewMode?: AppendBlockDataViewMode;
   strict?: boolean;
   placement?: AppendPlacement;
   tableData?: string[][];
@@ -133,6 +137,7 @@ type NormalizedAppendBlockInput = {
   headingLevel: 1 | 2 | 3 | 4 | 5 | 6;
   listStyle: AppendBlockListStyle;
   bookmarkStyle: AppendBlockBookmarkStyle;
+  dataViewMode: AppendBlockDataViewMode;
   checked: boolean;
   language: string;
   caption?: string;
@@ -178,6 +183,12 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const bearer = gql.bearer;
     return { endpoint, cookie, bearer };
   }
+
+  const SELECT_COLORS = [
+    "var(--affine-tag-blue)", "var(--affine-tag-green)", "var(--affine-tag-red)",
+    "var(--affine-tag-orange)", "var(--affine-tag-purple)", "var(--affine-tag-yellow)",
+    "var(--affine-tag-teal)", "var(--affine-tag-pink)", "var(--affine-tag-gray)",
+  ];
 
   function makeText(content: string): Y.Text {
     const yText = new Y.Text();
@@ -906,6 +917,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     } else if (raw.tableData !== undefined && normalized.strict) {
       throw new Error("The 'tableData' field can only be used with type='table'.");
     }
+
+    if (normalized.type !== "database" && normalized.type !== "data_view" && raw.viewMode !== undefined && normalized.strict) {
+      throw new Error("The 'viewMode' field can only be used with type='database' or type='data_view'.");
+    }
   }
 
   function normalizeAppendBlockInput(parsed: AppendBlockInput): NormalizedAppendBlockInput {
@@ -916,6 +931,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const headingLevel = Math.max(1, Math.min(6, headingLevelNumber)) as 1 | 2 | 3 | 4 | 5 | 6;
     const listStyle = typeInfo.listStyleFromAlias ?? parsed.style ?? "bulleted";
     const bookmarkStyle = parsed.bookmarkStyle ?? "horizontal";
+    const dataViewMode = parsed.viewMode ?? (typeInfo.type === "data_view" ? "kanban" : "table");
     const language = (parsed.language ?? "txt").trim().toLowerCase() || "txt";
     const placement = normalizePlacement(parsed.placement);
     const url = (parsed.url ?? "").trim();
@@ -965,6 +981,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       headingLevel,
       listStyle,
       bookmarkStyle,
+      dataViewMode,
       checked: Boolean(parsed.checked),
       language,
       caption: parsed.caption,
@@ -1128,6 +1145,125 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     }
 
     return { parentId, parentBlock, children, insertIndex };
+  }
+
+  function createDatabaseViewColumn(columnId: string, width: number = 200, hide: boolean = false): Y.Map<any> {
+    const column = new Y.Map<any>();
+    column.set("id", columnId);
+    column.set("width", width);
+    column.set("hide", hide);
+    return column;
+  }
+
+  function createDatabaseColumnDefinition(input: {
+    id: string;
+    name: string;
+    type: string;
+    width?: number;
+    options?: string[];
+  }): Y.Map<any> {
+    const column = new Y.Map<any>();
+    column.set("id", input.id);
+    column.set("name", input.name);
+    column.set("type", input.type);
+    column.set("width", input.width ?? 200);
+
+    if ((input.type === "select" || input.type === "multi-select") && input.options?.length) {
+      const data = new Y.Map<any>();
+      const options = new Y.Array<any>();
+      input.options.forEach((value, index) => {
+        const option = new Y.Map<any>();
+        option.set("id", generateId());
+        option.set("value", value);
+        option.set("color", SELECT_COLORS[index % SELECT_COLORS.length]);
+        options.push([option]);
+      });
+      data.set("options", options);
+      column.set("data", data);
+    }
+
+    return column;
+  }
+
+  function createPresetBackedDataViewBlock(
+    blockId: string,
+    titleText: string,
+    viewMode: AppendBlockDataViewMode,
+    blockType: string,
+  ): { blockId: string; block: Y.Map<any>; flavour: string; blockType: string } {
+    const block = new Y.Map<any>();
+    setSysFields(block, blockId, "affine:database");
+    block.set("sys:parent", null);
+    block.set("sys:children", new Y.Array<string>());
+    block.set("prop:title", makeText(titleText));
+    block.set("prop:cells", new Y.Map<any>());
+    block.set("prop:comments", undefined);
+
+    const titleColumnId = generateId();
+    const columns = new Y.Array<any>();
+    columns.push([createDatabaseColumnDefinition({
+      id: titleColumnId,
+      name: "Title",
+      type: "title",
+      width: 320,
+    })]);
+
+    const viewColumns = new Y.Array<any>();
+    viewColumns.push([createDatabaseViewColumn(titleColumnId, 320, false)]);
+    const header = {
+      titleColumn: titleColumnId,
+      iconColumn: "type",
+    };
+
+    let groupBy: Record<string, string> | null = null;
+    let groupProperties: unknown[] | null = null;
+
+    if (viewMode === "kanban") {
+      const statusColumnId = generateId();
+      columns.push([createDatabaseColumnDefinition({
+        id: statusColumnId,
+        name: "Status",
+        type: "select",
+        options: ["Todo", "In Progress", "Done"],
+      })]);
+      viewColumns.push([createDatabaseViewColumn(statusColumnId, 200, false)]);
+      groupBy = {
+        columnId: statusColumnId,
+        name: "select",
+        type: "groupBy",
+      };
+      groupProperties = [];
+    }
+
+    const view = new Y.Map<any>();
+    view.set("id", generateId());
+    view.set("name", viewMode === "kanban" ? "Kanban View" : "Table View");
+    view.set("mode", viewMode);
+    view.set("columns", viewColumns);
+    view.set("filter", { type: "group", op: "and", conditions: [] });
+    if (groupBy) {
+      view.set("groupBy", groupBy);
+    } else {
+      view.set("groupBy", null);
+    }
+    if (groupProperties) {
+      view.set("groupProperties", groupProperties);
+    }
+    view.set("sort", null);
+    view.set("header", header);
+
+    const views = new Y.Array<any>();
+    views.push([view]);
+
+    block.set("prop:columns", columns);
+    block.set("prop:views", views);
+
+    return {
+      blockId,
+      block,
+      flavour: "affine:database",
+      blockType,
+    };
   }
 
   function createBlock(normalized: NormalizedAppendBlockInput): {
@@ -1448,6 +1584,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         return { blockId, block, flavour: "affine:embed-iframe" };
       }
       case "database": {
+        if (normalized.dataViewMode === "kanban") {
+          return createPresetBackedDataViewBlock(blockId, normalized.text, "kanban", "database_kanban");
+        }
         setSysFields(block, blockId, "affine:database");
         block.set("sys:parent", null);
         block.set("sys:children", new Y.Array<string>());
@@ -1471,28 +1610,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         return { blockId, block, flavour: "affine:database" };
       }
       case "data_view": {
-        // AFFiNE 0.26.x currently crashes on raw affine:data-view render path.
-        // Keep API compatibility for type="data_view" by mapping it to the stable database block.
-        setSysFields(block, blockId, "affine:database");
-        block.set("sys:parent", null);
-        block.set("sys:children", new Y.Array<string>());
-        const dvDefaultView = new Y.Map<any>();
-        dvDefaultView.set("id", generateId());
-        dvDefaultView.set("name", "Table View");
-        dvDefaultView.set("mode", "table");
-        dvDefaultView.set("columns", new Y.Array<any>());
-        dvDefaultView.set("filter", { type: "group", op: "and", conditions: [] });
-        dvDefaultView.set("groupBy", null);
-        dvDefaultView.set("sort", null);
-        dvDefaultView.set("header", { titleColumn: null, iconColumn: null });
-        const dvViews = new Y.Array<any>();
-        dvViews.push([dvDefaultView]);
-        block.set("prop:views", dvViews);
-        block.set("prop:title", makeText(content));
-        block.set("prop:cells", new Y.Map<any>());
-        block.set("prop:columns", new Y.Array<any>());
-        block.set("prop:comments", undefined);
-        return { blockId, block, flavour: "affine:database", blockType: "data_view_fallback" };
+        return createPresetBackedDataViewBlock(blockId, normalized.text, normalized.dataViewMode, `data_view_${normalized.dataViewMode}`);
       }
       case "surface_ref": {
         setSysFields(block, blockId, "affine:surface-ref");
@@ -2813,6 +2931,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     level?: number;
     style?: AppendBlockListStyle;
     bookmarkStyle?: AppendBlockBookmarkStyle;
+    viewMode?: AppendBlockDataViewMode;
     strict?: boolean;
     placement?: AppendPlacement;
   }) => {
@@ -2857,6 +2976,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         level: z.number().int().min(1).max(6).optional().describe("Heading level for type=heading"),
         style: AppendBlockListStyle.optional().describe("List style for type=list"),
         bookmarkStyle: AppendBlockBookmarkStyle.optional().describe("Bookmark card style"),
+        viewMode: AppendBlockDataViewMode.optional().describe("Initial data view preset for type=database or type=data_view. Defaults: database=table, data_view=kanban"),
         checked: z.boolean().optional().describe("Todo state when type is todo"),
         language: z.string().optional().describe("Code language when type is code"),
         caption: z.string().optional().describe("Code caption when type is code"),
@@ -3225,6 +3345,15 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     mode: string;
     columns: DatabaseViewColumnDef[];
     columnIds: string[];
+    groupBy: {
+      columnId: string | null;
+      name: string | null;
+      type: string | null;
+    } | null;
+    header: {
+      titleColumn: string | null;
+      iconColumn: string | null;
+    };
   };
 
   type DatabaseColumnLookup = {
@@ -3293,6 +3422,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }
 
       const columnsRaw = view instanceof Y.Map ? view.get("columns") : view?.columns;
+      const headerRaw = view instanceof Y.Map ? view.get("header") : view?.header;
+      const groupByRaw = view instanceof Y.Map ? view.get("groupBy") : view?.groupBy;
       const columns: DatabaseViewColumnDef[] = databaseArrayValues(columnsRaw)
         .map((entry: any) => {
           const columnId = entry instanceof Y.Map ? entry.get("id") : entry?.id;
@@ -3319,6 +3450,17 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         mode: String((view instanceof Y.Map ? view.get("mode") : view?.mode) || ""),
         columns,
         columnIds: columns.map(column => column.id),
+        groupBy: groupByRaw
+          ? {
+              columnId: typeof (groupByRaw as any)?.columnId === "string" ? (groupByRaw as any).columnId : null,
+              name: typeof (groupByRaw as any)?.name === "string" ? (groupByRaw as any).name : null,
+              type: typeof (groupByRaw as any)?.type === "string" ? (groupByRaw as any).type : null,
+            }
+          : null,
+        header: {
+          titleColumn: typeof (headerRaw as any)?.titleColumn === "string" ? (headerRaw as any).titleColumn : null,
+          iconColumn: typeof (headerRaw as any)?.iconColumn === "string" ? (headerRaw as any).iconColumn : null,
+        },
       });
     });
 
@@ -3435,12 +3577,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     }
     return [];
   }
-
-  const SELECT_COLORS = [
-    "var(--affine-tag-blue)", "var(--affine-tag-green)", "var(--affine-tag-red)",
-    "var(--affine-tag-orange)", "var(--affine-tag-purple)", "var(--affine-tag-yellow)",
-    "var(--affine-tag-teal)", "var(--affine-tag-pink)", "var(--affine-tag-gray)",
-  ];
 
   /** Find or create a select option for a column, mutating the column's data in place */
   function resolveSelectOptionId(

--- a/tests/playwright/verify-data-view.pw.ts
+++ b/tests/playwright/verify-data-view.pw.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface TestState {
+  baseUrl: string;
+  email: string;
+  workspaceId: string;
+  docId: string;
+  dataViewBlockId: string;
+  groupLabels: string[];
+  rowTitles: string[];
+  error?: string;
+}
+
+const STATE_PATH = path.resolve(__dirname, '..', 'test-data-view-state.json');
+
+let state: TestState;
+
+test.beforeAll(() => {
+  if (!fs.existsSync(STATE_PATH)) {
+    throw new Error(
+      `State file not found: ${STATE_PATH}\n` +
+      'Run "npm run test:data-view" first to create MCP test data.',
+    );
+  }
+  state = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+  if (state.error) {
+    throw new Error(`State file contains error from data view test: ${state.error}`);
+  }
+  if (!state.workspaceId || !state.docId || !state.dataViewBlockId) {
+    throw new Error('State file missing workspaceId, docId, or dataViewBlockId');
+  }
+});
+
+const password = process.env.AFFINE_ADMIN_PASSWORD!;
+if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
+
+test.describe.serial('AFFiNE Data View Verification', () => {
+  test('login to AFFiNE', async ({ page, context }) => {
+    await page.goto(`${state.baseUrl}/sign-in`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
+    await emailInput.waitFor({ timeout: 30_000 });
+    await emailInput.fill(state.email);
+
+    const continueBtn = page.locator(
+      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
+    );
+    await continueBtn.first().click();
+
+    const passwordInput = page.locator('input[type="password"], input[name="password"]');
+    await passwordInput.waitFor({ timeout: 15_000 });
+    await passwordInput.fill(password);
+
+    const signInBtn = page.locator(
+      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
+    );
+    await signInBtn.first().click();
+
+    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+
+    for (let i = 0; i < 5; i++) {
+      await page.waitForTimeout(1_000);
+      const dismissBtn = page.locator(
+        'button:has-text("Skip"), button:has-text("Got it"), button:has-text("Close"), ' +
+        'button:has-text("Dismiss"), button:has-text("OK"), button:has-text("Later"), ' +
+        '[data-testid="modal-close"], .modal-close, button[aria-label="Close"]',
+      );
+      if (await dismissBtn.count() > 0) {
+        await dismissBtn.first().click({ timeout: 2_000 }).catch(() => {});
+      } else {
+        break;
+      }
+    }
+
+    const storageStatePath = path.resolve(__dirname, '..', 'playwright-auth-state.json');
+    await context.storageState({ path: storageStatePath });
+  });
+
+  test('verify kanban data view content in document', async ({ browser }) => {
+    const storageStatePath = path.resolve(__dirname, '..', 'playwright-auth-state.json');
+    const context = await browser.newContext({
+      storageState: storageStatePath,
+    });
+    const page = await context.newPage();
+
+    try {
+      const docUrl = `${state.baseUrl}/workspace/${state.workspaceId}/${state.docId}`;
+      await page.goto(docUrl);
+      await page.waitForLoadState('domcontentloaded');
+
+      if (page.url().includes('/sign-in')) {
+        throw new Error('Redirected to sign-in — login test did not persist auth state');
+      }
+
+      for (let i = 0; i < 3; i++) {
+        await page.waitForTimeout(1_000);
+        const dismissBtn = page.locator(
+          'button:has-text("Skip"), button:has-text("Got it"), button:has-text("Close"), ' +
+          'button:has-text("Dismiss"), button:has-text("OK"), button:has-text("Later"), ' +
+          '[data-testid="modal-close"], .modal-close, button[aria-label="Close"]',
+        );
+        if (await dismissBtn.count() > 0) {
+          await dismissBtn.first().click({ timeout: 2_000 }).catch(() => {});
+        } else {
+          break;
+        }
+      }
+
+      await page.waitForTimeout(5_000);
+
+      const kanbanGroup = page.locator('affine-data-view-kanban-group');
+      await expect(kanbanGroup.first()).toBeVisible({ timeout: 30_000 });
+
+      const kanbanCard = page.locator('affine-data-view-kanban-card');
+      await expect(kanbanCard.first()).toBeVisible({ timeout: 10_000 });
+      await expect(kanbanCard).toHaveCount(2, { timeout: 10_000 });
+
+      for (const label of state.groupLabels) {
+        await expect(page.getByText(label, { exact: true }).first()).toBeVisible({ timeout: 10_000 });
+      }
+
+      for (const title of state.rowTitles) {
+        await expect(page.getByText(title, { exact: true }).first()).toBeVisible({ timeout: 10_000 });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/test-data-view.mjs
+++ b/tests/test-data-view.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Focused integration test for preset-backed data_view creation.
+ *
+ * Verifies that append_block(type="data_view") creates an AFFiNE database block
+ * configured as a kanban view with title + status columns and that row writes
+ * work through the existing database tools.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
+const STATE_OUTPUT_PATH = path.resolve(__dirname, 'test-data-view-state.json');
+
+const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectTruthy(value, message) {
+  if (!value) {
+    throw new Error(`${message}: expected truthy value, got ${JSON.stringify(value)}`);
+  }
+}
+
+async function main() {
+  console.log('=== Data View Integration Test ===');
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Server: ${MCP_SERVER_PATH}`);
+  console.log();
+
+  const client = new Client({ name: 'affine-mcp-data-view-test', version: '1.0.0' });
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, '..'),
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: 'sync',
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+    },
+    stderr: 'pipe',
+  });
+
+  transport.stderr?.on('data', chunk => {
+    process.stderr.write(`[mcp-server] ${chunk}`);
+  });
+
+  const settle = (ms = 800) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function call(toolName, args = {}) {
+    console.log(`  → ${toolName}(${JSON.stringify(args)})`);
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    if (result?.isError) {
+      throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || 'unknown'}`);
+    }
+    const parsed = parseContent(result);
+    if (parsed && typeof parsed === 'object' && parsed.error) {
+      throw new Error(`${toolName} failed: ${parsed.error}`);
+    }
+    console.log('    ✓ OK');
+    return parsed;
+  }
+
+  await client.connect(transport);
+
+  const state = {
+    baseUrl: BASE_URL,
+    email: EMAIL,
+    workspaceId: null,
+    docId: null,
+    dataViewBlockId: null,
+    groupLabels: ['Todo', 'In Progress'],
+    rowTitles: ['Card Alpha', 'Card Beta'],
+  };
+
+  try {
+    const workspace = await call('create_workspace', { name: `data-view-test-${Date.now()}` });
+    state.workspaceId = workspace?.id;
+    if (!state.workspaceId) throw new Error('create_workspace did not return workspace id');
+
+    const doc = await call('create_doc', {
+      workspaceId: state.workspaceId,
+      title: 'Data View Test',
+      content: '',
+    });
+    state.docId = doc?.docId;
+    if (!state.docId) throw new Error('create_doc did not return docId');
+
+    const dataView = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'data_view',
+      text: 'Kanban Data View',
+    });
+    state.dataViewBlockId = dataView?.blockId;
+    if (!state.dataViewBlockId) throw new Error('append_block(data_view) did not return blockId');
+    expectEqual(dataView?.flavour, 'affine:database', 'data_view flavour');
+    expectEqual(dataView?.type, 'data_view_kanban', 'data_view returned type');
+    expectEqual(dataView?.normalizedType, 'data_view', 'data_view normalizedType');
+    await settle();
+
+    const schema = await call('read_database_columns', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.dataViewBlockId,
+    });
+
+    expectEqual(schema?.columnCount, 2, 'data_view column count');
+    expectEqual(schema?.rowCount, 0, 'data_view initial row count');
+    expectTruthy(Array.isArray(schema?.columns), 'data_view columns array');
+    expectTruthy(Array.isArray(schema?.views), 'data_view views array');
+    expectEqual(schema.views.length, 1, 'data_view view count');
+
+    const titleColumn = schema.columns.find(column => column.type === 'title');
+    const statusColumn = schema.columns.find(column => column.name === 'Status');
+    expectTruthy(titleColumn, 'data_view title column');
+    expectTruthy(statusColumn, 'data_view status column');
+    expectEqual(statusColumn.type, 'select', 'data_view status column type');
+    expectEqual(statusColumn.options.length, 3, 'data_view status option count');
+    expectEqual(statusColumn.options[0].value, 'Todo', 'data_view first status option');
+
+    const kanbanView = schema.views[0];
+    expectEqual(kanbanView.mode, 'kanban', 'data_view initial view mode');
+    expectEqual(kanbanView.name, 'Kanban View', 'data_view initial view name');
+    expectEqual(kanbanView.header.titleColumn, titleColumn.id, 'data_view title column header binding');
+    expectEqual(kanbanView.header.iconColumn, 'type', 'data_view icon column header binding');
+    expectEqual(kanbanView.groupBy?.columnId, statusColumn.id, 'data_view groupBy column');
+    expectEqual(kanbanView.groupBy?.name, 'select', 'data_view groupBy property type');
+
+    await call('add_database_row', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.dataViewBlockId,
+      cells: {
+        Title: 'Card Alpha',
+        Status: 'Todo',
+      },
+    });
+    await settle(1200);
+
+    await call('add_database_row', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.dataViewBlockId,
+      cells: {
+        Title: 'Card Beta',
+        Status: 'In Progress',
+      },
+    });
+    await settle(1200);
+
+    const rows = await call('read_database_cells', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.dataViewBlockId,
+    });
+    expectEqual(rows?.rows?.length, 2, 'data_view row count after inserts');
+    expectTruthy(rows.rows.some(row => row.title === 'Card Alpha'), 'data_view row title Card Alpha');
+    expectTruthy(rows.rows.some(row => row.title === 'Card Beta'), 'data_view row title Card Beta');
+
+    fs.writeFileSync(STATE_OUTPUT_PATH, JSON.stringify(state, null, 2));
+    console.log();
+    console.log(`State written to: ${STATE_OUTPUT_PATH}`);
+    console.log('=== Data view integration test passed ===');
+  } catch (err) {
+    fs.writeFileSync(STATE_OUTPUT_PATH, JSON.stringify({ ...state, error: err.message }, null, 2));
+    console.error();
+    console.error(`FAILED: ${err.message}`);
+    process.exitCode = 1;
+  } finally {
+    await transport.close();
+  }
+}
+
+main().catch(err => {
+  console.error('Test runner error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
# TL;DR
Replace the old `data_view` alias fallback with AFFiNE-compatible preset-backed data view support, including real kanban-oriented view metadata and verification.

# Context
`append_block(type="data_view")` previously created a plain database fallback without any meaningful data-view semantics. That kept the API surface nominally compatible, but it did not actually give callers a useful data-view shape to work with.

# Changes
- add preset-backed `data_view` creation on top of the current AFFiNE database-backed view model
- add `viewMode` support for `append_block` on `database` / `data_view` so callers can request `table` or `kanban`
- expose richer persisted view metadata through `read_database_columns`, including header and grouping details
- add focused integration and Playwright verification for kanban-style data views
- update docs and changelog for the new data-view behavior
- verification:
  - `npm run build`
  - `npm run test:tool-manifest`
  - `npm run test:data-view`
  - `npm run test:data-view-ui`
  - `APPEND_BLOCK_PROFILE=step4 node scripts/test-append-block-expansion.mjs`
