### PR TITLE
feat(http): expand auth diagnostics and search discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Notes for oauth mode:
 - `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS=true` is rejected in oauth mode
 - tokens are validated against the issuer discovery metadata and JWKS
 - the protected resource metadata is also served at `/.well-known/oauth-protected-resource/mcp` for path-specific discovery
+- `GET /healthz` and `GET /readyz` are available for deployment diagnostics
 
 #### Recommended presets
 
@@ -343,6 +344,8 @@ Endpoints currently available:
 - `/mcp` - MCP server (Streamable HTTP)
 - `/sse` - SSE endpoint (old protocol compatible)
 - `/messages` - Messages endpoint (old protocol compatible)
+- `/healthz` - HTTP liveness probe
+- `/readyz` - HTTP readiness probe
 
 ## Available Tools
 
@@ -356,6 +359,7 @@ Endpoints currently available:
 ### Documents
 - `list_docs` – list documents with pagination (includes `node.tags`)
 - `list_tags` – list all tags in a workspace
+- `search_docs` – fast title search with substring/prefix/exact matching, optional tag filtering, and updatedAt sorting
 - `list_docs_by_tag` – list documents by tag
 - `get_doc` – get document metadata
 - `read_doc` – read document block content and plain text snapshot (WebSocket)
@@ -423,7 +427,7 @@ npm run pack:check
 - For full tool-surface verification, run `npm run test:comprehensive` (self-bootstraps a local Docker AFFiNE stack).
 - For pre-provisioned environments, use `npm run test:comprehensive:raw`.
 - For full environment verification, run `npm run test:e2e` (Docker + MCP + Playwright).
-- Additional focused runners: `npm run test:db-create`, `npm run test:db-cells`, `npm run test:db-schema`, `npm run test:supporting-tools`, `npm run test:bearer`, `npm run test:cli-version`, `npm run test:playwright`.
+- Additional focused runners: `npm run test:db-create`, `npm run test:db-cells`, `npm run test:db-schema`, `npm run test:supporting-tools`, `npm run test:bearer`, `npm run test:http-bearer`, `npm run test:oauth-http`, `npm run test:doc-discovery`, `npm run test:cli-version`, `npm run test:playwright`.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:doc-discovery": "node tests/test-doc-discovery.mjs",
     "test:data-view-ui": "npx playwright test tests/playwright/verify-data-view.pw.ts --config tests/playwright/playwright.config.ts",
     "test:bearer": "node tests/test-bearer-auth.mjs",
+    "test:http-bearer": "node tests/test-http-bearer.mjs",
     "test:oauth-http": "node tests/test-oauth-http.mjs",
     "test:supporting-tools": "node tests/test-supporting-tools.mjs",
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",

