### PR TITLE
feat(move_doc): add move_doc tool for sidebar reorganization

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2895,7 +2895,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         pageId: parsed.docId,
       });
 
-      return { moved: true, docId: parsed.docId, toParentDocId: parsed.toParentDocId, removedFromParent };
+      return text({ moved: true, docId: parsed.docId, toParentDocId: parsed.toParentDocId, removedFromParent });
     } finally {
       socket.disconnect();
     }

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -30,6 +30,7 @@
     "list_notifications",
     "list_tags",
     "list_workspaces",
+    "move_doc",
     "publish_doc",
     "read_all_notifications",
     "read_database_cells",


### PR DESCRIPTION
## Problem

There was no way to move a doc in the AFFiNE sidebar via API. Newly created docs (especially orphans) could not be reorganized programmatically.

## Solution

New `move_doc` tool that manipulates `embed_linked_doc` blocks to reposition a doc in the sidebar hierarchy.

```bash
# Move doc to new parent (add link only)
move_doc(docId="abc", toParentDocId="xyz")

# Full move: remove from old parent, add to new
move_doc(docId="abc", toParentDocId="xyz", fromParentDocId="old")
```

## Behavior

- Always adds an `embed_linked_doc` block to `toParentDocId`
- If `fromParentDocId` is provided: finds and removes the existing `embed_linked_doc` block from that doc
- `removedFromParent` in response indicates whether the old link was successfully removed

## Notes
- Non-destructive when `fromParentDocId` is omitted — just adds the new link
- Compatible with the `parentDocId` param added to `create_doc_from_markdown`