### PR TITLE
chore(release): prepare v1.12.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+node_modules
+dist
+docker
+tests
+test-comprehensive.mjs
+*.md
+!README.md
+.env*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,6 @@ name: Docker
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
   pull_request:
@@ -44,14 +42,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # branch: latest on main
-            type=raw,value=latest,enable={{is_default_branch}}
-            # semver tags: v1.2.3 → 1.2.3, 1.2, 1
+            # semver tags: v1.2.3 → 1.2.3, 1.2, 1, latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            # short sha for traceability
-            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
           labels: |
             org.opencontainers.image.title=affine-mcp-server
             org.opencontainers.image.description=MCP server for AFFiNE with full read/write support

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Verify tag is on main
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          git fetch origin main --depth=50
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tagged commit is not reachable from origin/main. Refusing to publish."
+            exit 1
+          fi
+
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch: latest on main
+            type=raw,value=latest,enable={{is_default_branch}}
+            # semver tags: v1.2.3 → 1.2.3, 1.2, 1
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # short sha for traceability
+            type=sha,format=short
+          labels: |
+            org.opencontainers.image.title=affine-mcp-server
+            org.opencontainers.image.description=MCP server for AFFiNE with full read/write support
+            org.opencontainers.image.vendor=${{ github.repository_owner }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
   pull_request:
     branches:
-      - main
+      - develop
   workflow_dispatch:
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Fixed
+- `extractTableData` now reads `affine:table` blocks stored with flat dot-notation Y.js keys (`prop:rows.{rowId}.order`, `prop:columns.{colId}.order`, `prop:cells.{rowId}:{colId}.text`) used by self-hosted AFFiNE instances. Previously `block.get("prop:rows")` returned `undefined` for this schema, causing all table exports to show empty tables with `had no readable cell data` warnings.
 
 ## [1.11.2] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No unreleased changes yet.
+
+## [1.12.0] - 2026-04-09
+
+### Added
+- Database rows can now point to linked AFFiNE documents via `linkedDocId` on `add_database_row`, `update_database_cell`, and `update_database_row`. `read_database_cells` now returns `linkedDocId` when present.
+- Release tags now publish multi-arch GHCR images with a committed Docker runtime (`Dockerfile`, `.dockerignore`, `.github/workflows/docker.yml`) and documented container startup instructions.
+
 ### Fixed
-- `extractTableData` now reads `affine:table` blocks stored with flat dot-notation Y.js keys (`prop:rows.{rowId}.order`, `prop:columns.{colId}.order`, `prop:cells.{rowId}:{colId}.text`) used by self-hosted AFFiNE instances. Previously `block.get("prop:rows")` returned `undefined` for this schema, causing all table exports to show empty tables with `had no readable cell data` warnings.
+- Database row read, update, and delete flows now work for rows created from the AFFiNE UI, even when the row is attached through database children instead of `sys:parent`.
+- `extractTableData` now reads `affine:table` blocks stored with flat dot-notation Y.js keys (`prop:rows.{rowId}.order`, `prop:columns.{colId}.order`, `prop:cells.{rowId}:{colId}.text`) used by self-hosted AFFiNE instances. Previously `block.get("prop:rows")` returned `undefined` for this schema, causing table exports to show empty tables with `had no readable cell data` warnings.
+
+### Tests
+- Added live regression coverage for linked database rows in `tests/test-database-linked-doc.mjs`.
+- Added live regression coverage for UI-created database rows in `tests/test-database-ui-rows.mjs`.
+
+### Dependencies
+- Refreshed locked dependencies used by verification flows, including `@modelcontextprotocol/sdk` `1.29.0` and `@playwright/test` `1.59.1`.
 
 ## [1.11.2] - 2026-03-31
 
@@ -359,6 +375,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[1.12.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.12.0
 [1.11.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.11.2
 [1.11.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.11.1
 [1.11.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.11.0
@@ -378,4 +395,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.11.2...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.12.0...HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# ─── Stage 1: build ──────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies first (layer cache)
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build TypeScript
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Prune dev dependencies
+RUN npm prune --omit=dev
+
+# ─── Stage 2: runtime ────────────────────────────────────────────────────────
+FROM node:20-alpine AS runtime
+
+# Non-root user for security
+RUN addgroup -S affine && adduser -S affine -G affine
+
+WORKDIR /app
+
+# Copy only what is needed to run
+COPY --from=builder --chown=affine:affine /app/node_modules ./node_modules
+COPY --from=builder --chown=affine:affine /app/dist ./dist
+COPY --chown=affine:affine bin/ ./bin/
+COPY --chown=affine:affine package.json ./
+COPY --chown=affine:affine tool-manifest.json ./
+
+USER affine
+
+EXPOSE 3000
+
+ENV MCP_TRANSPORT=http \
+    AFFINE_MCP_HTTP_HOST=0.0.0.0 \
+    PORT=3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost:${PORT}/healthz || exit 1
+
+ENTRYPOINT ["node", "bin/affine-mcp"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted or cloud). It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`).
 
-[![Version](https://img.shields.io/badge/version-1.11.2-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-1.12.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -19,7 +19,7 @@ A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted
 - Tools: 76 focused tools with WebSocket-based document editing
 - Status: Active
  
-> New in v1.11.2: Corrected stale deleted-document visibility in `list_docs` after `delete_doc`, completing the `v1.11.1` delete-metadata fix.
+> New in v1.12.0: Added linked documents on database rows, restored MCP CRUD for rows created in the AFFiNE UI, fixed self-hosted table exports, and documented GHCR Docker releases.
 
 ## Features
 
@@ -257,7 +257,7 @@ Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to the 
 
 ```
 ghcr.io/dawncr0w/affine-mcp-server:latest      # latest release
-ghcr.io/dawncr0w/affine-mcp-server:1.11.2      # specific version
+ghcr.io/dawncr0w/affine-mcp-server:1.12.0      # specific version
 ```
 
 Quick start:

--- a/README.md
+++ b/README.md
@@ -253,11 +253,11 @@ If you prefer `npx`:
 
 ### Docker
 
-Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry on every push to `main` and for every release tag:
+Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry on every release tag:
 
 ```
-ghcr.io/schwankner/affine-mcp-server:latest      # latest main
-ghcr.io/schwankner/affine-mcp-server:1.11.2      # specific version
+ghcr.io/dawncr0w/affine-mcp-server:latest      # latest release
+ghcr.io/dawncr0w/affine-mcp-server:1.11.2      # specific version
 ```
 
 Quick start:
@@ -268,7 +268,7 @@ docker run -d \
   -e AFFINE_BASE_URL=https://your-affine-instance.com \
   -e AFFINE_API_TOKEN=ut_your_token \
   -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
-  ghcr.io/schwankner/affine-mcp-server:latest
+  ghcr.io/dawncr0w/affine-mcp-server:latest
 ```
 
 Then add to your MCP client config:

--- a/README.md
+++ b/README.md
@@ -251,6 +251,42 @@ If you prefer `npx`:
 }
 ```
 
+### Docker
+
+Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry on every push to `main` and for every release tag:
+
+```
+ghcr.io/schwankner/affine-mcp-server:latest      # latest main
+ghcr.io/schwankner/affine-mcp-server:1.11.2      # specific version
+```
+
+Quick start:
+
+```bash
+docker run -d \
+  -p 3000:3000 \
+  -e AFFINE_BASE_URL=https://your-affine-instance.com \
+  -e AFFINE_API_TOKEN=ut_your_token \
+  -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
+  ghcr.io/schwankner/affine-mcp-server:latest
+```
+
+Then add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": { "Authorization": "Bearer your-strong-secret" }
+    }
+  }
+}
+```
+
+The container runs as a non-root user and exposes `/healthz` and `/readyz` for liveness/readiness probes.
+
 ### Remote Server
 
 If you want to host the server remotely (e.g., using Render, Railway, Docker, or a VPS) and connect via HTTP MCP (Streamable HTTP on `/mcp`) instead of local `stdio`, run the server in HTTP mode.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,39 @@
 # Release Notes
 
+## Version 1.12.0 (2026-04-09)
+
+### Highlights
+- Added linked-document support on database rows so a row can open an AFFiNE doc in center peek.
+- Restored MCP CRUD compatibility for database rows created directly in the AFFiNE UI.
+- Fixed self-hosted `affine:table` exports that store row, column, and cell data as flat dot-notation Y.js keys.
+- Added GHCR Docker publishing on release tags, guarded so image publication only proceeds when the tagged commit is reachable from `origin/main`.
+
+### What Changed
+- `src/tools/docs.ts`
+  - Added linked-doc row text encoding and decoding for `linkedDocId`.
+  - Relaxed database row ownership checks so MCP accepts rows created through the AFFiNE UI.
+  - Added a flat dot-notation fallback for `affine:table` extraction on self-hosted AFFiNE instances.
+- `tests/test-database-linked-doc.mjs`, `tests/test-database-ui-rows.mjs`, `package.json`
+  - Added live regressions for linked database rows and UI-created database rows.
+  - Added the targeted `npm run test:db-ui-rows` validation entrypoint.
+- `.github/workflows/docker.yml`, `Dockerfile`, `.dockerignore`, `README.md`
+  - Added a multi-arch Docker build and GHCR publish workflow for release tags.
+  - Documented container startup and HTTP MCP client configuration.
+- `package-lock.json`
+  - Refreshed locked verification dependencies for `@modelcontextprotocol/sdk` `1.29.0` and `@playwright/test` `1.59.1`.
+- `package.json`, `package-lock.json`, `tool-manifest.json`, `README.md`, `CHANGELOG.md`, `RELEASE_NOTES.md`
+  - Bumped release metadata to `1.12.0`.
+  - Refreshed release-facing docs for the minor release.
+
+### Validation Evidence
+- Release sanity gate passed:
+  - `npm run ci`
+- Docker-backed end-to-end validation passed:
+  - `npm run test:e2e`
+- Focused live verification passed:
+  - `node tests/test-database-linked-doc.mjs`
+  - `npm run test:db-ui-rows`
+
 ## Version 1.11.2 (2026-03-31)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,13 +533,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1818,13 +1818,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1837,9 +1837,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:e2e": "bash tests/run-e2e.sh",
     "test:db-create": "node tests/test-database-creation.mjs",
     "test:db-cells": "node tests/test-database-cells.mjs",
+    "test:db-ui-rows": "node tests/test-database-ui-rows.mjs",
     "test:db-schema": "node tests/test-database-schema.mjs",
     "test:data-view": "node tests/test-data-view.mjs",
     "test:doc-discovery": "node tests/test-doc-discovery.mjs",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1952,7 +1952,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const columnsValue = block.get("prop:columns");
     const cellsValue = block.get("prop:cells");
 
-    const rowEntries = mapEntries(rowsValue)
+    let rowEntries = mapEntries(rowsValue)
       .map(([rowId, payload]) => ({
         rowId,
         order:
@@ -1962,7 +1962,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }))
       .sort((a, b) => a.order.localeCompare(b.order));
 
-    const columnEntries = mapEntries(columnsValue)
+    let columnEntries = mapEntries(columnsValue)
       .map(([columnId, payload]) => ({
         columnId,
         order:
@@ -1972,19 +1972,58 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       }))
       .sort((a, b) => a.order.localeCompare(b.order));
 
+    let cells = new Map<string, string>();
+
     if (rowEntries.length === 0 || columnEntries.length === 0) {
-      return null;
+      // Fallback: AFFiNE self-hosted stores table props as flat dot-notation keys
+      // directly on the block Y.Map instead of nested Y.Maps:
+      //   prop:rows.{rowId}.order
+      //   prop:columns.{colId}.order
+      //   prop:cells.{rowId}:{colId}.text  (Y.Text)
+      const flatRows = new Map<string, string>(); // rowId -> order
+      const flatColumns = new Map<string, string>(); // colId -> order
+      const flatCells = new Map<string, string>(); // rowId:colId -> text
+
+      block.forEach((value: unknown, key: string) => {
+        const rowMatch = key.match(/^prop:rows\.([^.]+)\.order$/);
+        if (rowMatch) {
+          flatRows.set(rowMatch[1], typeof value === "string" ? value : rowMatch[1]);
+          return;
+        }
+        const colMatch = key.match(/^prop:columns\.([^.]+)\.order$/);
+        if (colMatch) {
+          flatColumns.set(colMatch[1], typeof value === "string" ? value : colMatch[1]);
+          return;
+        }
+        const cellMatch = key.match(/^prop:cells\.([^.]+:[^.]+)\.text$/);
+        if (cellMatch) {
+          flatCells.set(cellMatch[1], richTextValueToString(value));
+        }
+      });
+
+      if (flatRows.size > 0 && flatColumns.size > 0) {
+        rowEntries = Array.from(flatRows.entries())
+          .map(([rowId, order]) => ({ rowId, order }))
+          .sort((a, b) => a.order.localeCompare(b.order));
+        columnEntries = Array.from(flatColumns.entries())
+          .map(([columnId, order]) => ({ columnId, order }))
+          .sort((a, b) => a.order.localeCompare(b.order));
+        cells = flatCells;
+      }
+    } else {
+      for (const [cellKey, payload] of mapEntries(cellsValue)) {
+        if (payload instanceof Y.Map) {
+          cells.set(cellKey, richTextValueToString(payload.get("text")));
+          continue;
+        }
+        if (payload && typeof payload === "object" && "text" in payload) {
+          cells.set(cellKey, richTextValueToString((payload as any).text));
+        }
+      }
     }
 
-    const cells = new Map<string, string>();
-    for (const [cellKey, payload] of mapEntries(cellsValue)) {
-      if (payload instanceof Y.Map) {
-        cells.set(cellKey, richTextValueToString(payload.get("text")));
-        continue;
-      }
-      if (payload && typeof payload === "object" && "text" in payload) {
-        cells.set(cellKey, richTextValueToString((payload as any).text));
-      }
+    if (rowEntries.length === 0 || columnEntries.length === 0) {
+      return null;
     }
 
     const tableData: string[][] = [];

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -213,6 +213,35 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return yText;
   }
 
+  /**
+   * Build a Y.Text containing a LinkedPage reference delta.
+   * This is the mechanism AFFiNE uses to associate a database row with a
+   * linked doc that opens in "center peek" when the row title is clicked.
+   */
+  function makeLinkedDocText(docId: string): Y.Text {
+    const delta = [{ insert: "\u200B", attributes: { reference: { type: "LinkedPage", pageId: docId } } }];
+    // Cast needed: TextDelta.attributes doesn't declare `reference`, but
+    // makeText spreads all attributes at runtime via `{ ...delta.attributes }`.
+    return makeText(delta as TextDelta[]);
+  }
+
+  /**
+   * Extract a linked-doc page ID from a database row block's prop:text,
+   * if it contains a LinkedPage reference delta.  Returns null otherwise.
+   */
+  function readLinkedDocId(rowBlock: Y.Map<any>): string | null {
+    const propText = rowBlock.get("prop:text");
+    if (!(propText instanceof Y.Text)) return null;
+    const delta = propText.toDelta();
+    if (!Array.isArray(delta)) return null;
+    for (const d of delta) {
+      if (d.attributes?.reference?.type === "LinkedPage" && d.attributes.reference.pageId) {
+        return d.attributes.reference.pageId;
+      }
+    }
+    return null;
+  }
+
   function asText(value: unknown): string {
     if (value instanceof Y.Text) return value.toString();
     if (typeof value === "string") return value;
@@ -4783,6 +4812,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     docId: string;
     databaseBlockId: string;
     cells: Record<string, unknown>;
+    linkedDocId?: string;
   }) => {
     const workspaceId = parsed.workspaceId || defaults.workspaceId;
     if (!workspaceId) throw new Error("workspaceId is required");
@@ -4795,8 +4825,12 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       rowBlock.set("sys:parent", parsed.databaseBlockId);
       rowBlock.set("sys:children", new Y.Array<string>());
       rowBlock.set("prop:type", "text");
-      const titleValue = resolveDatabaseTitleValue(parsed.cells, ctx);
-      rowBlock.set("prop:text", makeText(String(titleValue)));
+      if (parsed.linkedDocId) {
+        rowBlock.set("prop:text", makeLinkedDocText(parsed.linkedDocId));
+      } else {
+        const titleValue = resolveDatabaseTitleValue(parsed.cells, ctx);
+        rowBlock.set("prop:text", makeText(String(titleValue)));
+      }
       ctx.blocks.set(rowBlockId, rowBlock);
 
       // Add row block to database's children
@@ -4825,6 +4859,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         rowBlockId,
         databaseBlockId: parsed.databaseBlockId,
         cellCount: Object.keys(parsed.cells).length,
+        linkedDocId: parsed.linkedDocId || null,
       });
     } finally {
       ctx.socket.disconnect();
@@ -4840,6 +4875,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         docId: DocId.describe("Document ID containing the database"),
         databaseBlockId: z.string().min(1).describe("Block ID of the affine:database block"),
         cells: z.record(z.unknown()).describe("Map of column name (or column ID) to cell value. For select columns, pass the display label (option auto-created if new)."),
+        linkedDocId: z.string().optional().describe("Link this row to an existing doc by ID. The row will open the linked doc in center peek when clicked."),
       },
     },
     addDatabaseRowHandler as any
