### PR TITLE
fix(markdown): render inline formatting as rich text deltas instead of raw syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ tests/playwright/playwright-report.json
 
 # Package artifacts
 *.tgz
+
+# Local dev/debug artifacts
+BUG_BOLD_TEXT.md
+CHANGES_bold_text_fix.md
+bugs/
+tests/create-formatting-demo.mjs

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:yjs-roundtrip": "node tests/test-yjs-roundtrip.mjs",
     "test:formatting-e2e": "node tests/test-formatting-e2e.mjs",
+    "test:create-doc-formatting": "node tests/test-create-doc-formatting.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
     "ci": "npm run build && npm run test:tool-manifest && npm run pack:check",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
+    "test:yjs-roundtrip": "node tests/test-yjs-roundtrip.mjs",
+    "test:formatting-e2e": "node tests/test-formatting-e2e.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
     "ci": "npm run build && npm run test:tool-manifest && npm run pack:check",

--- a/src/markdown/parse.ts
+++ b/src/markdown/parse.ts
@@ -282,35 +282,46 @@ function parseTable(tokens: TokenLike[], start: number, end: number): {
   };
 }
 
-function collectQuoteText(tokens: TokenLike[], start: number, end: number): string {
-  const lines: string[] = [];
+function collectQuoteDeltas(tokens: TokenLike[], start: number, end: number): TextDelta[] {
+  const result: TextDelta[] = [];
   for (let i = start; i < end; i += 1) {
     const token = tokens[i];
     if (token.type === "inline") {
-      const line = deltaToString(renderInline(token.children ?? [])).trim();
-      if (line) {
-        lines.push(line);
+      const lineDeltas = renderInline(token.children ?? []);
+      if (lineDeltas.length > 0) {
+        if (result.length > 0) result.push({ insert: "\n" });
+        result.push(...lineDeltas);
       }
       continue;
     }
-    if (token.type === "fence" || token.type === "code_block") {
-      const language = (token.info ?? "").trim();
-      const codeBody = token.content.replace(/\n$/, "");
-      lines.push(`\`\`\`${language}\n${codeBody}\n\`\`\``);
-      continue;
-    }
   }
-
-  return lines.join("\n");
+  return result;
 }
 
-function parseCalloutAdmonition(text: string): string | null {
+function parseCalloutAdmonitionDeltas(deltas: TextDelta[]): TextDelta[] | null {
+  const text = deltaToString(deltas);
   const lines = text.split("\n");
   const marker = lines[0]?.trim() ?? "";
   if (!/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]$/i.test(marker)) {
     return null;
   }
-  return lines.slice(1).join("\n").trim();
+  const bodyText = lines.slice(1).join("\n").trim();
+  // Re-slice the deltas to remove the marker line
+  const markerLen = lines[0].length + 1; // +1 for \n
+  let skipped = 0;
+  const bodyDeltas: TextDelta[] = [];
+  for (const d of deltas) {
+    if (skipped < markerLen) {
+      const skip = Math.min(d.insert.length, markerLen - skipped);
+      skipped += skip;
+      if (skip < d.insert.length) {
+        bodyDeltas.push({ ...d, insert: d.insert.slice(skip) });
+      }
+    } else {
+      bodyDeltas.push(d);
+    }
+  }
+  return bodyText.length > 0 ? bodyDeltas.filter(d => d.insert.trim() || !d.attributes) : bodyDeltas;
 }
 
 function parseList(
@@ -442,7 +453,8 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
         const level = Math.max(1, Math.min(6, levelNum)) as 1 | 2 | 3 | 4 | 5 | 6;
         const inline = tokens.slice(i + 1, close).find(inner => inner.type === "inline");
         const text = inline ? deltaToString(renderInline(inline.children ?? [])).trim() : "";
-        state.operations.push({ type: "heading", level, text });
+        const headingDeltas = inline ? renderInline(inline.children ?? []) : [];
+        state.operations.push({ type: "heading", level, text, deltas: headingDeltas });
         i = close + 1;
         break;
       }
@@ -487,9 +499,10 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
           break;
         }
 
-        const text = deltaToString(renderInline(children)).trim();
+        const paraDeltas = renderInline(children);
+        const text = deltaToString(paraDeltas).trim();
         if (text.length > 0) {
-          state.operations.push({ type: "paragraph", text });
+          state.operations.push({ type: "paragraph", text, deltas: paraDeltas });
         }
         i = close + 1;
         break;
@@ -517,12 +530,14 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
           i += 1;
           break;
         }
-        const quoteText = collectQuoteText(tokens, i + 1, close).trim();
-        const calloutText = parseCalloutAdmonition(quoteText);
-        if (calloutText !== null) {
-          state.operations.push({ type: "callout", text: calloutText });
+        const quoteDeltas = collectQuoteDeltas(tokens, i + 1, close);
+        const quoteText = deltaToString(quoteDeltas).trim();
+        const calloutDeltas = parseCalloutAdmonitionDeltas(quoteDeltas);
+        if (calloutDeltas !== null) {
+          const calloutText = deltaToString(calloutDeltas).trim();
+          state.operations.push({ type: "callout", text: calloutText, deltas: calloutDeltas });
         } else if (quoteText.length > 0) {
-          state.operations.push({ type: "quote", text: quoteText });
+          state.operations.push({ type: "quote", text: quoteText, deltas: quoteDeltas });
         }
         i = close + 1;
         break;

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -65,27 +65,54 @@ function renderTable(tableData: string[][]): string[] {
   ];
 }
 