--- a/src/httpAuth.ts
+++ b/src/httpAuth.ts
@@ -1,0 +1,196 @@
+import type express from "express";
+import type { NextFunction, Request, Response } from "express";
+
+import type { ServerConfig } from "./config.js";
+import type { OAuthConfig } from "./oauth.js";
+import {
+  buildOAuthProtectedResourceMetadata,
+  getOAuthProtectedResourceMetadataPaths,
+  getOAuthProtectedResourceMetadataUrl,
+  validateOAuthConfig,
+  verifyOAuthAccessToken,
+} from "./oauth.js";
+
+export type HttpAuthState = {
+  authMiddleware: (req: Request, res: Response, next: NextFunction) => void;
+  httpAuthToken?: string;
+  oauthConfig: OAuthConfig | null;
+  protectedResourceMetadataUrl: string | null;
+  protectedResourceMetadataPaths: string[];
+};
+
+function buildOAuthErrorResponse(error: string, description: string) {
+  return {
+    error,
+    error_description: description,
+  };
+}
+
+function buildWwwAuthenticateHeader(
+  protectedResourceMetadataUrl: string | null,
+  opts?: {
+    error?: string;
+    errorDescription?: string;
+    scope?: string;
+  },
+) {
+  const params: string[] = [];
+  if (opts?.error) {
+    params.push(`error="${opts.error}"`);
+  }
+  if (opts?.errorDescription) {
+    params.push(`error_description="${opts.errorDescription.replace(/"/g, "'")}"`);
+  }
+  if (opts?.scope) {
+    params.push(`scope="${opts.scope}"`);
+  }
+  if (protectedResourceMetadataUrl) {
+    params.push(`resource_metadata="${protectedResourceMetadataUrl}"`);
+  }
+  return params.length > 0 ? `Bearer ${params.join(", ")}` : "Bearer";
+}
+
+export function createHttpAuthState(
+  config: ServerConfig,
+  opts: { allowAnyOrigin: boolean; httpAuthToken?: string },
+): HttpAuthState {
+  let oauthConfig: OAuthConfig | null = null;
+  let protectedResourceMetadataUrl: string | null = null;
+  let protectedResourceMetadataPaths: string[] = [];
+
+  if (config.authMode === "oauth") {
+    if (!config.publicBaseUrl) {
+      throw new Error("AFFINE_MCP_PUBLIC_BASE_URL is required when AFFINE_MCP_AUTH_MODE=oauth.");
+    }
+    if (!config.oauthIssuerUrl) {
+      throw new Error("AFFINE_OAUTH_ISSUER_URL is required when AFFINE_MCP_AUTH_MODE=oauth.");
+    }
+    oauthConfig = {
+      publicBaseUrl: config.publicBaseUrl,
+      issuerUrl: config.oauthIssuerUrl,
+      scopes: config.oauthScopes,
+      clockSkewSeconds: config.oauthClockSkewSeconds,
+    };
+    validateOAuthConfig(oauthConfig, opts);
+    protectedResourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(oauthConfig.publicBaseUrl);
+    protectedResourceMetadataPaths = getOAuthProtectedResourceMetadataPaths(oauthConfig.publicBaseUrl);
+  }
+
+  const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    if (req.method === "OPTIONS") return next();
+
+    if (config.authMode === "oauth") {
+      if (!oauthConfig) {
+        res.status(500).json(buildOAuthErrorResponse("server_error", "OAuth configuration was not initialized."));
+        return;
+      }
+
+      if (typeof req.query.token === "string") {
+        res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl, {
+          error: "invalid_request",
+          errorDescription: "Query parameter token is not allowed in oauth mode.",
+        }));
+        res.status(400).json(buildOAuthErrorResponse("invalid_request", "Query parameter token is not allowed in oauth mode."));
+        return;
+      }
+
+      const authHeader = req.headers.authorization;
+      if (!authHeader) {
+        res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl));
+        res.status(401).json(buildOAuthErrorResponse("invalid_token", "Missing Authorization header."));
+        return;
+      }
+
+      const raw = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      const bearerMatch = /^Bearer\s+(.+)$/i.exec(raw);
+      if (!bearerMatch) {
+        res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl, {
+          error: "invalid_request",
+          errorDescription: "Use 'Authorization: Bearer <token>'.",
+        }));
+        res.status(401).json(buildOAuthErrorResponse("invalid_request", "Use 'Authorization: Bearer <token>'."));
+        return;
+      }
+
+      void verifyOAuthAccessToken(bearerMatch[1], oauthConfig)
+        .then((authInfo) => {
+          const requiredScopes = oauthConfig?.scopes || [];
+          const hasAllScopes = requiredScopes.every((scope) => authInfo.scopes.includes(scope));
+          if (!hasAllScopes) {
+            res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl, {
+              error: "insufficient_scope",
+              errorDescription: "The access token does not include the required scope.",
+              scope: requiredScopes.join(" "),
+            }));
+            res.status(403).json(
+              buildOAuthErrorResponse("insufficient_scope", "The access token does not include the required scope."),
+            );
+            return;
+          }
+          next();
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : "Access token validation failed.";
+          res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl, {
+            error: "invalid_token",
+            errorDescription: message,
+          }));
+          res.status(401).json(buildOAuthErrorResponse("invalid_token", message));
+        });
+      return;
+    }
+
+    const httpAuthToken = opts.httpAuthToken;
+    if (!httpAuthToken) return next();
+
+    const authHeader = req.headers.authorization;
+    const queryToken = typeof req.query.token === "string" ? req.query.token : undefined;
+    let token: string | undefined;
+
+    if (authHeader !== undefined) {
+      const raw = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      const bearerMatch = /^Bearer\s+(.+)$/i.exec(raw);
+      if (bearerMatch) {
+        token = bearerMatch[1];
+      } else {
+        res.status(401).send("Unauthorized: Use 'Authorization: Bearer <token>'");
+        return;
+      }
+    } else if (queryToken !== undefined) {
+      token = queryToken;
+    }
+
+    if (token !== httpAuthToken) {
+      res.status(401).send("Unauthorized: Invalid or missing token");
+      return;
+    }
+    next();
+  };
+
+  return {
+    authMiddleware,
+    httpAuthToken: opts.httpAuthToken,
+    oauthConfig,
+    protectedResourceMetadataUrl,
+    protectedResourceMetadataPaths,
+  };
+}
+
+export function registerHttpAuthRoutes(
+  app: express.Express,
+  state: HttpAuthState,
+  corsMiddleware: (req: Request, res: Response, next: NextFunction) => void,
+) {
+  if (!state.oauthConfig || state.protectedResourceMetadataPaths.length === 0) {
+    return;
+  }
+
+  const metadata = buildOAuthProtectedResourceMetadata(state.oauthConfig);
+  const metadataHandler = (_req: Request, res: Response) => {
+    res.json(metadata);
+  };
+
+  for (const path of state.protectedResourceMetadataPaths) {
+    app.get(path, corsMiddleware, metadataHandler);
+  }
+}

