### PR TITLE
feat(search): add search_docs tool for fast title search

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2402,17 +2402,19 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const meta = wsDoc.getMap("meta");
       const pages = getWorkspacePageEntries(meta);
 
-      const matches = pages
-        .filter((p) => p.title && p.title.toLowerCase().includes(q))
+      const baseUrl = (process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '');
+      const filtered = pages.filter((p) => p.title && p.title.toLowerCase().includes(q));
+      const totalCount = filtered.length;
+      const matches = filtered
         .slice(0, limit)
         .map((p) => ({
           docId: p.id,
           title: p.title,
           updatedAt: p.updatedDate ? new Date(p.updatedDate).toISOString() : null,
-          url: `${(process.env.AFFINE_BASE_URL || "").replace(/\/$/, "")}/workspace/${workspaceId}/${p.id}`,
+          url: `${baseUrl}/workspace/${workspaceId}/${p.id}`,
         }));
 
-      return text({ query: parsed.query, totalCount: matches.length, results: matches });
+      return text({ query: parsed.query, totalCount, results: matches });
     } finally {
       socket.disconnect();
     }

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -40,6 +40,7 @@
     "resolve_comment",
     "revoke_access_token",
     "revoke_doc",
+    "search_docs",
     "sign_in",
     "update_comment",
     "update_database_cell",


### PR DESCRIPTION
## Problem

Finding a document by title currently requires calling `export_doc_markdown` on every doc ID one by one — O(n) round trips, can take minutes on large workspaces.

## Solution

New `search_docs` tool that uses the workspace metadata snapshot (same approach already used by `list_tags`) to search doc titles in a single round trip — effectively O(1).

```bash
mcporter call affine.search_docs workspaceId=<id> query="my doc"
```

Returns:
```json
{
  "query": "my doc",
  "totalCount": 2,
  "results": [
    { "docId": "abc123", "title": "My Doc — Overview", "updatedAt": "2026-01-01T00:00:00.000Z", "url": "http://.../workspace/.../abc123" },
    { "docId": "def456", "title": "My Doc — Details", "updatedAt": null, "url": "..." }
  ]
}
```

## Parameters
- `workspaceId` — optional if default set
- `query` — case-insensitive substring match on title
- `limit` — max results (default: 20)