### PR TITLE
feat(workspace): add list_workspace_tree tool

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3701,6 +3701,60 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       dryRun: z.boolean().optional().describe("If true, only report matches without replacing (default: false)."),
     },
   }, findAndReplaceHandler as any);
+  // ─── list_workspace_tree ────────────────────────────────────────────────────
+  const listWorkspaceTreeHandler = async (parsed: { workspaceId?: string; depth?: number }) => {
+    const workspaceId = parsed.workspaceId || defaults.workspaceId;
+    if (!workspaceId) throw new Error("workspaceId is required.");
+    const maxDepth = parsed.depth ?? 3;
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
+    const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
+    const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
+    try {
+      await joinWorkspace(socket, workspaceId);
+      const wsSnap = await loadDoc(socket, workspaceId, workspaceId);
+      if (!wsSnap.missing) return text({ workspaceId, tree: [] });
+      const wsDoc = new Y.Doc();
+      Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
+      const pages = getWorkspacePageEntries(wsDoc.getMap("meta"));
+      const titleById = new Map(pages.map(p => [p.id, p.title ?? "Untitled"]));
+      const childrenOf = new Map<string, string[]>();
+      const allChildren = new Set<string>();
+      for (const page of pages) {
+        const snap = await loadDoc(socket, workspaceId, page.id);
+        if (!snap.missing) continue;
+        const doc = new Y.Doc();
+        Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
+        const blocks = doc.getMap("blocks") as Y.Map<any>;
+        const kids: string[] = [];
+        for (const [, raw] of blocks) {
+          if (!(raw instanceof Y.Map)) continue;
+          if (raw.get("sys:flavour") !== "affine:embed-linked-doc") continue;
+          const pid = raw.get("prop:pageId");
+          if (typeof pid === "string" && pid && titleById.has(pid)) {
+            kids.push(pid);
+            allChildren.add(pid);
+          }
+        }
+        if (kids.length) childrenOf.set(page.id, kids);
+      }
+      const baseUrl = (process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '');
+      const roots = pages.filter(p => !allChildren.has(p.id)).map(p => p.id);
+      const buildNode = (id: string, depth: number): any => ({
+        docId: id, title: titleById.get(id) ?? "Untitled",
+        url: `${baseUrl}/workspace/${workspaceId}/${id}`,
+        children: depth < maxDepth ? (childrenOf.get(id) ?? []).map(cid => buildNode(cid, depth + 1)) : [],
+      });
+      return text({ workspaceId, totalDocs: pages.length, rootCount: roots.length, tree: roots.map(id => buildNode(id, 0)) });
+    } finally { socket.disconnect(); }
+  };
+  server.registerTool("list_workspace_tree", {
+    title: "List Workspace Tree",
+    description: "Returns the full document hierarchy as a tree (roots → children → grandchildren). Use depth to limit nesting (default: 3). Note: loads all docs — may be slow on large workspaces.",
+    inputSchema: {
+      workspaceId: z.string().optional(),
+      depth: z.number().optional().describe("Max nesting depth to return (default: 3)."),
+    },
+  }, listWorkspaceTreeHandler as any);
 
   // ── helpers for database select columns ──
 

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -32,6 +32,7 @@
     "list_histories",
     "list_notifications",
     "list_tags",
+    "list_workspace_tree",
     "list_workspaces",
     "move_doc",
     "publish_doc",


### PR DESCRIPTION
Returns the full document hierarchy as a nested tree by scanning `embed_linked_doc` blocks across all docs.

**How it works:**
1. Loads workspace metadata snapshot to get all page entries
2. For each doc, scans `embed_linked_doc` blocks to build a parent→children map
3. Identifies root docs (not referenced as children by anyone)
4. Recursively builds the tree up to `depth` levels (default: 3)

**Returns:** `workspaceId`, `totalDocs`, `rootCount`, `tree` with `{ docId, title, url, children[] }` at each node.

**Note:** O(n) on workspace size — loads every doc. Noted in the description.

Base URL uses `process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')`, consistent with the pattern in `workspaces.ts`.