@@ -4947,6 +4983,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         return {
           rowBlockId,
           title,
+          linkedDocId: readLinkedDocId(rowBlock),
           cells,
         };
       });
@@ -5023,6 +5060,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     column: string;
     value: unknown;
     createOption?: boolean;
+    linkedDocId?: string;
   }) => {
     const workspaceId = parsed.workspaceId || defaults.workspaceId;
     if (!workspaceId) throw new Error("workspaceId is required");
@@ -5040,7 +5078,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         writeDatabaseCellValue(rowCells, col, parsed.value, parsed.createOption ?? true);
       }
 
-      if (isTitleAliasKey(parsed.column) || (col && (col.type === "title" || isTitleAliasKey(col.name)))) {
+      if (parsed.linkedDocId) {
+        rowBlock.set("prop:text", makeLinkedDocText(parsed.linkedDocId));
+      } else if (isTitleAliasKey(parsed.column) || (col && (col.type === "title" || isTitleAliasKey(col.name)))) {
         rowBlock.set("prop:text", makeText(String(parsed.value ?? "")));
       }
 
@@ -5070,6 +5110,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         column: z.string().min(1).describe("Column name or ID. Use `title` for the built-in row title."),
         value: z.unknown().describe("New cell value"),
         createOption: z.boolean().optional().describe("For select and multi-select columns, create the option label if it does not exist (default true)"),
+        linkedDocId: z.string().optional().describe("Link this row to an existing doc by ID. Replaces any existing title with a linked doc reference."),
       },
     },
     updateDatabaseCellHandler as any