--- a/src/httpDiagnostics.ts
+++ b/src/httpDiagnostics.ts
@@ -1,0 +1,50 @@
+import type express from "express";
+import type { NextFunction, Request, Response } from "express";
+
+import type { ServerConfig } from "./config.js";
+import type { HttpAuthState } from "./httpAuth.js";
+import { getOAuthResourceUrl, probeOAuthReadiness } from "./oauth.js";
+
+export function registerHttpDiagnosticsRoutes(
+  app: express.Express,
+  config: ServerConfig,
+  authState: HttpAuthState,
+  corsMiddleware: (req: Request, res: Response, next: NextFunction) => void,
+) {
+  app.get("/healthz", corsMiddleware, (_req: Request, res: Response) => {
+    res.json({
+      status: "ok",
+      authMode: config.authMode,
+      protected: config.authMode === "oauth" || Boolean(authState.httpAuthToken),
+    });
+  });
+
+  app.get("/readyz", corsMiddleware, async (_req: Request, res: Response) => {
+    if (config.authMode === "oauth" && authState.oauthConfig) {
+      try {
+        const readiness = await probeOAuthReadiness(authState.oauthConfig);
+        res.json({
+          status: "ok",
+          authMode: "oauth",
+          issuer: readiness.issuer,
+          jwksUri: readiness.jwksUri,
+          resource: getOAuthResourceUrl(authState.oauthConfig.publicBaseUrl),
+        });
+        return;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "OAuth readiness check failed.";
+        res.status(503).json({
+          status: "not_ready",
+          authMode: "oauth",
+          error: message,
+        });
+        return;
+      }
+    }
+
+    res.json({
+      status: "ok",
+      authMode: config.authMode,
+    });
+  });
+}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -58,6 +58,13 @@ export function getOAuthProtectedResourceMetadataUrl(publicBaseUrl: string): str
   return `${publicBaseUrl.replace(/\/$/, "")}/.well-known/oauth-protected-resource`;
 }
 
+export function getOAuthProtectedResourceMetadataPaths(publicBaseUrl: string): string[] {
+  const primaryPath = new URL(getOAuthProtectedResourceMetadataUrl(publicBaseUrl)).pathname;
+  const resourcePath = new URL(getOAuthResourceUrl(publicBaseUrl)).pathname;
+  const aliasPath = `/.well-known/oauth-protected-resource${resourcePath === "/" ? "" : resourcePath}`;
+  return [...new Set([primaryPath, aliasPath])];
+}
+
 export function buildOAuthProtectedResourceMetadata(config: OAuthConfig) {
   return {
     resource: getOAuthResourceUrl(config.publicBaseUrl),
@@ -132,6 +139,17 @@ async function loadAuthorizationServerMetadata(issuerUrl: string): Promise<Autho
     metadataCache.set(issuerUrl, pending);
   }
   return pending;
+}
+
+export async function probeOAuthReadiness(config: OAuthConfig): Promise<{ issuer: string; jwksUri: string }> {
+  const metadata = await loadAuthorizationServerMetadata(config.issuerUrl);
+  if (!metadata.jwks_uri) {
+    throw new Error("Authorization server metadata is missing jwks_uri");
+  }
+  return {
+    issuer: metadata.issuer,
+    jwksUri: metadata.jwks_uri,
+  };
 }
 
 function getJwks(metadata: AuthorizationServerMetadata) {

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -6,15 +6,9 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import type { OAuthConfig } from "./oauth.js";
 import type { ServerConfig } from "./config.js";
-import {
-  buildOAuthProtectedResourceMetadata,
-  getOAuthProtectedResourceMetadataUrl,
-  getOAuthResourceUrl,
-  validateOAuthConfig,
-  verifyOAuthAccessToken,
-} from "./oauth.js";
+import { registerHttpDiagnosticsRoutes } from "./httpDiagnostics.js";
+import { createHttpAuthState, registerHttpAuthRoutes } from "./httpAuth.js";
 
 export async function startHttpMcpServer(
   createMcpServer: () => Promise<McpServer>,
@@ -105,166 +99,14 @@ export async function startHttpMcpServer(
     });
   };
 
