### PR TITLE
chore(release): sync main into develop after v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-03-10
+
 ### Added
 - `read_database_columns` to expose database schema metadata for empty or sparsely populated AFFiNE databases.
 - Preset-backed `data_view` creation for kanban-oriented AFFiNE database views.
+- Focused supporting-tools regression coverage via `npm run test:supporting-tools`.
+- Markdown callout round-trips for admonition-style import/export flows.
+
+### Changed
+- `test:comprehensive` now self-bootstraps a local Docker AFFiNE stack and provides a raw mode for pre-provisioned environments.
+- `test:e2e` now isolates Docker stacks per run and seeds data-view state before Playwright verification.
+- README release history was trimmed in favor of dedicated changelog and release-note sources.
 
 ### Fixed
 - Empty database workflows no longer depend on existing rows to discover column names, IDs, types, and view mappings.
+- Reduced Docker bootstrap flakiness in the E2E pipeline by isolating Compose projects and staging startup checks.
+- Prevented the E2E Playwright suite from failing on missing `test-data-view-state.json` by adding the data-view setup phase.
 
 ## [1.8.0] - 2026-03-09
 
@@ -252,6 +263,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[1.9.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.9.0
 [1.8.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.8.0
 [1.7.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.7.2
 [1.7.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.7.1
@@ -265,4 +277,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.9.0...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted or cloud). It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`).
 
-[![Version](https://img.shields.io/badge/version-1.8.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-1.9.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -16,10 +16,10 @@ A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted
 - Purpose: Manage AFFiNE workspaces and documents through MCP
 - Transport: stdio (default) and optional HTTP (`/mcp`) for remote MCP deployments
 - Auth: Token, Cookie, or Email/Password (priority order)
-- Tools: 46 focused tools with WebSocket-based document editing
+- Tools: 47 focused tools with WebSocket-based document editing
 - Status: Active
  
-> New in v1.8.0: Added database cell read/write tools, fixed Kanban row title persistence, and added CLI version commands.
+> New in v1.9.0: Added database schema discovery, preset-backed data views, self-bootstrapping comprehensive regression, focused supporting-tools coverage, and markdown callout round-trips.
 
 ## Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,38 @@
 # Release Notes
 
+## Version 1.9.0 (2026-03-10)
+
+### Highlights
+- Added dedicated database schema discovery with `read_database_columns`, so empty AFFiNE databases are now self-describing.
+- Added preset-backed `data_view` creation with kanban-oriented verification and richer exposed view metadata.
+- Hardened test infrastructure with a self-bootstrapping comprehensive runner, focused supporting-tools coverage, and a more reliable end-to-end Docker pipeline.
+
+### What Changed
+- `src/tools/docs.ts`
+  - Added `read_database_columns` for empty-database schema discovery.
+  - Added preset-backed `data_view` creation and richer exposed view metadata for database views.
+  - Added markdown callout import/export support through the document markdown pipeline.
+- `tests/run-e2e.sh`, `tests/run-comprehensive.sh`
+  - Isolated Docker-backed test stacks and staged startup/readiness checks for more reliable local and CI execution.
+  - Seeded data-view state before Playwright so the full UI verification suite can run end to end.
+- `tests/test-supporting-tools.mjs`, `tests/test-data-view.mjs`, `tests/test-markdown-roundtrip.mjs`
+  - Added focused supporting-tools regression coverage.
+  - Added data-view integration coverage and markdown callout round-trip coverage.
+- `README.md`, `CHANGELOG.md`, `RELEASE_NOTES.md`, `tool-manifest.json`, `package.json`
+  - Bumped release metadata to `1.9.0`.
+  - Trimmed duplicated release history from the README and pointed readers to the dedicated release documents.
+
+### Validation Evidence
+- Release sanity gate passed:
+  - `npm run ci`
+- Live environment verification passed:
+  - `npm run test:e2e`
+  - `npm run test:comprehensive`
+  - `npm run test:supporting-tools`
+  - `npm run test:data-view`
+  - `npm run test:data-view-ui`
+  - `npm run test:markdown-roundtrip`
+
 ## Version 1.8.0 (2026-03-09)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.0",
+  "version": "1.9.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
# TL;DR
Sync the `v1.9.0` release metadata from `main` back into `develop` so versioned documentation and package metadata stay aligned after the release cut.

# Context
`main` now contains the `v1.9.0` release commit from PR #66. `develop` already has the functional changes, but it still needs the released version metadata and release-document updates from the production branch.

# Changes
- sync `package.json`, `package-lock.json`, `tool-manifest.json`, changelog, release notes, and README release metadata from `main` into `develop`
- preserve the existing `develop` feature history while aligning the post-release versioned documentation set