@@ -5082,6 +5123,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     rowBlockId: string;
     cells: Record<string, unknown>;
     createOption?: boolean;
+    linkedDocId?: string;
   }) => {
     const workspaceId = parsed.workspaceId || defaults.workspaceId;
     if (!workspaceId) throw new Error("workspaceId is required");
@@ -5107,7 +5149,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         }
       }
 
-      if (titleValue !== null) {
+      if (parsed.linkedDocId) {
+        rowBlock.set("prop:text", makeLinkedDocText(parsed.linkedDocId));
+      } else if (titleValue !== null) {
         rowBlock.set("prop:text", makeText(titleValue));
       }
 
@@ -5135,6 +5179,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         rowBlockId: z.string().min(1).describe("Row paragraph block ID"),
         cells: z.record(z.unknown()).describe("Map of column name (or column ID) to new cell value. Use `title` for the built-in row title."),
         createOption: z.boolean().optional().describe("For select and multi-select columns, create the option label if it does not exist (default true)"),
+        linkedDocId: z.string().optional().describe("Link this row to an existing doc by ID. The row will open the linked doc in center peek when clicked."),
       },
     },
     updateDatabaseRowHandler as any

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -4532,6 +4532,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
 
   function getDatabaseRowBlock(
     blocks: Y.Map<any>,
+    dbBlock: Y.Map<any>,
     databaseBlockId: string,
     rowBlockId: string,
   ): Y.Map<any> {
@@ -4539,7 +4540,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     if (!rowBlock) {
       throw new Error(`Row block '${rowBlockId}' not found`);
     }
-    if (rowBlock.get("sys:parent") !== databaseBlockId) {
+    const parentId = rowBlock.get("sys:parent");
+    const isDatabaseChild = getDatabaseRowIds(dbBlock).includes(rowBlockId);
+    if (parentId !== databaseBlockId && !isDatabaseChild) {
       throw new Error(`Row block '${rowBlockId}' does not belong to database '${databaseBlockId}'`);
     }
     if (rowBlock.get("sys:flavour") !== "affine:paragraph") {
@@ -4855,7 +4858,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     if (!workspaceId) throw new Error("workspaceId is required");
     const ctx = await loadDatabaseDocContext(workspaceId, parsed.docId, parsed.databaseBlockId);
     try {
-      const rowBlock = getDatabaseRowBlock(ctx.blocks, parsed.databaseBlockId, parsed.rowBlockId);
+      const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, parsed.rowBlockId);
       const descendantBlockIds = collectDescendantBlockIds(ctx.blocks, [parsed.rowBlockId, ...childIdsFrom(rowBlock.get("sys:children"))]);
       const dbChildren = ensureChildrenArray(ctx.dbBlock);
       const rowIndex = indexOfChild(dbChildren, parsed.rowBlockId);
@@ -4923,7 +4926,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const requestedColumnIds = new Set(requestedColumns.map(col => col.id));
 
       const rows = requestedRows.map(rowBlockId => {
-        const rowBlock = getDatabaseRowBlock(ctx.blocks, parsed.databaseBlockId, rowBlockId);
+        const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, rowBlockId);
         const title = readDatabaseRowTitle(rowBlock) || null;
         const rowCells = ctx.cellsMap.get(rowBlockId);
         const cells: Record<string, Record<string, unknown>> = {};
@@ -5028,7 +5031,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     if (!workspaceId) throw new Error("workspaceId is required");
     const ctx = await loadDatabaseDocContext(workspaceId, parsed.docId, parsed.databaseBlockId);
     try {
-      const rowBlock = getDatabaseRowBlock(ctx.blocks, parsed.databaseBlockId, parsed.rowBlockId);
+      const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, parsed.rowBlockId);
       const rowCells = ensureDatabaseRowCells(ctx.cellsMap, parsed.rowBlockId);
       const col = findDatabaseColumn(parsed.column, ctx);
 
@@ -5087,7 +5090,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     if (!workspaceId) throw new Error("workspaceId is required");
     const ctx = await loadDatabaseDocContext(workspaceId, parsed.docId, parsed.databaseBlockId);
     try {
-      const rowBlock = getDatabaseRowBlock(ctx.blocks, parsed.databaseBlockId, parsed.rowBlockId);
+      const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, parsed.rowBlockId);
       const rowCells = ensureDatabaseRowCells(ctx.cellsMap, parsed.rowBlockId);
       let titleValue: string | null = null;
 

--- a/tests/test-database-linked-doc.mjs
+++ b/tests/test-database-linked-doc.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * Integration test for database row linked-doc support.
+ *
+ * Covers:
+ * - `add_database_row` with `linkedDocId` creates a linked-doc reference
+ * - `add_database_row` without `linkedDocId` leaves linkedDocId null (backward compat)
+ * - `read_database_cells` returns linkedDocId for linked rows
+ * - `update_database_cell` can set linkedDocId on an existing row
+ * - `update_database_row` can set linkedDocId on an existing row
+ * - Overwriting the title with plain text clears the linked-doc reference
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
+
+const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+function assertResult(toolName, result) {
+  if (result?.isError) {
+    throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || 'unknown'}`);
+  }
+  const parsed = parseContent(result);
+  if (parsed && typeof parsed === 'object' && parsed.error) {
+    throw new Error(`${toolName} failed: ${parsed.error}`);
+  }
+  return parsed;
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+async function main() {
+  console.log('=== Database Linked-Doc Integration Test ===');
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Server: ${MCP_SERVER_PATH}`);
+  console.log();
+
+  const client = new Client({ name: 'affine-mcp-linked-doc-test', version: '1.0.0' });
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, '..'),
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: 'sync',
+      // Isolate from local config file (~/.config/affine-mcp/config) which may
+      // contain an API token — we want pure email/password auth for this test.
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+    },
+    stderr: 'pipe',
+  });
+
+  transport.stderr?.on('data', chunk => {
+    process.stderr.write(`[mcp-server] ${chunk}`);
+  });
+
+  const settle = (ms = 800) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function call(toolName, args = {}) {
+    console.log(`  -> ${toolName}(${JSON.stringify(args).slice(0, 200)})`);
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    const parsed = assertResult(toolName, result);
+    console.log('     OK');
+    return parsed;
+  }
+
+  let workspaceId;
+  let hostDocId;
+  let dbBlockId;
+  let targetDocId;
+
+  try {
+    await client.connect(transport);
+    console.log('MCP client connected.\n');
+
+    // --- Setup: get workspace ---
+    console.log('[Setup] Finding workspace...');
+    const workspaces = await call('list_workspaces');
+    workspaceId = workspaces[0]?.id;
+    if (!workspaceId) throw new Error('No workspace available');
+    console.log(`  Workspace: ${workspaceId}\n`);
+
+    // --- Setup: create host doc with a database ---
+    console.log('[Setup] Creating host doc with database...');
+    const hostDoc = await call('create_doc', { workspaceId, title: 'LinkedDoc Test Host' });
+    hostDocId = hostDoc.docId;
+    await settle();
+
+    const dbBlock = await call('append_block', {
+      workspaceId,
+      docId: hostDocId,
+      type: 'database',
+      text: 'Test DB',
+      viewMode: 'table',
+    });
+    dbBlockId = dbBlock.blockId;
+
+    await call('add_database_column', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      name: 'Status', type: 'select', options: ['Active', 'Archived'],
+    });
+    await settle();
+
+    // --- Setup: create a target doc to link ---
+    console.log('[Setup] Creating target doc...');
+    const targetDoc = await call('create_doc', {
+      workspaceId,
+      title: 'Target Tool Doc',
+      content: 'This doc should be linked to a database row.',
+    });
+    targetDocId = targetDoc.docId;
+    await settle();
+    console.log(`  Target doc: ${targetDocId}\n`);
+
+    // ====================================================================
+    // TEST 1: add_database_row WITH linkedDocId
+    // ====================================================================
+    console.log('[Test 1] add_database_row with linkedDocId...');
+    const row1 = await call('add_database_row', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      cells: { Status: 'Active' },
+      linkedDocId: targetDocId,
+    });
+    expectEqual(row1.added, true, 'Row should be added');
+    expectEqual(row1.linkedDocId, targetDocId, 'Response should contain linkedDocId');
+    await settle();
+
+    // Verify via read_database_cells
+    const cells1 = await call('read_database_cells', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+    });
+    const linkedRow = cells1.rows.find(r => r.rowBlockId === row1.rowBlockId);
+    if (!linkedRow) throw new Error('Linked row not found in read_database_cells');
+    expectEqual(linkedRow.linkedDocId, targetDocId, 'read_database_cells should return linkedDocId');
+    console.log('  PASS: linked row has correct linkedDocId\n');
+
+    // ====================================================================
+    // TEST 2: add_database_row WITHOUT linkedDocId (backward compat)
+    // ====================================================================
+    console.log('[Test 2] add_database_row without linkedDocId (backward compat)...');
+    const row2 = await call('add_database_row', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      cells: { title: 'Plain Row', Status: 'Archived' },
+    });
+    expectEqual(row2.added, true, 'Plain row should be added');
+    expectEqual(row2.linkedDocId, null, 'Response should have null linkedDocId');
+    await settle();
+
+    const cells2 = await call('read_database_cells', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+    });
+    const plainRow = cells2.rows.find(r => r.rowBlockId === row2.rowBlockId);
+    if (!plainRow) throw new Error('Plain row not found');
+    expectEqual(plainRow.linkedDocId, null, 'Plain row should have null linkedDocId');
+    expectEqual(plainRow.title, 'Plain Row', 'Plain row title should be preserved');
+    console.log('  PASS: plain row has null linkedDocId, title preserved\n');
+
+    // ====================================================================
+    // TEST 3: update_database_cell to SET linkedDocId on a plain row
+    // ====================================================================
+    console.log('[Test 3] update_database_cell setting linkedDocId...');
+    await call('update_database_cell', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      rowBlockId: row2.rowBlockId,
+      column: 'Status',
+      value: 'Active',
+      linkedDocId: targetDocId,
+    });
+    await settle();
+
+    const cells3 = await call('read_database_cells', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+    });
+    const updatedRow = cells3.rows.find(r => r.rowBlockId === row2.rowBlockId);
+    expectEqual(updatedRow.linkedDocId, targetDocId, 'Row should now have linkedDocId after update_database_cell');
+    console.log('  PASS: update_database_cell set linkedDocId\n');
+
+    // ====================================================================
+    // TEST 4: update_database_row with linkedDocId
+    // ====================================================================
+    console.log('[Test 4] update_database_row with linkedDocId...');
+    // First create another plain row
+    const row3 = await call('add_database_row', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      cells: { title: 'Another Row', Status: 'Archived' },
+    });
+    await settle();
+
+    await call('update_database_row', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      rowBlockId: row3.rowBlockId,
+      cells: { Status: 'Active' },
+      linkedDocId: targetDocId,
+    });
+    await settle();
+
+    const cells4 = await call('read_database_cells', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+    });
+    const batchUpdated = cells4.rows.find(r => r.rowBlockId === row3.rowBlockId);
+    expectEqual(batchUpdated.linkedDocId, targetDocId, 'Row should have linkedDocId after update_database_row');
+    console.log('  PASS: update_database_row set linkedDocId\n');
+
+    // ====================================================================
+    // TEST 5: Overwriting title with plain text clears linkedDocId
+    // ====================================================================
+    console.log('[Test 5] Clearing linkedDocId by setting plain title...');
+    await call('update_database_cell', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+      rowBlockId: row3.rowBlockId,
+      column: 'title',
+      value: 'Now Plain',
+    });
+    await settle();
+
+    const cells5 = await call('read_database_cells', {
+      workspaceId, docId: hostDocId, databaseBlockId: dbBlockId,
+    });
+    const clearedRow = cells5.rows.find(r => r.rowBlockId === row3.rowBlockId);
+    expectEqual(clearedRow.linkedDocId, null, 'linkedDocId should be null after plain title update');
+    expectEqual(clearedRow.title, 'Now Plain', 'Title should be the new plain text');
+    console.log('  PASS: plain title update cleared linkedDocId\n');
+
+    // ====================================================================
+    console.log('=== ALL TESTS PASSED ===');
+  } catch (err) {
+    console.error('\n=== TEST FAILED ===');
+    console.error(err.message);
+    process.exitCode = 1;
+  } finally {
+    // Cleanup
+    try {
+      if (hostDocId) await call('delete_doc', { workspaceId, docId: hostDocId }).catch(() => {});
+      if (targetDocId) await call('delete_doc', { workspaceId, docId: targetDocId }).catch(() => {});
+    } catch { /* best effort */ }
+    await client.close();
+  }
+}
+
+main();

