### PR TITLE
fix: seed data-view state in e2e pipeline

### DIFF
--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -7,8 +7,9 @@
 #   4. Run MCP database creation test (email/password auth)
 #   5. Run MCP bearer token auth test
 #   6. Run MCP tag visibility setup test
-#   7. Run Playwright UI verification (all scenarios)
-#   8. Tear down Docker (on exit)
+#   7. Run MCP data-view setup test
+#   8. Run Playwright UI verification (all scenarios)
+#   9. Tear down Docker (on exit)
 #
 set -euo pipefail
 
@@ -297,7 +298,12 @@ echo ""
 echo "=== Running MCP tag visibility setup test ==="
 node "$SCRIPT_DIR/test-tag-visibility.mjs"
 
-# --- Step 7: Run Playwright verification ---
+# --- Step 7: Run MCP data-view setup test ---
+echo ""
+echo "=== Running MCP data-view setup test ==="
+node "$SCRIPT_DIR/test-data-view.mjs"
+
+# --- Step 8: Run Playwright verification ---
 echo ""
 echo "=== Running Playwright UI verification ==="
 ensure_affine_ui_ready


### PR DESCRIPTION
# TL;DR
Fix the E2E pipeline so the new data-view Playwright verification gets its required seeded state before the UI suite runs.

# Context
After data-view support was added, the E2E workflow started running `tests/playwright/verify-data-view.pw.ts` as part of the shared Playwright suite. The pipeline still seeded only database, bearer-auth, and tag-visibility state, so the data-view UI test failed immediately because `tests/test-data-view-state.json` had never been created.

# Changes
- add the missing `test-data-view.mjs` setup step to `tests/run-e2e.sh` before the Playwright phase
- update the E2E step ordering comments so the seeded scenarios match the actual pipeline behavior
- verification:
  - `npm run ci`
  - `npm run test:e2e`
