### PR TITLE
feat(cli): improve help, diagnostics, and setup snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ The MCP server will use these credentials automatically.
 ```
 
 Other CLI commands:
+- `affine-mcp --help` / `-h` / `help` — show command help
 - `affine-mcp status` — show current config and test connection
+- `affine-mcp doctor` — run config and connectivity diagnostics
+- `affine-mcp show-config` — print the effective config with secrets redacted
+- `affine-mcp config-path` — print the config file path
+- `affine-mcp snippet <claude|cursor|codex> [--env]` — print ready-to-paste client configuration snippets
 - `affine-mcp logout` — remove stored credentials
 - `affine-mcp --version` / `-v` / `version` — print the installed CLI version and exit
 
@@ -186,6 +191,8 @@ Or with email/password for self-hosted instances (not supported on AFFiNE Cloud 
 Tips
 - Prefer `affine-mcp login` or `AFFINE_API_TOKEN` for zero‑latency startup.
 - If your password contains `!` (zsh history expansion), wrap it in single quotes in shells or use the JSON config above.
+- `affine-mcp doctor` is the fastest way to confirm that your saved config still works.
+- `affine-mcp snippet claude --env` and `affine-mcp snippet codex --env` can generate ready-to-paste client setup from your current config.
 
 ### Codex CLI
 
@@ -427,7 +434,7 @@ npm run pack:check
 - For full tool-surface verification, run `npm run test:comprehensive` (self-bootstraps a local Docker AFFiNE stack).
 - For pre-provisioned environments, use `npm run test:comprehensive:raw`.
 - For full environment verification, run `npm run test:e2e` (Docker + MCP + Playwright).
-- Additional focused runners: `npm run test:db-create`, `npm run test:db-cells`, `npm run test:db-schema`, `npm run test:supporting-tools`, `npm run test:bearer`, `npm run test:http-bearer`, `npm run test:oauth-http`, `npm run test:doc-discovery`, `npm run test:cli-version`, `npm run test:playwright`.
+- Additional focused runners: `npm run test:db-create`, `npm run test:db-cells`, `npm run test:db-schema`, `npm run test:supporting-tools`, `npm run test:bearer`, `npm run test:http-bearer`, `npm run test:oauth-http`, `npm run test:doc-discovery`, `npm run test:cli-version`, `npm run test:cli-commands`, `npm run test:playwright`.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start:http": "MCP_TRANSPORT=http node dist/index.js",
     "test": "npm run test:tool-manifest",
     "test:cli-version": "node tests/test-cli-version.mjs",
+    "test:cli-commands": "node tests/test-cli-commands.mjs",
     "test:tool-manifest": "node scripts/verify-tool-manifest.mjs",
     "test:comprehensive": "bash tests/run-comprehensive.sh",
     "test:comprehensive:raw": "node test-comprehensive.mjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 import { fetch } from "undici";
 import * as fs from "fs";
 import * as readline from "readline";
-import { CONFIG_FILE, loadConfigFile, writeConfigFile, validateBaseUrl, VERSION } from "./config.js";
+
+import { CONFIG_FILE, loadConfig, loadConfigFile, validateBaseUrl, VERSION, writeConfigFile } from "./config.js";
 import { loginWithPassword } from "./auth.js";
 
 const CLI_FETCH_TIMEOUT_MS = 30_000;
@@ -12,6 +13,13 @@ class CliError extends Error {
     this.name = "CliError";
   }
 }
+
+type CliCommandHandler = (args: string[]) => Promise<void> | void;
+type CliCommandDefinition = {
+  summary: string;
+  usage: string;
+  handler: CliCommandHandler;
+};
 
 function ask(prompt: string, hidden = false): Promise<string> {
   if (hidden && process.stdin.isTTY) {
@@ -46,12 +54,12 @@ function readHidden(prompt: string): Promise<string> {
           process.stderr.write("\n");
           resolve(buf.join(""));
           break;
-        case "\u0003": // Ctrl-C
+        case "\u0003":
           cleanup();
           process.stderr.write("\n");
           reject(new CliError("Aborted."));
           break;
-        case "\u007F": // Backspace
+        case "\u007F":
         case "\b":
           buf.pop();
           break;
@@ -73,10 +81,11 @@ async function gql(baseUrl: string, auth: { token?: string; cookie?: string }, q
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
   };
-  if (auth.token) headers["Authorization"] = `Bearer ${auth.token}`;
-  if (auth.cookie) headers["Cookie"] = auth.cookie;
+  if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
+  if (auth.cookie) headers.Cookie = auth.cookie;
   const body: any = { query };
   if (variables) body.variables = variables;
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), CLI_FETCH_TIMEOUT_MS);
   let res;
@@ -88,7 +97,9 @@ async function gql(baseUrl: string, auth: { token?: string; cookie?: string }, q
       signal: controller.signal,
     });
   } catch (err: any) {
-    if (err.name === "AbortError") throw new Error(`Request timed out after ${CLI_FETCH_TIMEOUT_MS / 1000}s`);
+    if (err.name === "AbortError") {
+      throw new Error(`Request timed out after ${CLI_FETCH_TIMEOUT_MS / 1000}s`);
+    }
     throw err;
   } finally {
     clearTimeout(timer);
@@ -97,6 +108,116 @@ async function gql(baseUrl: string, auth: { token?: string; cookie?: string }, q
   const json = await res.json() as any;
   if (json.errors) throw new Error(json.errors.map((e: any) => e.message).join("; "));
   return json.data;
+}
+
+function parseFlag(args: string[], ...flags: string[]): boolean {
+  return args.some((arg) => flags.includes(arg));
+}
+
+function ensureNoUnexpectedArgs(args: string[], command: string): void {
+  if (args.length > 0) {
+    throw new CliError(`Unexpected arguments for '${command}': ${args.join(" ")}`);
+  }
+}
+
+function redactSecret(value: string | undefined): string | null {
+  if (!value) return null;
+  if (value.length <= 8) return "*".repeat(value.length);
+  return `${value.slice(0, 4)}…${value.slice(-4)}`;
+}
+
+function getConfigValueSource(name: string, file: Record<string, string>, fallback?: string): "env" | "config" | "default" | "unset" {
+  if (process.env[name]) return "env";
+  if (file[name]) return "config";
+  if (fallback !== undefined) return "default";
+  return "unset";
+}
+
+function buildEffectiveConfigSummary() {
+  const stored = loadConfigFile();
+  const effective = loadConfig();
+  const authKind = effective.apiToken
+    ? "api-token"
+    : effective.cookie
+      ? "cookie"
+      : effective.email && effective.password
+        ? "email-password"
+        : "none";
+
+  return {
+    configFile: CONFIG_FILE,
+    configFileExists: fs.existsSync(CONFIG_FILE),
+    baseUrl: effective.baseUrl,
+    graphqlPath: effective.graphqlPath,
+    workspaceId: effective.defaultWorkspaceId || null,
+    authMode: effective.authMode,
+    authKind,
+    apiToken: effective.apiToken ? redactSecret(effective.apiToken) : null,
+    cookie: effective.cookie ? "(set)" : null,
+    email: effective.email || null,
+    publicBaseUrl: effective.publicBaseUrl || null,
+    oauthIssuerUrl: effective.oauthIssuerUrl || null,
+    oauthScopes: effective.oauthScopes,
+    sources: {
+      baseUrl: getConfigValueSource("AFFINE_BASE_URL", stored, "http://localhost:3010"),
+      apiToken: getConfigValueSource("AFFINE_API_TOKEN", stored),
+      cookie: getConfigValueSource("AFFINE_COOKIE", stored),
+      email: getConfigValueSource("AFFINE_EMAIL", stored),
+      password: getConfigValueSource("AFFINE_PASSWORD", stored),
+      workspaceId: getConfigValueSource("AFFINE_WORKSPACE_ID", stored),
+      authMode: getConfigValueSource("AFFINE_MCP_AUTH_MODE", stored, "bearer"),
+      publicBaseUrl: getConfigValueSource("AFFINE_MCP_PUBLIC_BASE_URL", stored),
+      oauthIssuerUrl: getConfigValueSource("AFFINE_OAUTH_ISSUER_URL", stored),
+      oauthScopes: getConfigValueSource("AFFINE_OAUTH_SCOPES", stored, "mcp"),
+    },
+  };
+}
+
+async function resolveCliAuth(baseUrl: string): Promise<{ auth: { token?: string; cookie?: string }; authKind: string }> {
+  const effective = loadConfig();
+  if (effective.apiToken) {
+    return { auth: { token: effective.apiToken }, authKind: "api-token" };
+  }
+  if (effective.cookie) {
+    return { auth: { cookie: effective.cookie }, authKind: "cookie" };
+  }
+  if (effective.email && effective.password) {
+    const { cookieHeader } = await loginWithPassword(baseUrl, effective.email, effective.password);
+    return { auth: { cookie: cookieHeader }, authKind: "email-password" };
+  }
+  throw new CliError("No authentication configured. Run 'affine-mcp login' or set AFFINE_API_TOKEN.");
+}
+
+function printHelp(command?: string) {
+  if (command) {
+    const definition = COMMANDS[command];
+    if (!definition) {
+      throw new CliError(`Unknown command '${command}'.`);
+    }
+    console.log(`${definition.usage}\n`);
+    console.log(definition.summary);
+    return;
+  }
+
+  console.log(`affine-mcp ${VERSION}`);
+  console.log("");
+  console.log("Usage:");
+  console.log("  affine-mcp                 Start the MCP server over stdio");
+  console.log("  affine-mcp <command>       Run a CLI command");
+  console.log("");
+  console.log("Commands:");
+  for (const [name, definition] of Object.entries(COMMANDS)) {
+    console.log(`  ${name.padEnd(12)} ${definition.summary}`);
+  }
+  console.log("");
+  console.log("Common examples:");
+  console.log("  affine-mcp login");
+  console.log("  affine-mcp status");
+  console.log("  affine-mcp doctor");
+  console.log("  affine-mcp show-config --json");
+  console.log("  affine-mcp snippet claude --env");
+  console.log("  affine-mcp --version");
+  console.log("  affine-mcp --help");
 }
 
 async function detectWorkspace(baseUrl: string, auth: { token?: string; cookie?: string }): Promise<string> {
@@ -155,7 +276,6 @@ async function loginWithEmail(baseUrl: string): Promise<{ token: string; workspa
     throw new CliError(`Sign-in failed: ${err.message}`);
   }
 
-  // Verify identity
   const auth = { cookie: cookieHeader };
   try {
     const data = await gql(baseUrl, auth, "query { currentUser { name email } }");
@@ -164,20 +284,21 @@ async function loginWithEmail(baseUrl: string): Promise<{ token: string; workspa
     throw new CliError(`Session verification failed: ${err.message}`);
   }
 
-  // Auto-generate an API token so the MCP server can use token auth (no cookie expiry issues)
   console.error("Generating API token...");
   let token: string;
   try {
-    const data = await gql(baseUrl, auth,
+    const data = await gql(
+      baseUrl,
+      auth,
       `mutation($input: GenerateAccessTokenInput!) { generateUserAccessToken(input: $input) { id name token } }`,
-      { input: { name: `affine-mcp-${new Date().toISOString().slice(0, 10)}` } }
+      { input: { name: `affine-mcp-${new Date().toISOString().slice(0, 10)}` } },
     );
     token = data.generateUserAccessToken.token;
     console.error(`✓ Token created (name: ${data.generateUserAccessToken.name})\n`);
   } catch (err: any) {
     throw new CliError(
       `Failed to generate token: ${err.message}\n` +
-      "You can create one manually in Affine Settings → Integrations → MCP Server"
+      "You can create one manually in Affine Settings → Integrations → MCP Server",
     );
   }
 
@@ -208,14 +329,14 @@ async function loginWithToken(baseUrl: string): Promise<{ token: string; workspa
   return { token, workspaceId };
 }
 
-async function login() {
+async function login(_args: string[]) {
   console.error("Affine MCP Server — Login\n");
 
   const existing = loadConfigFile();
   if (existing.AFFINE_API_TOKEN) {
     console.error(`Existing config: ${CONFIG_FILE}`);
     console.error(`  URL:       ${existing.AFFINE_BASE_URL || "(default)"}`);
-    console.error(`  Token:     (set)`);
+    console.error("  Token:     (set)");
     console.error(`  Workspace: ${existing.AFFINE_WORKSPACE_ID || "(none)"}\n`);
     const overwrite = await ask("Overwrite? [y/N] ");
     if (!/^[yY]$/.test(overwrite)) {
@@ -234,13 +355,8 @@ async function login() {
 
   if (isSelfHosted) {
     const method = await ask("\nAuth method — [1] Email/password (recommended)  [2] Paste API token: ");
-    if (method === "2") {
-      result = await loginWithToken(baseUrl);
-    } else {
-      result = await loginWithEmail(baseUrl);
-    }
+    result = method === "2" ? await loginWithToken(baseUrl) : await loginWithEmail(baseUrl);
   } else {
-    // Cloudflare blocks programmatic sign-in on app.affine.pro — token is the only option
     result = await loginWithToken(baseUrl);
   }
 
@@ -254,21 +370,22 @@ async function login() {
   console.error("The MCP server will use these credentials automatically.");
 }
 
-async function status() {
+async function status(args: string[]) {
+  ensureNoUnexpectedArgs(args, "status");
   const config = loadConfigFile();
   if (!config.AFFINE_API_TOKEN) {
     throw new CliError("Not logged in. Run: affine-mcp login");
   }
   console.error(`Config: ${CONFIG_FILE}`);
   console.error(`URL:       ${config.AFFINE_BASE_URL || "(default)"}`);
-  console.error(`Token:     (set)`);
+  console.error("Token:     (set)");
   console.error(`Workspace: ${config.AFFINE_WORKSPACE_ID || "(none)"}\n`);
 
   try {
     const data = await gql(
       config.AFFINE_BASE_URL || "https://app.affine.pro",
       { token: config.AFFINE_API_TOKEN },
-      "query { currentUser { name email } workspaces { id } }"
+      "query { currentUser { name email } workspaces { id } }",
     );
     console.error(`User: ${data.currentUser.name} <${data.currentUser.email}>`);
     console.error(`Workspaces: ${data.workspaces.length}`);
@@ -277,7 +394,8 @@ async function status() {
   }
 }
 
-function logout() {
+function logout(args: string[]) {
+  ensureNoUnexpectedArgs(args, "logout");
   if (fs.existsSync(CONFIG_FILE)) {
     fs.unlinkSync(CONFIG_FILE);
     console.error(`Removed ${CONFIG_FILE}`);
@@ -286,13 +404,256 @@ function logout() {
   }
 }
 
-const COMMANDS: Record<string, () => Promise<void> | void> = { login, status, logout };
+function configPath(args: string[]) {
+  ensureNoUnexpectedArgs(args, "config-path");
+  console.log(CONFIG_FILE);
+}
 
-export async function runCli(command: string): Promise<boolean> {
-  const fn = COMMANDS[command];
-  if (!fn) return false;
+function showConfig(args: string[]) {
+  const asJson = parseFlag(args, "--json");
+  const unexpectedArgs = args.filter((arg) => arg !== "--json");
+  if (unexpectedArgs.length > 0) {
+    throw new CliError(`Unexpected arguments for 'show-config': ${unexpectedArgs.join(" ")}`);
+  }
+
+  const summary = buildEffectiveConfigSummary();
+  if (asJson) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  console.log(`Config file: ${summary.configFile} (${summary.configFileExists ? "found" : "missing"})`);
+  console.log(`Base URL: ${summary.baseUrl} (${summary.sources.baseUrl})`);
+  console.log(`GraphQL path: ${summary.graphqlPath}`);
+  console.log(`Auth mode: ${summary.authMode} (${summary.sources.authMode})`);
+  console.log(`Auth kind: ${summary.authKind}`);
+  console.log(`Workspace: ${summary.workspaceId || "(none)"} (${summary.sources.workspaceId})`);
+  if (summary.apiToken) console.log(`API token: ${summary.apiToken} (${summary.sources.apiToken})`);
+  if (summary.cookie) console.log(`Cookie: ${summary.cookie} (${summary.sources.cookie})`);
+  if (summary.email) console.log(`Email: ${summary.email} (${summary.sources.email})`);
+  if (summary.publicBaseUrl) console.log(`Public base URL: ${summary.publicBaseUrl} (${summary.sources.publicBaseUrl})`);
+  if (summary.oauthIssuerUrl) console.log(`OAuth issuer URL: ${summary.oauthIssuerUrl} (${summary.sources.oauthIssuerUrl})`);
+  if (summary.authMode === "oauth") console.log(`OAuth scopes: ${summary.oauthScopes.join(", ")} (${summary.sources.oauthScopes})`);
+}
+
+async function doctor(args: string[]) {
+  const asJson = parseFlag(args, "--json");
+  const unexpectedArgs = args.filter((arg) => arg !== "--json");
+  if (unexpectedArgs.length > 0) {
+    throw new CliError(`Unexpected arguments for 'doctor': ${unexpectedArgs.join(" ")}`);
+  }
+
+  const summary = buildEffectiveConfigSummary();
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+
+  checks.push({
+    name: "config-file",
+    ok: summary.configFileExists,
+    detail: summary.configFileExists ? summary.configFile : "No saved config file found",
+  });
+
+  let authKind = "none";
   try {
-    await fn();
+    const { auth, authKind: resolvedAuthKind } = await resolveCliAuth(summary.baseUrl);
+    authKind = resolvedAuthKind;
+    checks.push({
+      name: "auth-configured",
+      ok: true,
+      detail: `Using ${resolvedAuthKind}`,
+    });
+
+    const healthController = new AbortController();
+    const healthTimer = setTimeout(() => healthController.abort(), CLI_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(summary.baseUrl, { signal: healthController.signal });
+      checks.push({
+        name: "base-url",
+        ok: response.ok,
+        detail: `HTTP ${response.status}`,
+      });
+    } catch (err: any) {
+      checks.push({
+        name: "base-url",
+        ok: false,
+        detail: err?.message || "Could not reach base URL",
+      });
+    } finally {
+      clearTimeout(healthTimer);
+    }
+
+    try {
+      const data = await gql(
+        summary.baseUrl,
+        auth,
+        "query { currentUser { name email } workspaces { id } }",
+      );
+      checks.push({
+        name: "graphql-auth",
+        ok: true,
+        detail: `${data.currentUser.email} (${data.workspaces.length} workspace(s))`,
+      });
+    } catch (err: any) {
+      checks.push({
+        name: "graphql-auth",
+        ok: false,
+        detail: err?.message || "GraphQL auth failed",
+      });
+    }
+  } catch (err: any) {
+    checks.push({
+      name: "auth-configured",
+      ok: false,
+      detail: err?.message || "No authentication configured",
+    });
+  }
+
+  if (summary.authMode === "oauth") {
+    const oauthReady = Boolean(summary.publicBaseUrl && summary.oauthIssuerUrl && summary.oauthScopes.length > 0);
+    checks.push({
+      name: "oauth-config",
+      ok: oauthReady,
+      detail: oauthReady
+        ? `${summary.publicBaseUrl} -> ${summary.oauthIssuerUrl}`
+        : "OAuth mode requires AFFINE_MCP_PUBLIC_BASE_URL and AFFINE_OAUTH_ISSUER_URL",
+    });
+  }
+
+  const ok = checks.every((check) => check.ok);
+
+  if (asJson) {
+    console.log(JSON.stringify({
+      ok,
+      config: summary,
+      checks,
+      authKind,
+    }, null, 2));
+    if (!ok) process.exit(1);
+    return;
+  }
+
+  console.log(`Doctor: ${ok ? "OK" : "FAILED"}`);
+  console.log(`Base URL: ${summary.baseUrl}`);
+  console.log(`Auth mode: ${summary.authMode}`);
+  for (const check of checks) {
+    console.log(`${check.ok ? "✓" : "✗"} ${check.name}: ${check.detail}`);
+  }
+  if (!ok) {
+    throw new CliError("Doctor checks failed.");
+  }
+}
+
+function getSnippetEnv(): Record<string, string> {
+  const effective = loadConfig();
+  const env: Record<string, string> = {};
+  if (effective.baseUrl) env.AFFINE_BASE_URL = effective.baseUrl;
+  if (effective.apiToken) env.AFFINE_API_TOKEN = effective.apiToken;
+  if (effective.defaultWorkspaceId) env.AFFINE_WORKSPACE_ID = effective.defaultWorkspaceId;
+  if (effective.authMode === "oauth") {
+    env.AFFINE_MCP_AUTH_MODE = "oauth";
+    if (effective.publicBaseUrl) env.AFFINE_MCP_PUBLIC_BASE_URL = effective.publicBaseUrl;
+    if (effective.oauthIssuerUrl) env.AFFINE_OAUTH_ISSUER_URL = effective.oauthIssuerUrl;
+    if (effective.oauthScopes.length > 0) env.AFFINE_OAUTH_SCOPES = effective.oauthScopes.join(" ");
+  }
+  return env;
+}
+
+function snippet(args: string[]) {
+  const target = args[0];
+  if (!target) {
+    throw new CliError("Usage: affine-mcp snippet <claude|cursor|codex> [--env]");
+  }
+  const includeEnv = parseFlag(args, "--env");
+  const unexpectedArgs = args.slice(1).filter((arg) => arg !== "--env");
+  if (unexpectedArgs.length > 0) {
+    throw new CliError(`Unexpected arguments for 'snippet': ${unexpectedArgs.join(" ")}`);
+  }
+
+  const env = includeEnv ? getSnippetEnv() : undefined;
+
+  if (target === "claude" || target === "cursor") {
+    const payload = {
+      mcpServers: {
+        affine: {
+          command: "affine-mcp",
+          ...(env && Object.keys(env).length > 0 ? { env } : {}),
+        },
+      },
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  if (target === "codex") {
+    if (!env || Object.keys(env).length === 0) {
+      console.log("codex mcp add affine -- affine-mcp");
+      return;
+    }
+    const envArgs = Object.entries(env)
+      .map(([key, value]) => `--env ${key}=${JSON.stringify(value)}`)
+      .join(" ");
+    console.log(`codex mcp add affine ${envArgs} -- affine-mcp`);
+    return;
+  }
+
+  throw new CliError(`Unknown snippet target '${target}'. Expected claude, cursor, or codex.`);
+}
+
+function help(args: string[]) {
+  if (args.length > 1) {
+    throw new CliError("Usage: affine-mcp help [command]");
+  }
+  printHelp(args[0]);
+}
+
+const COMMANDS: Record<string, CliCommandDefinition> = {
+  help: {
+    summary: "Show CLI help",
+    usage: "affine-mcp help [command]",
+    handler: help,
+  },
+  login: {
+    summary: "Interactive login and config bootstrap",
+    usage: "affine-mcp login",
+    handler: login,
+  },
+  status: {
+    summary: "Test the saved config and print current user info",
+    usage: "affine-mcp status",
+    handler: status,
+  },
+  logout: {
+    summary: "Remove the saved config file",
+    usage: "affine-mcp logout",
+    handler: logout,
+  },
+  "config-path": {
+    summary: "Print the config file path",
+    usage: "affine-mcp config-path",
+    handler: configPath,
+  },
+  "show-config": {
+    summary: "Print the effective config (redacted)",
+    usage: "affine-mcp show-config [--json]",
+    handler: showConfig,
+  },
+  doctor: {
+    summary: "Run local config and connectivity diagnostics",
+    usage: "affine-mcp doctor [--json]",
+    handler: doctor,
+  },
+  snippet: {
+    summary: "Print ready-to-paste Claude/Cursor/Codex snippets",
+    usage: "affine-mcp snippet <claude|cursor|codex> [--env]",
+    handler: snippet,
+  },
+};
+
+export async function runCli(command: string, args: string[] = []): Promise<boolean> {
+  const normalizedCommand = command.trim().toLowerCase();
+  const definition = COMMANDS[normalizedCommand];
+  if (!definition) return false;
+  try {
+    await definition.handler(args);
   } catch (err: any) {
     if (err instanceof CliError) {
       console.error(`✗ ${err.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,12 +19,23 @@ import { startHttpMcpServer } from "./sse.js";
 
 // CLI commands: affine-mcp login|status|logout|version
 const rawArgs = process.argv.slice(2);
-const subcommand = rawArgs[0] === "--" ? rawArgs[1] : rawArgs[0];
+const cliArgs = rawArgs[0] === "--" ? rawArgs.slice(1) : rawArgs;
+const subcommand = cliArgs[0];
 if (subcommand === "--version" || subcommand === "-v" || subcommand === "version") {
   console.log(VERSION);
   process.exit(0);
 }
-if (subcommand && await runCli(subcommand)) {
+if (subcommand === "--help" || subcommand === "-h") {
+  await runCli("help");
+  process.exit(0);
+}
+if (subcommand) {
+  const handled = await runCli(subcommand, cliArgs.slice(1));
+  if (!handled) {
+    console.error(`Unknown command: ${subcommand}`);
+    await runCli("help");
+    process.exit(1);
+  }
   process.exit(0);
 }
 

--- a/tests/test-cli-commands.mjs
+++ b/tests/test-cli-commands.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const DIST_ENTRY = path.join(ROOT, "dist", "index.js");
+const BIN_ENTRY = path.join(ROOT, "bin", "affine-mcp");
+
+const tempRoot = path.join(os.tmpdir(), `affine-mcp-cli-test-${process.pid}`);
+const xdgConfigHome = path.join(tempRoot, "config-home");
+const configDir = path.join(xdgConfigHome, "affine-mcp");
+const expectedConfigPath = path.join(configDir, "config");
+
+rmSync(tempRoot, { recursive: true, force: true });
+mkdirSync(configDir, { recursive: true });
+writeFileSync(expectedConfigPath, [
+  "AFFINE_BASE_URL=https://example.affine.test",
+  "AFFINE_API_TOKEN=ut_test_token_12345678",
+  "AFFINE_WORKSPACE_ID=workspace-123",
+].join("\n"));
+
+function run(label, args, extraEnv = {}) {
+  const result = spawnSync("node", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      ...extraEnv,
+    },
+  });
+  return { label, ...result };
+}
+
+function expect(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function expectSuccess(result, label = result.label) {
+  expect(result.status === 0, `${label} exited with ${result.status}: ${result.stderr || result.stdout}`);
+}
+
+function expectFailure(result, label = result.label) {
+  expect(result.status !== 0, `${label} unexpectedly succeeded`);
+}
+
+const helpDist = run("dist --help", [DIST_ENTRY, "--help"]);
+expectSuccess(helpDist);
+expect(helpDist.stdout.includes("Usage:"), "dist --help should print usage");
+expect(helpDist.stdout.includes("doctor"), "dist --help should mention doctor");
+
+const helpBin = run("bin -h", [BIN_ENTRY, "-h"]);
+expectSuccess(helpBin);
+expect(helpBin.stdout.includes("snippet"), "bin -h should mention snippet");
+
+const configPath = run("config-path", [DIST_ENTRY, "config-path"]);
+expectSuccess(configPath);
+expect(configPath.stdout.trim() === expectedConfigPath, `config-path mismatch: ${configPath.stdout}`);
+
+const showConfig = run("show-config --json", [DIST_ENTRY, "show-config", "--json"]);
+expectSuccess(showConfig);
+const showConfigJson = JSON.parse(showConfig.stdout);
+expect(showConfigJson.baseUrl === "https://example.affine.test", "show-config baseUrl mismatch");
+expect(showConfigJson.workspaceId === "workspace-123", "show-config workspace mismatch");
+expect(showConfigJson.apiToken.includes("…"), "show-config should redact token");
+
+const claudeSnippet = run("snippet claude --env", [DIST_ENTRY, "snippet", "claude", "--env"]);
+expectSuccess(claudeSnippet);
+const claudeJson = JSON.parse(claudeSnippet.stdout);
+expect(claudeJson.mcpServers.affine.command === "affine-mcp", "claude snippet command mismatch");
+expect(claudeJson.mcpServers.affine.env.AFFINE_BASE_URL === "https://example.affine.test", "claude snippet env missing base URL");
+
+const codexSnippet = run("snippet codex --env", [DIST_ENTRY, "snippet", "codex", "--env"]);
+expectSuccess(codexSnippet);
+expect(codexSnippet.stdout.includes("codex mcp add affine"), "codex snippet should print codex command");
+expect(codexSnippet.stdout.includes("AFFINE_API_TOKEN"), "codex snippet should include env token");
+
+const unknown = run("unknown command", [DIST_ENTRY, "wat"]);
+expectFailure(unknown);
+expect(unknown.stderr.includes("Unknown command"), "unknown command should print error");
+
+const commandHelp = run("help doctor", [DIST_ENTRY, "help", "doctor"]);
+expectSuccess(commandHelp);
+expect(commandHelp.stdout.includes("affine-mcp doctor"), "help doctor should print command usage");
+
+console.log(JSON.stringify({
+  ok: true,
+  cases: [
+    "dist --help",
+    "bin -h",
+    "config-path",
+    "show-config --json",
+    "snippet claude --env",
+    "snippet codex --env",
+    "unknown command",
+    "help doctor",
+  ],
+}, null, 2));


### PR DESCRIPTION
# TL;DR
Improve the `affine-mcp` CLI so it is easier to discover, diagnose, and wire into MCP clients without leaving the terminal.

# Context
The CLI already handled `login`, `status`, `logout`, and version output, but it still had a few usability gaps for day-to-day setup:
- no `-h` / `--help`
- no quick way to inspect the effective config safely
- no terminal-first diagnostics command
- no command to generate ready-to-paste Claude/Cursor/Codex snippets from the current setup
- unknown commands could accidentally fall through into server mode

Validated locally with:
- `npm run build`
- `npm run test:cli-version`
- `npm run test:cli-commands`
- live local AFFiNE verification of `affine-mcp -h`, `show-config --json`, `doctor --json`, and `snippet codex --env`

# Changes
- add `--help` / `-h` / `help` support with command-specific usage output
- add `config-path`, `show-config`, `doctor`, and `snippet` CLI commands
- make unknown commands fail fast instead of dropping into MCP server mode
- document the new CLI commands in the README
- add `tests/test-cli-commands.mjs` for static CLI behavior regression coverage