--- a/tests/test-database-linked-doc.mjs
+++ b/tests/test-database-linked-doc.mjs
@@ -102,6 +102,10 @@ async function main() {
     console.log('[Setup] Finding workspace...');
     const workspaces = await call('list_workspaces');
     workspaceId = workspaces[0]?.id;
+    if (!workspaceId) {
+      const workspace = await call('create_workspace', { name: `linked-doc-test-${Date.now()}` });
+      workspaceId = workspace?.id;
+    }
     if (!workspaceId) throw new Error('No workspace available');
     console.log(`  Workspace: ${workspaceId}\n`);
 

--- a/tests/test-database-ui-rows.mjs
+++ b/tests/test-database-ui-rows.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Live regression test for UI-created database rows.
+ *
+ * Covers:
+ * - creating a database via MCP
+ * - creating a row from the AFFiNE UI
+ * - reading, updating, and deleting that row via MCP
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from 'playwright';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
+
+const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertResult(toolName, result) {
+  if (result?.isError) {
+    throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || 'unknown'}`);
+  }
+  const parsed = parseContent(result);
+  if (parsed && typeof parsed === 'object' && parsed.error) {
+    throw new Error(`${toolName} failed: ${parsed.error}`);
+  }
+  return parsed;
+}
+
+function expectEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectTruthy(value, message) {
+  if (!value) {
+    throw new Error(`${message}: expected truthy value, got ${JSON.stringify(value)}`);
+  }
+}
+
+async function main() {
+  console.log('=== Database UI Row Regression Test ===');
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Server: ${MCP_SERVER_PATH}`);
+  console.log();
+
+  const client = new Client({ name: 'affine-mcp-db-ui-row-test', version: '1.0.0' });
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, '..'),
+    env: {
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: 'sync',
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+    },
+    stderr: 'pipe',
+  });
+
+  transport.stderr?.on('data', chunk => {
+    process.stderr.write(`[mcp-server] ${chunk}`);
+  });
+
+  const settle = (ms = 1000) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function call(toolName, args = {}) {
+    console.log(`  -> ${toolName}(${JSON.stringify(args).slice(0, 200)})`);
+    const result = await client.callTool(
+      { name: toolName, arguments: args },
+      undefined,
+      { timeout: TOOL_TIMEOUT_MS },
+    );
+    const parsed = assertResult(toolName, result);
+    console.log('     OK');
+    return parsed;
+  }
+
+  let browser;
+  try {
+    await client.connect(transport);
+    console.log('MCP client connected.\n');
+
+    const workspace = await call('create_workspace', { name: `db-ui-rows-${Date.now()}` });
+    const workspaceId = workspace?.id;
+    expectTruthy(workspaceId, 'create_workspace did not return workspace id');
+
+    const doc = await call('create_doc', {
+      workspaceId,
+      title: 'Database UI Row Regression',
+      content: '',
+    });
+    const docId = doc?.docId;
+    expectTruthy(docId, 'create_doc did not return docId');
+
+    const database = await call('append_block', {
+      workspaceId,
+      docId,
+      type: 'database',
+    });
+    const databaseBlockId = database?.blockId;
+    expectTruthy(databaseBlockId, 'append_block(database) did not return blockId');
+    await settle();
+
+    await call('add_database_column', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      name: 'Title',
+      type: 'rich-text',
+    });
+    await settle(1500);
+
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+
+    await page.goto(`${BASE_URL}/sign-in`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]').first().fill(EMAIL);
+    await page.locator('button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]').first().click();
+    await page.locator('input[type="password"], input[name="password"]').first().fill(PASSWORD);
+    await page.locator('button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]').first().click();
+    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+
+    await page.goto(`${BASE_URL}/workspace/${workspaceId}/${docId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(5000);
+
+    const dismiss = page.getByRole('button', { name: 'Dismiss' });
+    if (await dismiss.count()) {
+      await dismiss.first().click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.getByRole('button', { name: 'New Record' }).click();
+    await page.waitForTimeout(1000);
+    await page.keyboard.type('UI row');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(2000);
+    await browser.close();
+    browser = null;
+
+    const readDoc = await call('read_doc', { workspaceId, docId });
+    const databaseBlock = readDoc?.blocks?.find(block => block.id === databaseBlockId);
+    const rowBlockId = databaseBlock?.childIds?.[0];
+    expectTruthy(rowBlockId, 'UI-created rowBlockId not found in database childIds');
+
+    const initialRead = await call('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockIds: [rowBlockId],
+    });
+    expectEqual(initialRead.rows.length, 1, 'read_database_cells UI row count');
+    expectEqual(initialRead.rows[0].title, 'UI row', 'UI-created row title');
+
+    const update = await call('update_database_cell', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockId,
+      column: 'title',
+      value: 'UI row updated',
+    });
+    expectEqual(update.updated, true, 'update_database_cell updated flag');
+
+    const updatedRead = await call('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockIds: [rowBlockId],
+    });
+    expectEqual(updatedRead.rows[0].title, 'UI row updated', 'updated UI-created row title');
+
+    const deletion = await call('delete_database_row', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+      rowBlockId,
+    });
+    expectEqual(deletion.deleted, true, 'delete_database_row deleted flag');
+
+    const afterDelete = await call('read_database_cells', {
+      workspaceId,
+      docId,
+      databaseBlockId,
+    });
+    expectEqual(afterDelete.rows.length, 0, 'row count after deleting UI-created row');
+
+    console.log('\n=== Database UI Row Regression Test Passed ===');
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    await transport.close();
+  }
+}
+
+main().catch(error => {
+  console.error(`FAILED: ${error.message}`);
+  process.exit(1);
+});

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.2",
+  "version": "1.12.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
# TL;DR
Prepare `v1.12.0` to ship linked database rows, UI-created database row CRUD compatibility, self-hosted table export fixes, and the new GHCR Docker release flow.

# Context
`develop` has moved beyond `v1.11.2` with a real minor release surface: database rows can now carry linked AFFiNE documents, MCP can manage rows created directly in the AFFiNE UI, self-hosted `affine:table` exports handle flat dot-notation Y.js keys, and release tags now publish Docker images to GHCR. This release branch packages those changes with synced release metadata and a fresh-stack linked-doc regression fix so the release validation is reproducible.

# Changes
- bump release metadata from `1.11.2` to `1.12.0` in `package.json`, `package-lock.json`, and `tool-manifest.json`
- refresh `README.md`, `CHANGELOG.md`, and `RELEASE_NOTES.md` for the `v1.12.0` minor release
- harden `tests/test-database-linked-doc.mjs` so it creates a workspace on fresh self-hosted stacks before running linked-row validation
- validation:
  - `npm run ci`
  - `npm run test:e2e`
  - `node tests/test-database-linked-doc.mjs`
  - `npm run test:db-ui-rows`