-  let oauthConfig: OAuthConfig | null = null;
-  let oauthProtectedResourceMetadataUrl: string | null = null;
-  let oauthProtectedResourceMetadataPath: string | null = null;
-  let oauthProtectedResourceMetadataPathAlias: string | null = null;
-
-  if (config.authMode === "oauth") {
-    if (!config.publicBaseUrl) {
-      throw new Error("AFFINE_MCP_PUBLIC_BASE_URL is required when AFFINE_MCP_AUTH_MODE=oauth.");
-    }
-    if (!config.oauthIssuerUrl) {
-      throw new Error("AFFINE_OAUTH_ISSUER_URL is required when AFFINE_MCP_AUTH_MODE=oauth.");
-    }
-    oauthConfig = {
-      publicBaseUrl: config.publicBaseUrl,
-      issuerUrl: config.oauthIssuerUrl,
-      scopes: config.oauthScopes,
-      clockSkewSeconds: config.oauthClockSkewSeconds,
-    };
-    validateOAuthConfig(oauthConfig, { allowAnyOrigin, httpAuthToken });
-    oauthProtectedResourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(oauthConfig.publicBaseUrl);
-    oauthProtectedResourceMetadataPath = new URL(oauthProtectedResourceMetadataUrl).pathname;
-    oauthProtectedResourceMetadataPathAlias = `/.well-known/oauth-protected-resource${new URL(getOAuthResourceUrl(oauthConfig.publicBaseUrl)).pathname}`;
-  }
-
-  const buildOAuthErrorResponse = (error: string, description: string) => ({
-    error,
-    error_description: description,
-  });
-
-  const buildWwwAuthenticateHeader = (opts?: {
-    error?: string;
-    errorDescription?: string;
-    scope?: string;
-  }) => {
-    const params: string[] = [];
-    if (opts?.error) {
-      params.push(`error="${opts.error}"`);
-    }
-    if (opts?.errorDescription) {
-      params.push(`error_description="${opts.errorDescription.replace(/"/g, "'")}"`);
-    }
-    if (opts?.scope) {
-      params.push(`scope="${opts.scope}"`);
-    }
-    if (oauthProtectedResourceMetadataUrl) {
-      params.push(`resource_metadata="${oauthProtectedResourceMetadataUrl}"`);
-    }
-    return params.length > 0 ? `Bearer ${params.join(", ")}` : "Bearer";
-  };
+  const authState = createHttpAuthState(config, { allowAnyOrigin, httpAuthToken });
 
   // Validates the Bearer token on all non-preflight requests.
   // The auth scheme match is case-insensitive for client compatibility.
   // OPTIONS is allowed through so CORS preflight can complete before auth is checked.
-  const authMiddleware = (req: Request, res: Response, next: NextFunction) => {
-    if (req.method === "OPTIONS") return next();
-    if (config.authMode === "oauth") {
-      if (!oauthConfig) {
-        res.status(500).json(buildOAuthErrorResponse("server_error", "OAuth configuration was not initialized."));
-        return;
-      }
-
-      if (typeof req.query.token === "string") {
-        res.set("WWW-Authenticate", buildWwwAuthenticateHeader({
-          error: "invalid_request",
-          errorDescription: "Query parameter token is not allowed in oauth mode.",
-        }));
-        res.status(400).json(buildOAuthErrorResponse("invalid_request", "Query parameter token is not allowed in oauth mode."));
-        return;
-      }
-
-      const authHeader = req.headers["authorization"];
-      if (authHeader === undefined) {
-        res.set("WWW-Authenticate", buildWwwAuthenticateHeader());
-        res.status(401).json(buildOAuthErrorResponse("invalid_token", "Missing Authorization header."));
-        return;
-      }
-
-      const raw = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-      const bearerMatch = /^Bearer\s+(.+)$/i.exec(raw);
-      if (!bearerMatch) {
-        res.set("WWW-Authenticate", buildWwwAuthenticateHeader({
-          error: "invalid_request",
-          errorDescription: "Use 'Authorization: Bearer <token>'.",
-        }));
-        res.status(401).json(buildOAuthErrorResponse("invalid_request", "Use 'Authorization: Bearer <token>'."));
-        return;
-      }
-
-      void verifyOAuthAccessToken(bearerMatch[1], oauthConfig)
-        .then((authInfo) => {
-          const requiredScopes = oauthConfig?.scopes || [];
-          const hasAllScopes = requiredScopes.every((scope) => authInfo.scopes.includes(scope));
-          if (!hasAllScopes) {
-            res.set("WWW-Authenticate", buildWwwAuthenticateHeader({
-              error: "insufficient_scope",
-              errorDescription: "The access token does not include the required scope.",
-              scope: requiredScopes.join(" "),
-            }));
-            res.status(403).json(
-              buildOAuthErrorResponse("insufficient_scope", "The access token does not include the required scope."),
-            );
-            return;
-          }
-          next();
-        })
-        .catch((error) => {
-          const message = error instanceof Error ? error.message : "Access token validation failed.";
-          res.set("WWW-Authenticate", buildWwwAuthenticateHeader({
-            error: "invalid_token",
-            errorDescription: message,
-          }));
-          res.status(401).json(buildOAuthErrorResponse("invalid_token", message));
-        });
-      return;
-    }
-
-    if (!httpAuthToken) return next();
-
-    const authHeader = req.headers["authorization"];
-    const queryToken =
-      typeof req.query.token === "string" ? req.query.token : undefined;
-    let token: string | undefined;
-
-    if (authHeader !== undefined) {
-      // Normalize string | string[] to string (HTTP spec allows duplicate headers).
-      const raw = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-      const bearerMatch = /^Bearer\s+(.+)$/i.exec(raw);
-      if (bearerMatch) {
-        token = bearerMatch[1];
-      } else {
-        // Strictly reject non-Bearer schemes to avoid accidentally accepting Basic / Digest.
-        console.warn(
-          "[affine-mcp] Authorization header is not Bearer scheme. " +
-            "Expected: 'Authorization: Bearer <token>'.",
-        );
-        res
-          .status(401)
-          .send("Unauthorized: Use 'Authorization: Bearer <token>'");
-        return;
-      }
-    } else if (queryToken !== undefined) {
-      token = queryToken;
-    }
-
-    if (token !== httpAuthToken) {
-      res.status(401).send("Unauthorized: Invalid or missing token");
-      return;
-    }
-    next();
-  };
-
-  if (oauthConfig && oauthProtectedResourceMetadataPath && oauthProtectedResourceMetadataPathAlias) {
-    const metadataHandler = (_req: Request, res: Response) => {
-      res.json(buildOAuthProtectedResourceMetadata(oauthConfig!));
-    };
-    app.get(oauthProtectedResourceMetadataPath, corsMiddleware, metadataHandler);
-    if (oauthProtectedResourceMetadataPathAlias !== oauthProtectedResourceMetadataPath) {
-      app.get(oauthProtectedResourceMetadataPathAlias, corsMiddleware, metadataHandler);
-    }
-  }
+  const { authMiddleware } = authState;
+  registerHttpAuthRoutes(app, authState, corsMiddleware);
+  registerHttpDiagnosticsRoutes(app, config, authState, corsMiddleware);
 
   // Explicit preflight handlers for the legacy SSE routes.
   app.options("/sse", corsMiddleware);
