### PR TITLE
feat(batch): add batch_create_docs tool

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3096,7 +3096,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     exportDocMarkdownHandler as any
   );
 
-  const createDocFromMarkdownHandler = async (parsed: {
+  // Core logic for creating a doc from markdown — returns structured data, no MCP envelope.
+  // Used by both createDocFromMarkdownHandler and batchCreateDocsHandler.
+  const createDocFromMarkdownCore = async (parsed: {
     workspaceId?: string;
     title?: string;
     markdown: string;
@@ -3141,7 +3143,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         ? [`${applied.skippedCount} markdown block(s) could not be applied to AFFiNE and were skipped.`]
         : [];
 
-    return text({
+    return {
       workspaceId: created.workspaceId,
       docId: created.docId,
       title: created.title,
@@ -3152,7 +3154,16 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         appliedBlocks: applied.appendedCount,
         skippedBlocks: applied.skippedCount,
       },
-    });
+    };
+  };
+
+  const createDocFromMarkdownHandler = async (parsed: {
+    workspaceId?: string;
+    title?: string;
+    markdown: string;
+    strict?: boolean;
+  }) => {
+    return text(await createDocFromMarkdownCore(parsed));
   };
   server.registerTool(
     "create_doc_from_markdown",
@@ -3183,8 +3194,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
 
     for (const item of parsed.docs) {
       try {
-        const r = await createDocFromMarkdownHandler({ workspaceId, title: item.title, markdown: item.markdown });
-        const d = JSON.parse((r as any).content[0].text);
+        const d = await createDocFromMarkdownCore({ workspaceId, title: item.title, markdown: item.markdown });
 
         // Link to parent if provided
         let linkedToParent = false;

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -7,6 +7,7 @@
     "append_block",
     "append_markdown",
     "append_paragraph",
+    "batch_create_docs",
     "cleanup_blobs",
     "create_comment",
     "create_doc",


### PR DESCRIPTION
## Problem

Creating a hierarchy of documents (e.g. a hub page with multiple child docs) required N sequential tool calls — one per document. This is slow and verbose.

## Solution

New `batch_create_docs` tool that creates up to 20 documents in a single call. Each doc can optionally specify a `parentDocId` to be automatically embedded in the sidebar.

```bash
batch_create_docs(docs=[
  { title: "Doc A", markdown: "# Doc A\n...", parentDocId: "hub-id" },
  { title: "Doc B", markdown: "# Doc B\n...", parentDocId: "hub-id" },
  { title: "Doc C", markdown: "# Doc C\n..." }  # orphan
])
```

Response:
```json
{
  "created": 3,
  "failed": 0,
  "results": [
    { "title": "Doc A", "docId": "...", "linkedToParent": true, "warnings": [] },
    { "title": "Doc B", "docId": "...", "linkedToParent": true, "warnings": [] },
    { "title": "Doc C", "docId": "...", "linkedToParent": false, "warnings": [] }
  ]
}
```

## Notes
- Max 20 docs per batch
- Per-item error handling: a single failure does not abort the rest of the batch
- Failed items report `docId: ""` and a warning message