### PR TITLE
feat(docs): add create_doc_from_template tool

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3905,6 +3905,58 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     },
   }, findAndReplaceHandler as any);
 
+  // ─── create_doc_from_template ───────────────────────────────────────────────
+  const createDocFromTemplateHandler = async (parsed: {
+    workspaceId?: string; templateDocId: string; title: string;
+    variables?: Record<string, string>; parentDocId?: string;
+  }) => {
+    const workspaceId = parsed.workspaceId || defaults.workspaceId;
+    if (!workspaceId) throw new Error("workspaceId is required.");
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
+    const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
+    const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
+    try {
+      await joinWorkspace(socket, workspaceId);
+      const snap = await loadDoc(socket, workspaceId, parsed.templateDocId);
+      if (!snap.missing) throw new Error(`Template doc ${parsed.templateDocId} not found.`);
+      const doc = new Y.Doc();
+      Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
+      const collected = collectDocForMarkdown(doc, new Map());
+      const rendered = renderBlocksToMarkdown({ rootBlockIds: collected.rootBlockIds, blocksById: collected.blocksById });
+      let markdown = rendered.markdown;
+      const vars = parsed.variables ?? {};
+      for (const [key, value] of Object.entries(vars)) {
+        const pattern = new RegExp(`\\{\\{\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\}}`, "g");
+        markdown = markdown.replace(pattern, value);
+      }
+      const unfilled = [...markdown.matchAll(/\{\{\s*[\w.-]+\s*\}\}/g)].map(m => m[0]);
+      socket.disconnect();
+      const created = await createDocFromMarkdownCore({ workspaceId, title: parsed.title, markdown });
+      let linkedToParent = false;
+      if (parsed.parentDocId && created.docId) {
+        try {
+          await appendBlockInternal({ workspaceId, docId: parsed.parentDocId, type: "embed_linked_doc", pageId: created.docId });
+          linkedToParent = true;
+        } catch { /* non-fatal */ }
+      }
+      return text({ ...created, sourceTemplateDocId: parsed.templateDocId, linkedToParent, unfilledVariables: unfilled });
+    } catch (err) {
+      try { socket.disconnect(); } catch { /* already disconnected */ }
+      throw err;
+    }
+  };
+  server.registerTool("create_doc_from_template", {
+    title: "Create Document from Template",
+    description: "Clone a template doc and substitute {{variable}} placeholders. Returns a warning for any unfilled variables. Optionally link to a parent doc in the sidebar.",
+    inputSchema: {
+      workspaceId: z.string().optional(),
+      templateDocId: z.string().describe("The template doc to clone from."),
+      title: z.string().describe("Title for the new doc."),
+      variables: z.record(z.string(), z.string()).optional().describe("Key-value map of {{variable}} substitutions, e.g. { \"client\": \"Leodonati\", \"month\": \"Marzo\" }."),
+      parentDocId: z.string().optional().describe("Parent doc to link the new doc under in the sidebar."),
+    },
+  }, createDocFromTemplateHandler as any);
+
   // ── helpers for database select columns ──
 
   type DatabaseColumnDef = {

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -13,6 +13,7 @@
     "create_comment",
     "create_doc",
     "create_doc_from_markdown",
+    "create_doc_from_template",
     "create_tag",
     "create_workspace",
     "current_user",


### PR DESCRIPTION
Clone an existing doc as a template, substituting `{{variable}}` placeholders before creating the new document.

**How it works:**
1. Loads the template doc and exports it to markdown
2. Applies regex substitution for each key in the `variables` map (`{{ key }}` → value, whitespace-tolerant)
3. Warns about any remaining unfilled placeholders via `unfilledVariables[]`
4. Creates the new doc via `createDocFromMarkdownCore` (shared helper, no JSON.parse on MCP envelope)
5. Optionally links the new doc under `parentDocId` in the sidebar

**Returns:** full creation metadata (`docId`, `title`, `warnings`, `lossy`, `stats`) plus `sourceTemplateDocId`, `linkedToParent`, `unfilledVariables`.