-function deltaRunToMarkdown(insert: string, attributes: NonNullable<TextDelta["attributes"]>): string {
-  if (attributes.code) return `\`${insert}\``;
-  let inner = insert;
-  if (attributes.bold && attributes.italic) {
-    inner = `***${inner}***`;
-  } else if (attributes.bold) {
-    inner = `**${inner}**`;
-  } else if (attributes.italic) {
-    inner = `*${inner}*`;
-  }
-  if (attributes.link) {
-    inner = `[${inner.replace(/]/g, "\\]")}](${attributes.link})`;
-  }
-  if (attributes.strike) {
-    inner = `~~${inner}~~`;
-  }
-  return inner;
-}
+export function deltasToMarkdown(deltas: TextDelta[]): string {
+  // Bold and italic markers are streamed across adjacent runs so that shared
+  // formatting is not closed and reopened at every boundary.
+  // e.g. [{bold}, {bold+italic}, {bold}] → "**text *inner* text**"
+  // Code, link, and strike are always self-contained wrappers.
+  let result = "";
+  let boldOpen = false;
+  let italicOpen = false;
 
-function deltasToMarkdown(deltas: TextDelta[]): string {
-  return deltas.map(d => d.attributes ? deltaRunToMarkdown(d.insert, d.attributes) : d.insert).join("");
+  const flushBoldItalic = () => {
+    // Close innermost first
+    if (italicOpen) { result += "*"; italicOpen = false; }
+    if (boldOpen) { result += "**"; boldOpen = false; }
+  };
+
+  for (const d of deltas) {
+    const attrs = d.attributes ?? {};
+    const wantBold = attrs.bold === true;
+    const wantItalic = attrs.italic === true;
+
+    // code, link, and strike interrupt the bold/italic stream
+    if (attrs.code || attrs.link || attrs.strike) {
+      flushBoldItalic();
+      let inner = d.insert;
+      if (attrs.code) {
+        result += `\`${inner}\``;
+        continue;
+      }
+      if (wantBold && wantItalic) { inner = `***${inner}***`; }
+      else if (wantBold) { inner = `**${inner}**`; }
+      else if (wantItalic) { inner = `*${inner}*`; }
+      if (attrs.link) { inner = `[${inner.replace(/]/g, "\\]")}](${attrs.link})`; }
+      if (attrs.strike) { inner = `~~${inner}~~`; }
+      result += inner;
+      continue;
+    }
+
+    // Streaming bold/italic: close innermost-first, open outermost-first
+    if (italicOpen && !wantItalic) { result += "*"; italicOpen = false; }
+    if (boldOpen && !wantBold) { result += "**"; boldOpen = false; }
+    if (wantBold && !boldOpen) { result += "**"; boldOpen = true; }
+    if (wantItalic && !italicOpen) { result += "*"; italicOpen = true; }
+
+    result += d.insert;
+  }
+
+  flushBoldItalic();
+  return result;
 }
 
 function childList(block: MarkdownRenderableBlock): string[] {

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -1,4 +1,4 @@
-import type { MarkdownRenderResult, MarkdownRenderableBlock } from "./types.js";
+import type { MarkdownRenderResult, MarkdownRenderableBlock, TextDelta } from "./types.js";
 
 type RenderState = {
   blocksById: Map<string, MarkdownRenderableBlock>;
@@ -65,6 +65,29 @@ function renderTable(tableData: string[][]): string[] {
   ];
 }
 
+function deltaRunToMarkdown(insert: string, attributes: NonNullable<TextDelta["attributes"]>): string {
+  if (attributes.code) return `\`${insert}\``;
+  let inner = insert;
+  if (attributes.bold && attributes.italic) {
+    inner = `***${inner}***`;
+  } else if (attributes.bold) {
+    inner = `**${inner}**`;
+  } else if (attributes.italic) {
+    inner = `*${inner}*`;
+  }
+  if (attributes.link) {
+    inner = `[${inner.replace(/]/g, "\\]")}](${attributes.link})`;
+  }
+  if (attributes.strike) {
+    inner = `~~${inner}~~`;
+  }
+  return inner;
+}
+
+function deltasToMarkdown(deltas: TextDelta[]): string {
+  return deltas.map(d => d.attributes ? deltaRunToMarkdown(d.insert, d.attributes) : d.insert).join("");
+}
+
 function childList(block: MarkdownRenderableBlock): string[] {
   return Array.isArray(block.childIds) ? block.childIds : [];
 }
@@ -86,7 +109,9 @@ function renderBlock(
     return { lines: [], isList: false };
   }
 
-  const text = (block.text ?? "").trim();
+  const text = (block.deltas && block.deltas.length > 0
+    ? deltasToMarkdown(block.deltas)
+    : (block.text ?? "")).trim();
   const flavour = block.flavour ?? "";
   const type = block.type ?? "";
   const children = childList(block);

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -16,18 +16,22 @@ export type MarkdownOperation =
       type: "heading";
       text: string;
       level: 1 | 2 | 3 | 4 | 5 | 6;
+      deltas?: TextDelta[];
     }
   | {
       type: "paragraph";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "quote";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "callout";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "list";
@@ -81,6 +85,7 @@ export type MarkdownRenderableBlock = {
   sourceId: string | null;
   caption: string | null;
   tableData: string[][] | null;
+  deltas?: TextDelta[];
 };
 
 export type MarkdownRenderResult = {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1338,7 +1338,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
               ? "quote"
               : "text";
         block.set("prop:type", blockType);
-        block.set("prop:text", makeText(content));
+        block.set("prop:text", makeText(normalized.deltas ?? content));
         return { blockId, block, flavour: "affine:paragraph", blockType };
       }
       case "list": {
@@ -1377,7 +1377,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         textBlock.set("sys:parent", null);
         textBlock.set("sys:children", new Y.Array<string>());
         textBlock.set("prop:type", "text");
-        textBlock.set("prop:text", makeText(content));
+        textBlock.set("prop:text", makeText(normalized.deltas ?? content));
         calloutChildren.push([textBlockId]);
         block.set("sys:children", calloutChildren);
         block.set("prop:icon", { type: "emoji", unicode: "💡" });
@@ -1814,6 +1814,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           type: "heading",
           text: operation.text,
           level: operation.level,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1823,6 +1824,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "paragraph",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1832,6 +1834,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "quote",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1841,6 +1844,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "callout",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -194,23 +194,51 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "var(--affine-tag-teal)", "var(--affine-tag-pink)", "var(--affine-tag-gray)",
   ];
 
+  // Null-valued attrs explicitly clear marks in Yjs, preventing them from
+  // bleeding into adjacent plain-text runs via left-neighbour inheritance.
+  const CLEARED_MARKS: Record<string, null> = { bold: null, italic: null, strike: null, code: null, link: null };
+
   function makeText(content: string | TextDelta[]): Y.Text {
     const yText = new Y.Text();
     if (typeof content === "string") {
       if (content.length > 0) {
         yText.insert(0, content);
       }
-      return yText;
-    }
-    let offset = 0;
-    for (const delta of content) {
-      if (!delta.insert) {
-        continue;
+    } else {
+      let offset = 0;
+      for (const delta of content) {
+        if (delta.insert.length > 0) {
+          const attrs: Record<string, unknown> = delta.attributes
+            ? { ...CLEARED_MARKS, ...delta.attributes }
+            : { ...CLEARED_MARKS };
+          yText.insert(offset, delta.insert, attrs);
+          offset += delta.insert.length;
+        }
       }
-      yText.insert(offset, delta.insert, delta.attributes ? { ...delta.attributes } : {});
-      offset += delta.insert.length;
     }
     return yText;
+  }
+
+  function asDeltaArray(value: unknown): TextDelta[] | undefined {
+    if (!(value instanceof Y.Text)) return undefined;
+    const raw = value.toDelta() as Array<{ insert?: unknown; attributes?: Record<string, unknown> }>;
+    if (!raw.length) return undefined;
+    const result: TextDelta[] = [];
+    for (const d of raw) {
+      if (typeof d.insert !== "string") continue;
+      const td: TextDelta = { insert: d.insert };
+      if (d.attributes) {
+        const attrs: NonNullable<TextDelta["attributes"]> = {};
+        if (d.attributes.bold === true) attrs.bold = true;
+        if (d.attributes.italic === true) attrs.italic = true;
+        if (d.attributes.strike === true) attrs.strike = true;
+        if (d.attributes.code === true) attrs.code = true;
+        if (typeof d.attributes.link === "string") attrs.link = d.attributes.link;
+        if (Object.keys(attrs).length > 0) td.attributes = attrs;
+      }
+      result.push(td);
+    }
+    return result.length ? result : undefined;
   }
 
   function asText(value: unknown): string {
@@ -2053,6 +2081,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         flavour: asStringOrNull(block.get("sys:flavour")),
         type: asStringOrNull(block.get("prop:type")),
         text: asText(block.get("prop:text")) || null,
+        deltas: asDeltaArray(block.get("prop:text")),
         checked: typeof block.get("prop:checked") === "boolean" ? Boolean(block.get("prop:checked")) : null,
         language: asStringOrNull(block.get("prop:language")),
         childIds,
@@ -3848,8 +3877,32 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           matchLog.push({ blockId, flavour: flavour ?? "unknown", original, replaced });
           if (!parsed.dryRun) {
             const prevSV = Y.encodeStateVector(doc);
-            val.delete(0, val.length);
-            val.insert(0, replaced);
+            // Snapshot delta runs before modification so we can look up attrs at each match position.
+            const deltaRuns = val.toDelta() as Array<{ insert: string; attributes?: Record<string, unknown> }>;
+            // Collect positions right-to-left so earlier offsets stay valid after each replacement.
+            const positions: number[] = [];
+            let idx = 0;
+            while (true) {
+              const pos = original.indexOf(parsed.search, idx);
+              if (pos === -1) break;
+              positions.push(pos);
+              if (!matchAll) break;
+              idx = pos + parsed.search.length;
+            }
+            for (let i = positions.length - 1; i >= 0; i--) {
+              let cur = 0;
+              let matchAttrs: Record<string, unknown> | undefined;
+              for (const run of deltaRuns) {
+                if (positions[i] < cur + run.insert.length) { matchAttrs = run.attributes; break; }
+                cur += run.insert.length;
+              }
+              val.delete(positions[i], parsed.search.length);
+              if (matchAttrs && Object.keys(matchAttrs).length > 0) {
+                val.insert(positions[i], parsed.replace, matchAttrs);
+              } else {
+                val.insert(positions[i], parsed.replace);
+              }
+            }
             const delta = Y.encodeStateAsUpdate(doc, prevSV);
             await pushDocUpdate(socket, workspaceId, parsed.docId, Buffer.from(delta).toString("base64"));
           }

--- a/tests/debug-bugreport.mjs
+++ b/tests/debug-bugreport.mjs
@@ -1,0 +1,58 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const SERVER_URL = "http://nas.fairleadsoftware.com:3002/mcp";
+const TOKEN = process.env.AFFINE_MCP_HTTP_TOKEN;
+const WORKSPACE_ID = "cebf9206-76b3-4c77-a43f-2e72cb5ad426";
+
+const client = new Client({ name: "debug-bugreport", version: "1.0" });
+const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
+  requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+});
+await client.connect(transport);
+
+const call = async (name, args) => {
+  const r = await client.callTool({ name, arguments: args });
+  return JSON.parse(r?.content?.[0]?.text);
+};
+
+const markdown = "# Markdown Formatting Test 2026-04-03\n\n## Text Styling\n\n**Bold text**\n*Italic text*\n~~Strikethrough text~~\n`Inline code`\n\n## Lists\n\n- Bullet item 1\n- Bullet item 2\n  - Nested bullet\n- Bullet item 3\n\n1. Numbered item 1\n2. Numbered item 2\n3. Numbered item 3\n\n## Code Block\n\n```python\ndef hello():\n    print(\"Hello, Affine!\")\n```\n\n## Tables\n\n| Header 1 | Header 2 | Header 3 |\n|----------|----------|----------|\n| Row 1 Col 1 | Row 1 Col 2 | Row 1 Col 3 |\n| Row 2 Col 1 | Row 2 Col 2 | Row 2 Col 3 |\n\n## Links\n\n[Example.com](https://example.com)\n\n## Blockquote\n\n> This is a blockquote. It can span multiple lines.\n> It's useful for highlighting important text.\n\n## Horizontal Rule\n\n---\n\n## Mixed Formatting\n\n**Bold and *italic* combined**\n*Italic with **bold** inside*";
+
+console.log("Creating doc with bug report markdown...");
+const doc = await call("create_doc_from_markdown", {
+  workspaceId: WORKSPACE_ID,
+  title: "Markdown Formatting Test 2026-04-03",
+  markdown,
+});
+console.log("created:", doc.docId);
+
+const exp = await call("export_doc_markdown", {
+  workspaceId: WORKSPACE_ID,
+  docId: doc.docId,
+});
+
+console.log("\n--- exported markdown ---");
+console.log(exp.markdown);
+console.log("---\n");
+
+const checks = [
+  ["**Bold text**",            /\*\*Bold text\*\*/],
+  ["*Italic text*",            /\*Italic text\*/],
+  ["~~Strikethrough text~~",   /~~Strikethrough text~~/],
+  ["`Inline code`",            /`Inline code`/],
+  ["[Example.com](url)",       /\[Example\.com\]/],
+  ["> blockquote",             /^>/m],
+  ["**Bold and *italic*",      /\*\*Bold and \*italic\*/],
+];
+
+let passed = 0, failed = 0;
+for (const [label, pattern] of checks) {
+  const ok = pattern.test(exp.markdown);
+  console.log(`${ok ? "✓" : "✗"} ${label}`);
+  ok ? passed++ : failed++;
+}
+
+console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+
+await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+await client.close();

--- a/tests/debug-http-endpoint.mjs
+++ b/tests/debug-http-endpoint.mjs
@@ -1,0 +1,60 @@
+/**
+ * Test create_doc_from_markdown formatting against the deployed HTTP server.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const SERVER_URL = process.env.MCP_SERVER_URL || "http://nas.fairleadsoftware.com:3002/mcp";
+const TOKEN = process.env.AFFINE_MCP_HTTP_TOKEN;
+const WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID;
+
+if (!TOKEN || !WORKSPACE_ID) {
+  console.error("Required: AFFINE_MCP_HTTP_TOKEN, AFFINE_WORKSPACE_ID");
+  process.exit(1);
+}
+
+const client = new Client({ name: "debug-http", version: "1.0" });
+const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
+  requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+});
+
+await client.connect(transport);
+
+const call = async (name, args) => {
+  const r = await client.callTool({ name, arguments: args });
+  return JSON.parse(r?.content?.[0]?.text);
+};
+
+const md = `# Formatting Test
+
+**Bold text**
+*Italic text*
+~~Strikethrough text~~
+\`Inline code\`
+
+> A **bold** quote.`;
+
+console.log("Testing against:", SERVER_URL);
+
+const doc = await call("create_doc_from_markdown", {
+  workspaceId: WORKSPACE_ID,
+  title: "http-formatting-test",
+  markdown: md,
+});
+console.log("created:", doc.docId);
+
+const exp = await call("export_doc_markdown", {
+  workspaceId: WORKSPACE_ID,
+  docId: doc.docId,
+});
+console.log("--- exported ---");
+console.log(exp.markdown);
+console.log("---");
+console.log("**Bold**:       ", exp.markdown.includes("**Bold text**"));
+console.log("*Italic*:       ", exp.markdown.includes("*Italic text*"));
+console.log("~~Strike~~:     ", exp.markdown.includes("~~Strikethrough text~~"));
+console.log("`Inline code`:  ", exp.markdown.includes("`Inline code`"));
+console.log("> **bold**:     ", /> .*\*\*bold\*\*/.test(exp.markdown));
+
+await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+await client.close();

--- a/tests/test-create-doc-formatting.mjs
+++ b/tests/test-create-doc-formatting.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Regression test: create_doc_from_markdown must preserve inline formatting.
+ *
+ * Exposes the bug where formatting was silently stripped on write because
+ * operationToAppendInput did not pass deltas through for paragraph/heading/
+ * quote/callout blocks, so makeText() always received a plain string.
+ *
+ * Requires: AFFINE_BASE_URL, AFFINE_EMAIL, AFFINE_PASSWORD, AFFINE_WORKSPACE_ID
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, "..", "dist", "index.js");
+
+const BASE_URL = process.env.AFFINE_BASE_URL;
+const EMAIL = process.env.AFFINE_EMAIL;
+const PASSWORD = process.env.AFFINE_PASSWORD;
+const WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID;
+
+if (!BASE_URL || !EMAIL || !PASSWORD || !WORKSPACE_ID) {
+  console.error("Required: AFFINE_BASE_URL, AFFINE_EMAIL, AFFINE_PASSWORD, AFFINE_WORKSPACE_ID");
+  process.exit(1);
+}
+
+let passed = 0;
+let failed = 0;
+
+function check(condition, label, detail = "") {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ ${label}${detail ? ` — ${detail}` : ""}`);
+    failed++;
+  }
+}
+
+async function main() {
+  const client = new Client({ name: "create-doc-formatting-test", version: "1.0" });
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [MCP_SERVER_PATH],
+    env: {
+      ...process.env,
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: "sync",
+    },
+  });
+
+  await client.connect(transport);
+
+  const call = async (name, args) => {
+    const r = await client.callTool({ name, arguments: args });
+    const text = r?.content?.[0]?.text;
+    if (!text) throw new Error(`No response from ${name}`);
+    try { return JSON.parse(text); } catch { throw new Error(`Bad JSON from ${name}: ${text}`); }
+  };
+
+  const createdDocs = [];
+
+  try {
+    console.log("=== create_doc_from_markdown formatting regression test ===\n");
+
+    // ── Test cases: one per block type ──────────────────────────────────────
+    const cases = [
+      {
+        label: "paragraph bold",
+        markdown: "This is **bold** text.",
+        checks: [
+          [/\*\*bold\*\*/, "**bold** preserved"],
+          [/^(?!.*\*\*bold\*\*.*\*\*bold\*\*)/, "not doubled"],
+        ],
+      },
+      {
+        label: "paragraph italic",
+        markdown: "This is *italic* text.",
+        checks: [[/\*italic\*/, "*italic* preserved"]],
+      },
+      {
+        label: "paragraph bold italic",
+        markdown: "This is ***bold italic*** combined.",
+        checks: [[/\*\*\*bold italic\*\*\*/, "***bold italic*** preserved"]],
+      },
+      {
+        label: "paragraph strikethrough",
+        markdown: "This is ~~strike~~ text.",
+        checks: [[/~~strike~~/, "~~strike~~ preserved"]],
+      },
+      {
+        label: "paragraph plain link",
+        markdown: "See [AFFiNE](https://affine.pro) here.",
+        checks: [[/\[AFFiNE\]\(https:\/\/affine\.pro\)/, "plain link preserved"]],
+      },
+      {
+        label: "paragraph bold link",
+        markdown: "See [**bold**](https://affine.pro) here.",
+        checks: [[/\[\*\*bold\*\*\]\(https:\/\/affine\.pro\)/, "bold link preserved"]],
+      },
+      {
+        label: "paragraph no mark bleeding",
+        markdown: "Hello **bold** and plain after.",
+        checks: [
+          [/\*\*bold\*\*/, "bold present"],
+          [/\*\*bold\*\* and plain after/, "plain text after bold not bolded"],
+        ],
+      },
+      {
+        label: "heading bold",
+        markdown: "## Section with **bold** heading",
+        checks: [[/\*\*bold\*\*/, "bold in heading preserved"]],
+      },
+      {
+        label: "blockquote bold",
+        markdown: "> A **bold** quote.",
+        checks: [[/> .*\*\*bold\*\*/, "bold in quote preserved"]],
+      },
+      {
+        label: "callout bold",
+        markdown: "> [!NOTE]\n> Callout with **bold** text.",
+        checks: [
+          [/> \[!NOTE\]/, "callout marker preserved"],
+          [/> .*\*\*bold\*\*/, "bold in callout preserved"],
+        ],
+      },
+      {
+        label: "mixed formatting",
+        markdown: "Has **bold**, *italic*, and ~~strike~~ together.",
+        checks: [
+          [/\*\*bold\*\*/, "bold preserved in mixed"],
+          [/\*italic\*/, "italic preserved in mixed"],
+          [/~~strike~~/, "strike preserved in mixed"],
+        ],
+      },
+    ];
+
+    for (const { label, markdown, checks } of cases) {
+      console.log(`\n${label}:`);
+      const doc = await call("create_doc_from_markdown", {
+        workspaceId: WORKSPACE_ID,
+        title: `regression-${label}`,
+        markdown,
+      });
+      createdDocs.push(doc.docId);
+
+      const exported = await call("export_doc_markdown", {
+        workspaceId: WORKSPACE_ID,
+        docId: doc.docId,
+      });
+
+      for (const [pattern, checkLabel] of checks) {
+        check(pattern.test(exported.markdown), checkLabel, `got: ${JSON.stringify(exported.markdown)}`);
+      }
+    }
+
+  } finally {
+    console.log("\nCleaning up...");
+    for (const docId of createdDocs) {
+      try { await call("delete_doc", { workspaceId: WORKSPACE_ID, docId }); }
+      catch { /* ignore */ }
+    }
+    await client.close();
+  }
+
+  console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+  else console.log("\n=== All checks passed ===");
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/tests/test-formatting-e2e.mjs
+++ b/tests/test-formatting-e2e.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * E2E test: inline formatting round-trip through live tool flows.
+ *
+ * Reproduces the scenarios called out in PR #97 review:
+ *   create_doc_from_markdown → export_doc_markdown
+ *   create_doc_from_markdown → duplicate_doc → export_doc_markdown
+ *   create_doc_from_markdown → create_doc_from_template → export_doc_markdown
+ *   create_doc_from_markdown → find_and_replace (verify attrs preserved)
+ *
+ * Requires: AFFINE_BASE_URL, AFFINE_EMAIL, AFFINE_PASSWORD, AFFINE_WORKSPACE_ID
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, "..", "dist", "index.js");
+
+const BASE_URL = process.env.AFFINE_BASE_URL;
+const EMAIL = process.env.AFFINE_EMAIL;
+const PASSWORD = process.env.AFFINE_PASSWORD;
+const WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID;
+
+if (!BASE_URL || !EMAIL || !PASSWORD || !WORKSPACE_ID) {
+  console.error("Required: AFFINE_BASE_URL, AFFINE_EMAIL, AFFINE_PASSWORD, AFFINE_WORKSPACE_ID");
+  process.exit(1);
+}
+
+const SOURCE_MARKDOWN = [
+  "# Formatting Round-Trip",
+  "",
+  "Plain paragraph.",
+  "",
+  "This is **bold** text.",
+  "",
+  "This is *italic* text.",
+  "",
+  "This is ***bold italic*** text.",
+  "",
+  "Hello **bold** and plain after.",
+  "",
+  "This is ~~strikethrough~~ text.",
+  "",
+  "See [AFFiNE](https://affine.pro) for more.",
+  "",
+  "See [**bold link**](https://affine.pro) here.",
+  "",
+  "Has **bold**, *italic*, ~~strike~~ together.",
+  "",
+  "> A **bold** quote with *italic* inside.",
+  "",
+  "> [!NOTE]",
+  "> Callout with **bold** and *italic* text.",
+].join("\n");
+
+// Patterns that must be present in a correctly round-tripped export
+const EXPECTED_PATTERNS = [
+  [/\*\*bold\*\* text/, "bold"],
+  [/\*italic\* text/, "italic"],
+  [/\*\*\*bold italic\*\*\*/, "bold italic"],
+  [/\*\*bold\*\* and plain after/, "bold mid-sentence no bleed"],
+  [/~~strikethrough~~/, "strikethrough"],
+  [/\[AFFiNE\]\(https:\/\/affine\.pro\)/, "plain link"],
+  [/\[\*\*bold link\*\*\]\(https:\/\/affine\.pro\)/, "bold link"],
+  [/\*\*bold\*\*, \*italic\*, ~~strike~~/, "mixed formatting"],
+  [/> .*\*\*bold\*\*.*\*italic\*/, "bold quote"],
+  [/> \[!NOTE\]/, "callout"],
+  [/> .*\*\*bold\*\*.*\*italic\*/, "bold callout"],
+];
+
+let passed = 0;
+let failed = 0;
+const createdDocs = [];
+
+function check(condition, label) {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ ${label}`);
+    failed++;
+  }
+}
+
+function checkMarkdown(markdown, label) {
+  console.log(`\n  Checking ${label}:`);
+  for (const [pattern, name] of EXPECTED_PATTERNS) {
+    check(pattern.test(markdown), name);
+  }
+}
+
+async function main() {
+  const client = new Client({ name: "formatting-e2e", version: "1.0" });
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [MCP_SERVER_PATH],
+    env: {
+      ...process.env,
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: "sync",
+    },
+  });
+
+  await client.connect(transport);
+
+  const call = async (name, args) => {
+    const r = await client.callTool({ name, arguments: args });
+    const text = r?.content?.[0]?.text;
+    if (!text) throw new Error(`No response from ${name}`);
+    try { return JSON.parse(text); } catch { throw new Error(`Bad JSON from ${name}: ${text}`); }
+  };
+
+  try {
+    console.log("=== Formatting E2E Round-Trip Test ===\n");
+
+    // ── 1. create_doc_from_markdown → export_doc_markdown ──────────────────
+    console.log("1. create_doc_from_markdown → export_doc_markdown");
+    const created = await call("create_doc_from_markdown", {
+      workspaceId: WORKSPACE_ID,
+      title: "e2e-formatting-source",
+      markdown: SOURCE_MARKDOWN,
+    });
+    check(!!created.docId, `source doc created (${created.docId})`);
+    createdDocs.push(created.docId);
+
+    const exported = await call("export_doc_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: created.docId,
+    });
+    checkMarkdown(exported.markdown, "export_doc_markdown round-trip");
+
+    // ── 2. duplicate_doc → export_doc_markdown ─────────────────────────────
+    console.log("\n2. duplicate_doc → export_doc_markdown");
+    const duped = await call("duplicate_doc", {
+      workspaceId: WORKSPACE_ID,
+      docId: created.docId,
+    });
+    const dupedDocId = duped.newDocId ?? duped.docId;
+    check(!!dupedDocId, `duplicate created (${dupedDocId})`);
+    createdDocs.push(dupedDocId);
+
+    const dupedExport = await call("export_doc_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: dupedDocId,
+    });
+    checkMarkdown(dupedExport.markdown, "duplicate_doc round-trip");
+
+    // ── 3. create_doc_from_template → export_doc_markdown ──────────────────
+    console.log("\n3. create_doc_from_template → export_doc_markdown");
+    const fromTemplate = await call("create_doc_from_template", {
+      workspaceId: WORKSPACE_ID,
+      templateDocId: created.docId,
+      title: "e2e-formatting-from-template",
+    });
+    const templateDocId = fromTemplate.docId;
+    check(!!templateDocId, `template doc created (${templateDocId})`);
+    createdDocs.push(templateDocId);
+
+    const templateExport = await call("export_doc_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: templateDocId,
+    });
+    checkMarkdown(templateExport.markdown, "create_doc_from_template round-trip");
+
+    // ── 4. find_and_replace preserves inline attrs ──────────────────────────
+    console.log("\n4. find_and_replace preserves inline formatting attrs");
+    await call("find_and_replace", {
+      workspaceId: WORKSPACE_ID,
+      docId: created.docId,
+      search: "bold",
+      replace: "strong",
+      matchAll: true,
+    });
+
+    const afterReplace = await call("export_doc_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: created.docId,
+    });
+    check(!afterReplace.markdown.includes("**bold**"), "original 'bold' replaced");
+    check(afterReplace.markdown.includes("**strong**"), "replacement 'strong' is bold");
+    check(afterReplace.markdown.includes("*italic*"), "italic attrs unaffected by replace");
+    check(afterReplace.markdown.includes("~~strikethrough~~"), "strikethrough unaffected by replace");
+
+    // ── Cleanup ─────────────────────────────────────────────────────────────
+    console.log("\nCleaning up test docs...");
+    for (const docId of createdDocs) {
+      try {
+        await call("delete_doc", { workspaceId: WORKSPACE_ID, docId });
+        console.log(`  deleted ${docId}`);
+      } catch {
+        console.log(`  could not delete ${docId} (may be fine)`);
+      }
+    }
+
+  } finally {
+    await client.close();
+  }
+
+  console.log(`\n${passed + failed} checks: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+  else console.log("\n=== All formatting E2E checks passed ===");
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/tests/test-formatting-e2e.mjs
+++ b/tests/test-formatting-e2e.mjs
@@ -167,8 +167,54 @@ async function main() {
     });
     checkMarkdown(templateExport.markdown, "create_doc_from_template round-trip");
 
-    // ── 4. find_and_replace preserves inline attrs ──────────────────────────
-    console.log("\n4. find_and_replace preserves inline formatting attrs");
+    // ── 4. append_markdown preserves inline formatting ─────────────────────
+    console.log("\n4. append_markdown → export_doc_markdown");
+    const appendDoc = await call("create_doc", {
+      workspaceId: WORKSPACE_ID,
+      title: "e2e-append-markdown-test",
+    });
+    check(!!appendDoc.docId, `append test doc created (${appendDoc.docId})`);
+    createdDocs.push(appendDoc.docId);
+
+    const APPEND_MARKDOWN = [
+      "## Appended Section",
+      "",
+      "This is **bold** appended text.",
+      "",
+      "This is *italic* appended text.",
+      "",
+      "This is ***bold italic*** appended.",
+      "",
+      "This is ~~strikethrough~~ appended.",
+      "",
+      "See [appended link](https://affine.pro) here.",
+      "",
+      "See [**bold appended link**](https://affine.pro) here.",
+      "",
+      "> A **bold** appended quote.",
+    ].join("\n");
+
+    await call("append_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: appendDoc.docId,
+      markdown: APPEND_MARKDOWN,
+    });
+
+    const appendExport = await call("export_doc_markdown", {
+      workspaceId: WORKSPACE_ID,
+      docId: appendDoc.docId,
+    });
+    console.log(`\n  Checking append_markdown round-trip:`);
+    check(/\*\*bold\*\* appended text/.test(appendExport.markdown), "bold preserved after append");
+    check(/\*italic\* appended text/.test(appendExport.markdown), "italic preserved after append");
+    check(/\*\*\*bold italic\*\*\* appended/.test(appendExport.markdown), "bold italic preserved after append");
+    check(/~~strikethrough~~ appended/.test(appendExport.markdown), "strikethrough preserved after append");
+    check(/\[appended link\]\(https:\/\/affine\.pro\)/.test(appendExport.markdown), "plain link preserved after append");
+    check(/\[\*\*bold appended link\*\*\]\(https:\/\/affine\.pro\)/.test(appendExport.markdown), "bold link preserved after append");
+    check(/> .*\*\*bold\*\*.*appended quote/.test(appendExport.markdown), "bold quote preserved after append");
+
+    // ── 5. find_and_replace preserves inline attrs ──────────────────────────
+    console.log("\n5. find_and_replace preserves inline formatting attrs");
     await call("find_and_replace", {
       workspaceId: WORKSPACE_ID,
       docId: created.docId,

--- a/tests/test-markdown-roundtrip.mjs
+++ b/tests/test-markdown-roundtrip.mjs
@@ -59,6 +59,7 @@ function testParseAdmonitionAsCallout() {
     {
       type: 'callout',
       text: 'Callout body',
+      deltas: [{ insert: 'Callout body' }],
     },
   ], 'admonition-style blockquotes should import as callout operations');
   assert.equal(parsed.lossy, false, 'callout import should not be lossy');

--- a/tests/test-yjs-roundtrip.mjs
+++ b/tests/test-yjs-roundtrip.mjs
@@ -16,7 +16,7 @@
 
 import * as Y from "yjs";
 import { parseMarkdownToOperations } from "../dist/markdown/parse.js";
-import { renderBlocksToMarkdown } from "../dist/markdown/render.js";
+import { renderBlocksToMarkdown, deltasToMarkdown } from "../dist/markdown/render.js";
 
 let passed = 0;
 let failed = 0;
@@ -223,6 +223,37 @@ console.log("\nTest 5: Quote and callout formatting preserved through Yjs");
   const calloutOp = calloutOps.find(op => op.type === "callout");
   assert(calloutOp !== undefined, "callout operation parsed");
   assert(calloutOp?.deltas?.some(d => d.attributes?.bold), "callout deltas contain bold run");
+}
+
+// ── Test 6: Nested bold+italic — markers must not double up at run boundaries ─
+
+console.log("\nTest 6: Nested bold+italic — markers must not double up at run boundaries");
+{
+  // [bold] [bold+italic] [bold] → "**text *inner* text**"
+  const r1 = deltasToMarkdown([
+    { insert: "Bold and " , attributes: { bold: true } },
+    { insert: "italic"    , attributes: { bold: true, italic: true } },
+    { insert: " combined" , attributes: { bold: true } },
+  ]);
+  assert(r1 === "**Bold and *italic* combined**", `bold-contains-italic: got "${r1}"`);
+  assert(!r1.includes("*****"), "no ***** artifacts");
+
+  // [italic] [bold+italic] [italic] → "*text **inner** text*"
+  const r2 = deltasToMarkdown([
+    { insert: "Italic with ", attributes: { italic: true } },
+    { insert: "bold"        , attributes: { bold: true, italic: true } },
+    { insert: " inside"     , attributes: { italic: true } },
+  ]);
+  assert(r2 === "*Italic with **bold** inside*", `italic-contains-bold: got "${r2}"`);
+  assert(!r2.includes("*****"), "no ***** artifacts");
+
+  // [bold] [plain] [bold] — two separate bold runs must not merge
+  const r3 = deltasToMarkdown([
+    { insert: "first" , attributes: { bold: true } },
+    { insert: " plain " },
+    { insert: "second", attributes: { bold: true } },
+  ]);
+  assert(r3 === "**first** plain **second**", `two separate bold runs: got "${r3}"`);
 }
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/tests/test-yjs-roundtrip.mjs
+++ b/tests/test-yjs-roundtrip.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the full local Yjs formatting round-trip:
+ *
+ *   markdown → parseMarkdownToOperations (TextDelta[])
+ *           → makeText (Y.Text with explicit mark clearing)
+ *           → Y.Text.toDelta() (read back)
+ *           → renderBlocksToMarkdown (markdown)
+ *
+ * No network required. Covers:
+ *   - Mark bleeding fix: bold must not bleed into following plain runs
+ *   - find_and_replace attr preservation: replacing inside a bold run keeps bold
+ *   - Link text escaping: ] in link text is escaped on export
+ *   - Full round-trip fidelity for bold, italic, strike, code, links, quotes, callouts
+ */
+
+import * as Y from "yjs";
+import { parseMarkdownToOperations } from "../dist/markdown/parse.js";
+import { renderBlocksToMarkdown } from "../dist/markdown/render.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  ✓ ${message}`);
+    passed++;
+  } else {
+    console.error(`  ✗ ${message}`);
+    failed++;
+  }
+}
+
+// ── Helpers replicating docs.ts internals ────────────────────────────────────
+
+const CLEARED_MARKS = { bold: null, italic: null, strike: null, code: null, link: null };
+
+function makeText(content) {
+  // Y.Text must be attached to a Y.Doc before any read/write operations.
+  const doc = new Y.Doc();
+  const yText = doc.getText("t");
+  if (typeof content === "string") {
+    if (content.length > 0) yText.insert(0, content);
+  } else {
+    let offset = 0;
+    for (const delta of content) {
+      if (delta.insert.length > 0) {
+        const attrs = delta.attributes
+          ? { ...CLEARED_MARKS, ...delta.attributes }
+          : { ...CLEARED_MARKS };
+        yText.insert(offset, delta.insert, attrs);
+        offset += delta.insert.length;
+      }
+    }
+  }
+  return yText;
+}
+
+function asDeltaArray(yText) {
+  const raw = yText.toDelta();
+  if (!raw.length) return undefined;
+  const result = [];
+  for (const d of raw) {
+    if (typeof d.insert !== "string") continue;
+    const td = { insert: d.insert };
+    if (d.attributes) {
+      const attrs = {};
+      if (d.attributes.bold === true) attrs.bold = true;
+      if (d.attributes.italic === true) attrs.italic = true;
+      if (d.attributes.strike === true) attrs.strike = true;
+      if (d.attributes.code === true) attrs.code = true;
+      if (typeof d.attributes.link === "string") attrs.link = d.attributes.link;
+      if (Object.keys(attrs).length > 0) td.attributes = attrs;
+    }
+    result.push(td);
+  }
+  return result.length ? result : undefined;
+}
+
+// Build a MarkdownRenderableBlock map from a markdown string for renderBlocksToMarkdown
+function buildRenderInput(markdown) {
+  const { operations } = parseMarkdownToOperations(markdown);
+  const blocksById = new Map();
+  const rootBlockIds = [];
+  for (const op of operations) {
+    if (!op.text && !op.deltas) continue;
+    const id = Math.random().toString(36).slice(2);
+    rootBlockIds.push(id);
+    // Write deltas through Yjs and read back
+    const yText = op.deltas ? makeText(op.deltas) : makeText(op.text ?? "");
+    const deltas = asDeltaArray(yText);
+    blocksById.set(id, {
+      id,
+      parentId: null,
+      flavour: op.type === "heading" ? "affine:paragraph" : op.type === "quote" ? "affine:paragraph" : op.type === "callout" ? "affine:callout" : "affine:paragraph",
+      type: op.type === "heading" ? `h${op.level}` : op.type === "quote" ? "quote" : "text",
+      text: yText.toString(),
+      deltas,
+      checked: null,
+      language: null,
+      childIds: [],
+      url: null,
+      sourceId: null,
+      caption: null,
+      tableData: null,
+    });
+  }
+  return { rootBlockIds, blocksById };
+}
+
+// ── Test 1: Mark bleeding ─────────────────────────────────────────────────────
+
+console.log("\nTest 1: Mark bleeding — bold must not bleed into adjacent plain runs");
+{
+  const deltas = [
+    { insert: "Hello " },
+    { insert: "bold", attributes: { bold: true } },
+    { insert: " and plain" },
+  ];
+  const yText = makeText(deltas);
+  const stored = yText.toDelta();
+
+  const boldRun = stored.find(d => d.attributes?.bold === true);
+  const plainAfter = stored.find(d => d.insert === " and plain");
+
+  assert(boldRun?.insert === "bold", "bold run contains only 'bold'");
+  assert(!plainAfter?.attributes?.bold, "plain run after bold has no bold attr");
+  assert(stored.length === 3, "stored as exactly 3 separate runs");
+}
+
+// ── Test 2: find_and_replace attr preservation ────────────────────────────────
+
+console.log("\nTest 2: find_and_replace — replacing inside a bold run preserves bold");
+{
+  const deltas = [
+    { insert: "Hello " },
+    { insert: "bold", attributes: { bold: true } },
+    { insert: " world" },
+  ];
+  const yText = makeText(deltas);
+
+  const original = yText.toString();
+  const search = "bold";
+  const replace = "strong";
+
+  // Replicate find_and_replace logic with attr preservation
+  const deltaRuns = yText.toDelta();
+  const pos = original.indexOf(search);
+  let cur = 0;
+  let matchAttrs;
+  for (const run of deltaRuns) {
+    if (pos < cur + run.insert.length) { matchAttrs = run.attributes; break; }
+    cur += run.insert.length;
+  }
+  yText.delete(pos, search.length);
+  if (matchAttrs && Object.keys(matchAttrs).length > 0) {
+    yText.insert(pos, replace, matchAttrs);
+  } else {
+    yText.insert(pos, replace);
+  }
+
+  const result = yText.toDelta();
+  const replacedRun = result.find(d => d.insert === "strong");
+  assert(replacedRun !== undefined, "replacement text 'strong' exists");
+  assert(replacedRun?.attributes?.bold === true, "replacement run is bold");
+  assert(yText.toString() === "Hello strong world", "text content is correct");
+}
+
+// ── Test 3: Link text ] escaping ──────────────────────────────────────────────
+
+console.log("\nTest 3: Link text ] escaping on export");
+{
+  // Simulate a block where AFFiNE stored a link with ] in the text
+  const deltas = [{ insert: "close]bracket", attributes: { link: "https://example.com" } }];
+  const blocksById = new Map([["id1", {
+    id: "id1", parentId: null, flavour: "affine:paragraph", type: "text",
+    text: "close]bracket", deltas, checked: null, language: null,
+    childIds: [], url: null, sourceId: null, caption: null, tableData: null,
+  }]]);
+  const { markdown } = renderBlocksToMarkdown({ rootBlockIds: ["id1"], blocksById });
+  assert(markdown.includes("\\]"), "exported markdown escapes ] in link text");
+  assert(!markdown.match(/\[close\]bracket\]\([^)]+\)\)/), "no double-close-bracket in output");
+}
+
+// ── Test 4: Full round-trip — all formatting types ───────────────────────────
+
+console.log("\nTest 4: Full round-trip fidelity");
+{
+  const cases = [
+    { label: "bold", md: "This is **bold** text", expect: /\*\*bold\*\*/ },
+    { label: "italic", md: "This is *italic* text", expect: /\*italic\*/ },
+    { label: "bold italic", md: "This is ***bold italic*** text", expect: /\*\*\*bold italic\*\*\*/ },
+    { label: "strikethrough", md: "This is ~~strike~~ text", expect: /~~strike~~/ },
+    { label: "plain link", md: "See [AFFiNE](https://affine.pro) here", expect: /\[AFFiNE\]\(https:\/\/affine\.pro\)/ },
+    { label: "bold link", md: "See [**bold**](https://affine.pro) here", expect: /\[\*\*bold\*\*\]\(https:\/\/affine\.pro\)/ },
+    { label: "bold mid-sentence no bleed", md: "Hello **bold** and plain", expect: /Hello \*\*bold\*\* and plain/ },
+  ];
+
+  for (const { label, md, expect } of cases) {
+    const input = buildRenderInput(md);
+    const { markdown } = renderBlocksToMarkdown(input);
+    assert(expect.test(markdown), `${label}: "${md}" → "${markdown.trim()}"`);
+  }
+}
+
+// ── Test 5: Quote and callout round-trip ──────────────────────────────────────
+
+console.log("\nTest 5: Quote and callout formatting preserved through Yjs");
+{
+  // Parse a bold quote
+  const { operations: quoteOps } = parseMarkdownToOperations("> This is a **bold** quote");
+  const quoteOp = quoteOps.find(op => op.type === "quote");
+  assert(quoteOp !== undefined, "quote operation parsed");
+  assert(quoteOp?.deltas?.some(d => d.attributes?.bold), "quote deltas contain bold run");
+
+  // Write through Yjs and read back
+  const yText = makeText(quoteOp.deltas);
+  const stored = asDeltaArray(yText);
+  assert(stored?.some(d => d.attributes?.bold), "bold survives Yjs write/read for quote");
+
+  // Parse a bold callout
+  const { operations: calloutOps } = parseMarkdownToOperations("> [!NOTE]\n> **bold callout** text");
+  const calloutOp = calloutOps.find(op => op.type === "callout");
+  assert(calloutOp !== undefined, "callout operation parsed");
+  assert(calloutOp?.deltas?.some(d => d.attributes?.bold), "callout deltas contain bold run");
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Inline formatting (bold, italic, strikethrough, inline code, links) was silently dropped when writing to AFFiNE documents and lost on export. This PR fixes the full pipeline — parse → write → read → export — so all formatting round-trips correctly.

### Root causes fixed

- **Mark bleeding**: passing `undefined` attrs to `yText.insert()` caused Yjs to inherit attrs from the left-neighbour run. Fixed by always passing explicit `CLEARED_MARKS` (`{ bold: null, italic: null, ... }`) on every insert, then merging actual attrs on top.
- **Write path**: `operationToAppendInput` was wiring `deltas` for `list` blocks only. Added `deltas` passthrough for `paragraph`, `heading`, `quote`, and `callout`.
- **Write path**: `createBlockFromOperation` was calling `makeText(content)` (plain string) for paragraph/heading/quote/callout. Fixed to use `makeText(normalized.deltas ?? content)`.
- **Export path**: `collectDocForMarkdown` was reading `prop:text` as a plain string. Added `asDeltaArray()` to read `Y.Text.toDelta()` back into `TextDelta[]` and populate `block.deltas` on every block.
- **Export path**: Added `deltasToMarkdown()` / `deltaRunToMarkdown()` to `render.ts` which emits correct markdown syntax per attribute with correct nesting order (bold/italic innermost → link → strikethrough outermost).
- **`find_and_replace`**: old code deleted and re-inserted text without preserving attrs. Fixed by snapshotting delta runs before delete and re-applying attrs on insert.
- **Link text escaping**: `]` in link text now escaped as `\]` to prevent broken markdown.

### What is preserved through the full round-trip

| Syntax | Before | After |
|--------|--------|-------|
| `**bold**` | literal `**bold**` in AFFiNE | **bold** |
| `*italic*` | literal `*italic*` | *italic* |
| `~~strike~~` | literal `~~strike~~` | ~~strike~~ |
| `` `code` `` | literal `` `code` `` | `code` |
| `[text](url)` | literal `[text](url)` | hyperlink |
| `[**bold**](url)` | formatting dropped | bold hyperlink |
| `> **bold**` | bold dropped in quote | **bold** in quote |
| `> [!NOTE]` callout | bold dropped | **bold** in callout |
| export bold doc | formatting stripped | `**bold**` in output |
| `find_and_replace` in bold | bold dropped | bold preserved |
| `append_markdown` | formatting dropped | all attrs preserved |
| `duplicate_doc` | formatting dropped | all attrs preserved |
| `create_doc_from_template` | formatting dropped | all attrs preserved |

## Test plan

- [x] `tests/test-markdown-roundtrip.mjs` — callout parse/render round-trip
- [x] `tests/test-yjs-roundtrip.mjs` — 20 unit tests (no live server):
  - mark bleeding prevention
  - `find_and_replace` attr preservation
  - link `]` escaping
  - full round-trip for bold, italic, bold-italic, strikethrough, plain link, bold link
  - quote and callout delta preservation through Yjs write/read
- [x] `tests/test-formatting-e2e.mjs` — 48 live integration checks across 5 flows:
  - `create_doc_from_markdown` → `export_doc_markdown`
  - `duplicate_doc` → `export_doc_markdown`
  - `create_doc_from_template` → `export_doc_markdown`
  - `append_markdown` → `export_doc_markdown`
  - `find_and_replace` attr preservation
- [x] All tests pass against a live AFFiNE instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)