@@ -441,6 +283,11 @@ export async function startHttpMcpServer(
     console.error(
       `[affine-mcp] Legacy SSE     (2024-11-05): http://${displayHost}:${port}/sse`,
     );
+    console.error(`[affine-mcp] Diagnostics: http://${displayHost}:${port}/healthz`);
+    console.error(`[affine-mcp] Readiness:   http://${displayHost}:${port}/readyz`);
+    if (authState.protectedResourceMetadataUrl) {
+      console.error(`[affine-mcp] Protected resource metadata: ${authState.protectedResourceMetadataUrl}`);
+    }
   });
 
   // Graceful shutdown: stop accepting new connections, then close active transports.

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2395,13 +2395,48 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       socket.disconnect();
     }
   };
+  const getSearchMatchRank = (
+    title: string | null,
+    normalizedQuery: string,
+    matchMode: "substring" | "prefix" | "exact",
+  ): number | null => {
+    if (!title) return null;
+    const normalizedTitle = title.toLocaleLowerCase();
+    const isExact = normalizedTitle === normalizedQuery;
+    const isPrefix = normalizedTitle.startsWith(normalizedQuery);
+    const isSubstring = normalizedTitle.includes(normalizedQuery);
+
+    if (matchMode === "exact") {
+      return isExact ? 0 : null;
+    }
+    if (matchMode === "prefix") {
+      return isPrefix ? (isExact ? 0 : 1) : null;
+    }
+    if (isExact) return 0;
+    if (isPrefix) return 1;
+    if (isSubstring) return 2;
+    return null;
+  };
+
   // search_docs: fast title search via workspace metadata (no per-doc loading needed)
