### PR TITLE
fix(docs): restore list_docs titles from workspace metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:db-cells": "node tests/test-database-cells.mjs",
     "test:db-schema": "node tests/test-database-schema.mjs",
     "test:data-view": "node tests/test-data-view.mjs",
+    "test:doc-discovery": "node tests/test-doc-discovery.mjs",
     "test:data-view-ui": "npx playwright test tests/playwright/verify-data-view.pw.ts --config tests/playwright/playwright.config.ts",
     "test:bearer": "node tests/test-bearer-auth.mjs",
     "test:supporting-tools": "node tests/test-supporting-tools.mjs",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2270,6 +2270,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const docs = data.workspace.docs;
 
       const tagsByDocId = new Map<string, string[]>();
+      const titlesByDocId = new Map<string, string>();
       try {
         const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -2284,6 +2285,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             const pages = getWorkspacePageEntries(meta);
             const { byId } = getWorkspaceTagOptionMaps(meta);
             for (const page of pages) {
+              if (page.title) {
+                titlesByDocId.set(page.id, page.title);
+              }
               const tagEntries = getStringArray(page.tagsArray);
               tagsByDocId.set(page.id, resolveTagLabels(tagEntries, byId));
             }
@@ -2307,6 +2311,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
                 ...edge,
                 node: {
                   ...node,
+                  title: titlesByDocId.get(node.id) || node.title,
                   tags: tagsByDocId.get(node.id) || [],
                 },
               };

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -303,7 +303,12 @@ echo ""
 echo "=== Running MCP data-view setup test ==="
 node "$SCRIPT_DIR/test-data-view.mjs"
 
-# --- Step 8: Run Playwright verification ---
+# --- Step 8: Run MCP doc discovery regression test ---
+echo ""
+echo "=== Running MCP doc discovery regression test ==="
+node "$SCRIPT_DIR/test-doc-discovery.mjs"
+
+# --- Step 9: Run Playwright verification ---
 echo ""
 echo "=== Running Playwright UI verification ==="
 ensure_affine_ui_ready

--- a/tests/test-doc-discovery.mjs
+++ b/tests/test-doc-discovery.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Focused integration test for document discovery helpers.
+ *
+ * Covers:
+ * - list_docs should return titles from workspace metadata when GraphQL omits them
+ * - search_docs should find matching docs in a single call
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, "..", "dist", "index.js");
+
+const BASE_URL = process.env.AFFINE_BASE_URL || "http://localhost:3010";
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || "test@affine.local";
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error("AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh");
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || "60000");
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function expectTruthy(value, message) {
+  if (!value) {
+    throw new Error(`${message}: expected truthy value, got ${JSON.stringify(value)}`);
+  }
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(haystack, needle, message) {
+  if (!Array.isArray(haystack) || !haystack.includes(needle)) {
+    throw new Error(`${message}: expected ${JSON.stringify(haystack)} to include ${JSON.stringify(needle)}`);
+  }
+}
+
+async function main() {
+  console.log("=== Document Discovery Integration Test ===");
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log();
+
+  const client = new Client({ name: "affine-mcp-doc-discovery", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, ".."),
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: "sync",
+      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-doc-discovery-noconfig",
+    },
+    stderr: "pipe",
+  });
+
+  transport.stderr?.on("data", chunk => {
+    process.stderr.write(`[mcp-server] ${chunk}`);
+  });
+
+  async function call(toolName, args = {}) {
+    console.log(`  → ${toolName}(${JSON.stringify(args)})`);
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    if (result?.isError) {
+      throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || "unknown"}`);
+    }
+    const parsed = parseContent(result);
+    if (parsed && typeof parsed === "object" && parsed.error) {
+      throw new Error(`${toolName} failed: ${parsed.error}`);
+    }
+    if (typeof parsed === "string" && /^(GraphQL error:|Error:|MCP error)/i.test(parsed)) {
+      throw new Error(`${toolName} failed: ${parsed}`);
+    }
+    console.log("    ✓ OK");
+    return parsed;
+  }
+
+  await client.connect(transport);
+
+  try {
+    const timestamp = Date.now();
+    const workspace = await call("create_workspace", { name: `doc-discovery-${timestamp}` });
+    expectTruthy(workspace?.id, "create_workspace id");
+
+    await call("update_doc_title", {
+      workspaceId: workspace.id,
+      docId: workspace.firstDocId,
+      title: "Workspace Home",
+    });
+
+    const listed = await call("list_docs", { workspaceId: workspace.id, first: 50 });
+    const listedTitles = listed?.edges?.map(edge => edge?.node?.title) || [];
+    expectIncludes(listedTitles, "Workspace Home", "list_docs titles");
+
+    for (const title of ["Tasky", "Operations Notes", "Task Tracker"]) {
+      const created = await call("create_doc", {
+        workspaceId: workspace.id,
+        title,
+        content: `${title} body`,
+      });
+      expectTruthy(created?.docId, `create_doc docId for ${title}`);
+    }
+
+    const search = await call("search_docs", { workspaceId: workspace.id, query: "Task", limit: 10 });
+    expectEqual(search?.totalCount, 2, "search_docs totalCount");
+    const searchTitles = search?.results?.map(result => result?.title) || [];
+    expectIncludes(searchTitles, "Tasky", "search_docs result titles");
+    expectIncludes(searchTitles, "Task Tracker", "search_docs result titles");
+
+    console.log();
+    console.log("=== Document discovery integration test passed ===");
+  } finally {
+    await transport.close();
+  }
+}
+
+main().catch(err => {
+  console.error("FAILED:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
# TL;DR
Restore `list_docs` titles from workspace metadata when the GraphQL payload omits them, and add a live regression test that also covers the lightweight `search_docs` flow requested in #90.

# Context
The current `list_docs` response can still return `node.title: null` even when the same document has a valid title in the workspace snapshot. That breaks list rendering and forces callers to fall back to `get_doc`. The issue discussion also asked for a lightweight discovery path; `search_docs` already exists, so this PR keeps that path covered in the same live regression.

Validated locally with:
- `npm run build`
- `npm test`
- `npm run test:doc-discovery`

# Changes
- read page titles from the workspace Yjs metadata during `list_docs` and use them as a fallback when GraphQL omits the title
- add `tests/test-doc-discovery.mjs` to verify both the `list_docs` title fallback and the `search_docs` single-call discovery path against a live AFFiNE instance
- wire the new regression into `tests/run-e2e.sh` and expose it as `npm run test:doc-discovery`