-  const searchDocsHandler = async (parsed: { workspaceId?: string; query: string; limit?: number }) => {
+  const searchDocsHandler = async (parsed: {
+    workspaceId?: string;
+    query: string;
+    limit?: number;
+    matchMode?: "substring" | "prefix" | "exact";
+    tag?: string;
+    sortBy?: "relevance" | "updatedAt";
+    sortDirection?: "asc" | "desc";
+  }) => {
     const workspaceId = parsed.workspaceId || defaults.workspaceId;
     if (!workspaceId) throw new Error("workspaceId is required.");
-    const q = (parsed.query ?? "").toLowerCase().trim();
+    const q = (parsed.query ?? "").toLocaleLowerCase().trim();
     if (!q) throw new Error("query is required.");
     const limit = parsed.limit ?? 20;
+    const matchMode = parsed.matchMode ?? "substring";
+    const sortBy = parsed.sortBy ?? "relevance";
+    const sortDirection = parsed.sortDirection ?? "desc";
+    const normalizedTag = (parsed.tag ?? "").toLocaleLowerCase().trim();
 
     const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -2416,20 +2451,66 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       Y.applyUpdate(wsDoc, Buffer.from(snapshot.missing, "base64"));
       const meta = wsDoc.getMap("meta");
       const pages = getWorkspacePageEntries(meta);
+      const { byId } = getWorkspaceTagOptionMaps(meta);
 
       const baseUrl = (process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '');
-      const filtered = pages.filter((p) => p.title && p.title.toLowerCase().includes(q));
+      const filtered = pages
+        .map((page) => {
+          const rank = getSearchMatchRank(page.title, q, matchMode);
+          if (rank === null) {
+            return null;
+          }
+          const tags = resolveTagLabels(getStringArray(page.tagsArray), byId);
+          if (normalizedTag && !tags.some((tag) => tag.toLocaleLowerCase().includes(normalizedTag))) {
+            return null;
+          }
+          const updatedTimestamp = page.updatedDate ?? page.createDate ?? 0;
+          return {
+            docId: page.id,
+            title: page.title,
+            tags,
+            updatedAt: updatedTimestamp > 0 ? new Date(updatedTimestamp).toISOString() : null,
+            updatedTimestamp,
+            url: `${baseUrl}/workspace/${workspaceId}/${page.id}`,
+            rank,
+          };
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+      filtered.sort((a, b) => {
+        if (sortBy === "updatedAt") {
+          const diff = a.updatedTimestamp - b.updatedTimestamp;
+          if (diff !== 0) {
+            return sortDirection === "asc" ? diff : -diff;
+          }
+        } else if (a.rank !== b.rank) {
+          return a.rank - b.rank;
+        } else if (a.updatedTimestamp !== b.updatedTimestamp) {
+          return b.updatedTimestamp - a.updatedTimestamp;
+        }
+        return (a.title ?? "").localeCompare(b.title ?? "");
+      });
+
       const totalCount = filtered.length;
       const matches = filtered
         .slice(0, limit)
-        .map((p) => ({
-          docId: p.id,
-          title: p.title,
-          updatedAt: p.updatedDate ? new Date(p.updatedDate).toISOString() : null,
-          url: `${baseUrl}/workspace/${workspaceId}/${p.id}`,
+        .map((entry) => ({
+          docId: entry.docId,
+          title: entry.title,
+          tags: entry.tags,
+          updatedAt: entry.updatedAt,
+          url: entry.url,
         }));
 
-      return text({ query: parsed.query, totalCount, results: matches });
+      return text({
+        query: parsed.query,
+        tag: parsed.tag ?? null,
+        matchMode,
+        sortBy,
+        sortDirection,
+        totalCount,
+        results: matches,
+      });
     } finally {
       socket.disconnect();
     }
@@ -2444,6 +2525,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)."),
         query: z.string().describe("Search query — matched case-insensitively against doc titles."),
         limit: z.number().optional().describe("Max results to return (default: 20)."),
+        matchMode: z.enum(["substring", "prefix", "exact"]).optional().describe("How to match titles (default: substring)."),
+        tag: z.string().optional().describe("Optional tag filter (case-insensitive substring match against resolved tag names)."),
+        sortBy: z.enum(["relevance", "updatedAt"]).optional().describe("Sort by match relevance (default) or by updatedAt."),
+        sortDirection: z.enum(["asc", "desc"]).optional().describe("Sort direction for updatedAt sorting (default: desc)."),
       },
     },
     searchDocsHandler as any

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -293,27 +293,32 @@ echo ""
 echo "=== Running MCP bearer token auth test ==="
 node "$SCRIPT_DIR/test-bearer-auth.mjs"
 
-# --- Step 6: Run MCP OAuth HTTP auth test ---
+# --- Step 6: Run MCP HTTP bearer auth test ---
+echo ""
+echo "=== Running MCP HTTP bearer auth test ==="
+node "$SCRIPT_DIR/test-http-bearer.mjs"
+
+# --- Step 7: Run MCP OAuth HTTP auth test ---
 echo ""
 echo "=== Running MCP OAuth HTTP auth test ==="
 node "$SCRIPT_DIR/test-oauth-http.mjs"
 
-# --- Step 7: Run MCP tag visibility setup test ---
+# --- Step 8: Run MCP tag visibility setup test ---
 echo ""
 echo "=== Running MCP tag visibility setup test ==="
 node "$SCRIPT_DIR/test-tag-visibility.mjs"
 
-# --- Step 8: Run MCP data-view setup test ---
+# --- Step 9: Run MCP data-view setup test ---
 echo ""
 echo "=== Running MCP data-view setup test ==="
 node "$SCRIPT_DIR/test-data-view.mjs"
 
-# --- Step 9: Run MCP doc discovery regression test ---
+# --- Step 10: Run MCP doc discovery regression test ---
 echo ""
 echo "=== Running MCP doc discovery regression test ==="
 node "$SCRIPT_DIR/test-doc-discovery.mjs"
 
-# --- Step 10: Run Playwright verification ---
+# --- Step 11: Run Playwright verification ---
 echo ""
 echo "=== Running Playwright UI verification ==="
 ensure_affine_ui_ready

--- a/tests/test-doc-discovery.mjs
+++ b/tests/test-doc-discovery.mjs
@@ -4,7 +4,7 @@
  *
  * Covers:
  * - list_docs should return titles from workspace metadata when GraphQL omits them
- * - search_docs should find matching docs in a single call
+ * - search_docs should support exact/prefix matching, tag filtering, and updatedAt sorting
  */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -111,6 +111,7 @@ async function main() {
     const listedTitles = listed?.edges?.map(edge => edge?.node?.title) || [];
     expectIncludes(listedTitles, "Workspace Home", "list_docs titles");
 
+    const createdDocs = [];
     for (const title of ["Tasky", "Operations Notes", "Task Tracker"]) {
       const created = await call("create_doc", {
         workspaceId: workspace.id,
@@ -118,13 +119,57 @@ async function main() {
         content: `${title} body`,
       });
       expectTruthy(created?.docId, `create_doc docId for ${title}`);
+      createdDocs.push(created);
     }
+
+    await call("create_tag", { workspaceId: workspace.id, tag: "urgent" });
+    await call("add_tag_to_doc", {
+      workspaceId: workspace.id,
+      docId: createdDocs[2].docId,
+      tag: "urgent",
+    });
 
     const search = await call("search_docs", { workspaceId: workspace.id, query: "Task", limit: 10 });
     expectEqual(search?.totalCount, 2, "search_docs totalCount");
     const searchTitles = search?.results?.map(result => result?.title) || [];
     expectIncludes(searchTitles, "Tasky", "search_docs result titles");
     expectIncludes(searchTitles, "Task Tracker", "search_docs result titles");
+
+    const exactMatch = await call("search_docs", {
+      workspaceId: workspace.id,
+      query: "Tasky",
+      matchMode: "exact",
+      limit: 10,
+    });
+    expectEqual(exactMatch?.totalCount, 1, "search_docs exact totalCount");
+    expectEqual(exactMatch?.results?.[0]?.title, "Tasky", "search_docs exact first result");
+
+    const prefixMatch = await call("search_docs", {
+      workspaceId: workspace.id,
+      query: "Task",
+      matchMode: "prefix",
+      limit: 10,
+    });
+    expectEqual(prefixMatch?.totalCount, 2, "search_docs prefix totalCount");
+
+    const tagFiltered = await call("search_docs", {
+      workspaceId: workspace.id,
+      query: "Task",
+      tag: "urgent",
+      limit: 10,
+    });
+    expectEqual(tagFiltered?.totalCount, 1, "search_docs tag-filter totalCount");
+    expectEqual(tagFiltered?.results?.[0]?.title, "Task Tracker", "search_docs tag-filter result");
+    expectIncludes(tagFiltered?.results?.[0]?.tags || [], "urgent", "search_docs tag-filter tags");
+
+    const sortedByUpdatedAt = await call("search_docs", {
+      workspaceId: workspace.id,
+      query: "Task",
+      sortBy: "updatedAt",
+      sortDirection: "desc",
+      limit: 10,
+    });
+    expectEqual(sortedByUpdatedAt?.results?.[0]?.title, "Task Tracker", "search_docs updatedAt sort");
 
     console.log();
     console.log("=== Document discovery integration test passed ===");

--- a/tests/test-http-bearer.mjs
+++ b/tests/test-http-bearer.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Integration test for HTTP bearer-token protection on /mcp.
+ *
+ * Covers:
+ * - /healthz and /readyz
+ * - 401 for missing/invalid bearer token
+ * - query-string token fallback
+ * - valid static bearer auth over Streamable HTTP
+ */
+import { createServer } from "node:http";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = path.resolve(__dirname, "..");
+const MCP_SERVER_PATH = path.resolve(PROJECT_DIR, "dist", "index.js");
+
+const BASE_URL = process.env.AFFINE_BASE_URL || "http://localhost:3010";
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || "test@affine.local";
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error("AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh");
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || "60000");
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function expectTruthy(value, message) {
+  if (!value) {
+    throw new Error(`${message}: expected truthy value, got ${JSON.stringify(value)}`);
+  }
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+async function findFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForSuccessfulFetch(url, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      await response.body?.cancel();
+    } catch {
+      // ignore until timeout
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function generateAffineApiToken() {
+  const client = new Client({ name: "affine-mcp-http-bearer-token", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [MCP_SERVER_PATH],
+    cwd: PROJECT_DIR,
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: "sync",
+      XDG_CONFIG_HOME: "/tmp/affine-mcp-http-bearer-token-noconfig",
+    },
+    stderr: "pipe",
+  });
+
+  transport.stderr?.on("data", chunk => {
+    process.stderr.write(`[stdio-token] ${chunk}`);
+  });
+
+  await client.connect(transport);
+  try {
+    const tokenResult = await client.callTool(
+      { name: "generate_access_token", arguments: { name: `http-bearer-${Date.now()}` } },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    const parsed = parseContent(tokenResult);
+    expectTruthy(parsed?.token, "generate_access_token token");
+    return parsed.token;
+  } finally {
+    await transport.close();
+  }
+}
+
+async function startBearerHttpServer(affineApiToken, staticToken) {
+  const port = await findFreePort();
+  const publicBaseUrl = `http://127.0.0.1:${port}`;
+  const child = spawn("node", [MCP_SERVER_PATH], {
+    cwd: PROJECT_DIR,
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "http",
+      PORT: String(port),
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_API_TOKEN: affineApiToken,
+      AFFINE_MCP_AUTH_MODE: "bearer",
+      AFFINE_MCP_HTTP_HOST: "127.0.0.1",
+      AFFINE_MCP_HTTP_TOKEN: staticToken,
+      XDG_CONFIG_HOME: "/tmp/affine-mcp-http-bearer-server-noconfig",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", chunk => process.stderr.write(`[http-bearer-server] ${chunk}`));
+  child.stderr.on("data", chunk => process.stderr.write(`[http-bearer-server] ${chunk}`));
+
+  await waitForSuccessfulFetch(`${publicBaseUrl}/healthz`);
+
+  return {
+    child,
+    publicBaseUrl,
+    mcpUrl: `${publicBaseUrl}/mcp`,
+    async close() {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => child.once("exit", resolve));
+    },
+  };
+}
+
+async function main() {
+  console.log("=== HTTP Bearer Integration Test ===");
+  console.log(`AFFiNE Base URL: ${BASE_URL}`);
+  console.log();
+
+  const affineApiToken = await generateAffineApiToken();
+  const staticToken = `http-bearer-${Date.now()}`;
+  const server = await startBearerHttpServer(affineApiToken, staticToken);
+
+  try {
+    const healthz = await fetch(`${server.publicBaseUrl}/healthz`);
+    expectEqual(healthz.status, 200, "healthz status");
+    const readyz = await fetch(`${server.publicBaseUrl}/readyz`);
+    expectEqual(readyz.status, 200, "readyz status");
+
+    const initializeBody = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "http-bearer-test", version: "1.0.0" },
+      },
+    };
+
+    const unauthorized = await fetch(server.mcpUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(initializeBody),
+    });
+    expectEqual(unauthorized.status, 401, "missing bearer token status");
+
+    const invalidToken = await fetch(server.mcpUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong-token",
+      },
+      body: JSON.stringify(initializeBody),
+    });
+    expectEqual(invalidToken.status, 401, "invalid bearer token status");
+
+    const queryTokenResponse = await fetch(`${server.mcpUrl}?token=${encodeURIComponent(staticToken)}`, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+      },
+    });
+    if (queryTokenResponse.status === 401) {
+      throw new Error("query-string token was rejected before reaching the MCP handler");
+    }
+
+    const client = new Client({ name: "http-bearer-client", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(new URL(server.mcpUrl), {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${staticToken}`,
+        },
+      },
+    });
+
+    await client.connect(transport);
+    try {
+      const currentUser = parseContent(await client.callTool({ name: "current_user", arguments: {} }));
+      expectEqual(currentUser?.email, EMAIL, "current_user via http bearer");
+    } finally {
+      await transport.close();
+    }
+
+    console.log();
+    console.log("=== HTTP bearer integration test passed ===");
+  } finally {
+    await server.close();
+  }
+}
+
+main().catch(err => {
+  console.error("FAILED:", err.message);
+  process.exit(1);
+});

--- a/tests/test-oauth-http.mjs
+++ b/tests/test-oauth-http.mjs
@@ -249,6 +249,13 @@ async function main() {
     server = await startOAuthHttpServer(affineApiToken, issuer.issuerBaseUrl);
     issuer.setAudienceBase(server.publicBaseUrl);
 
+    const healthz = await fetch(`${server.publicBaseUrl}/healthz`);
+    expectEqual(healthz.status, 200, "oauth healthz status");
+    const readyz = await fetch(`${server.publicBaseUrl}/readyz`);
+    expectEqual(readyz.status, 200, "oauth readyz status");
+    const readyzPayload = await readyz.json();
+    expectEqual(readyzPayload?.authMode, "oauth", "oauth readyz authMode");
+
     const metadataResponse = await fetch(`${server.publicBaseUrl}/.well-known/oauth-protected-resource`);
     expectEqual(metadataResponse.status, 200, "protected resource metadata status");
     const metadata = await metadataResponse.json();


### PR DESCRIPTION
# TL;DR
Expand HTTP deployment ergonomics by adding direct `/mcp` bearer-auth regression coverage, extracting HTTP auth and diagnostics wiring into dedicated modules, extending `search_docs`, and exposing lightweight health/readiness probes.

# Context
This follows the recent HTTP auth and discovery work and closes a few practical gaps that were still missing:
- no direct regression for static bearer auth on `/mcp`
- HTTP auth wiring still lived inline in `src/sse.ts`
- `search_docs` was still limited to plain substring title matching
- remote deployments had no built-in `/healthz` or `/readyz` endpoints

Validated locally against a live AFFiNE Docker stack with:
- `npm run build`
- `npm test`
- `npm run test:doc-discovery`
- `npm run test:http-bearer`
- `npm run test:oauth-http`

# Changes
- add `src/httpAuth.ts` to encapsulate bearer vs oauth HTTP auth behavior and protected-resource metadata registration
- add `src/httpDiagnostics.ts` to expose `/healthz` and `/readyz`, including issuer/JWKS readiness checks in oauth mode
- extend `search_docs` with `matchMode`, optional `tag` filtering, and `updatedAt` sorting while keeping the metadata-only fast path
- add `tests/test-http-bearer.mjs` for direct `/mcp` bearer protection coverage and extend the existing discovery/oauth tests to cover the new behavior
- update `tests/run-e2e.sh` and README to document and exercise the new HTTP diagnostics and search behavior
