### PR TITLE
fix: preserve rich text marks in paragraphs, headings, quotes, and callouts

### DIFF
--- a/src/markdown/parse.ts
+++ b/src/markdown/parse.ts
@@ -83,6 +83,31 @@ function deltaToString(deltas: TextDelta[]): string {
   return deltas.map(delta => delta.insert).join("");
 }
 
+/**
+ * Strip deltas corresponding to the first line (up to and including the first
+ * "\n" separator).  Used by callout parsing to remove the `[!NOTE]` marker
+ * line from the collected blockquote deltas.
+ */
+function stripFirstDeltaLine(deltas: TextDelta[]): TextDelta[] {
+  const result: TextDelta[] = [];
+  let pastNewline = false;
+  for (const delta of deltas) {
+    if (pastNewline) {
+      result.push(delta);
+      continue;
+    }
+    const nlIndex = delta.insert.indexOf("\n");
+    if (nlIndex >= 0) {
+      pastNewline = true;
+      const remainder = delta.insert.slice(nlIndex + 1);
+      if (remainder.length > 0) {
+        result.push({ ...delta, insert: remainder });
+      }
+    }
+  }
+  return result;
+}
+
 function renderInline(children: TokenLike[]): TextDelta[] {
   function applyAttrs(deltas: TextDelta[], attrs: NonNullable<TextDelta["attributes"]>): TextDelta[] {
     return deltas.map(delta => ({
@@ -282,26 +307,40 @@ function parseTable(tokens: TokenLike[], start: number, end: number): {
   };
 }
 
-function collectQuoteText(tokens: TokenLike[], start: number, end: number): string {
+function collectQuoteText(tokens: TokenLike[], start: number, end: number): { text: string; deltas: TextDelta[] } {
   const lines: string[] = [];
+  const allDeltas: TextDelta[] = [];
+  let firstLine = true;
   for (let i = start; i < end; i += 1) {
     const token = tokens[i];
     if (token.type === "inline") {
-      const line = deltaToString(renderInline(token.children ?? [])).trim();
+      const lineDeltas = renderInline(token.children ?? []);
+      const line = deltaToString(lineDeltas).trim();
       if (line) {
+        if (!firstLine) {
+          allDeltas.push({ insert: "\n" });
+        }
+        allDeltas.push(...lineDeltas);
         lines.push(line);
+        firstLine = false;
       }
       continue;
     }
     if (token.type === "fence" || token.type === "code_block") {
       const language = (token.info ?? "").trim();
       const codeBody = token.content.replace(/\n$/, "");
-      lines.push(`\`\`\`${language}\n${codeBody}\n\`\`\``);
+      const fenceText = `\`\`\`${language}\n${codeBody}\n\`\`\``;
+      if (!firstLine) {
+        allDeltas.push({ insert: "\n" });
+      }
+      allDeltas.push({ insert: fenceText });
+      lines.push(fenceText);
+      firstLine = false;
       continue;
     }
   }
 
-  return lines.join("\n");
+  return { text: lines.join("\n"), deltas: allDeltas };
 }
 
 function parseCalloutAdmonition(text: string): string | null {
@@ -441,8 +480,9 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
         const levelNum = Number((token.tag ?? "h1").replace("h", ""));
         const level = Math.max(1, Math.min(6, levelNum)) as 1 | 2 | 3 | 4 | 5 | 6;
         const inline = tokens.slice(i + 1, close).find(inner => inner.type === "inline");
-        const text = inline ? deltaToString(renderInline(inline.children ?? [])).trim() : "";
-        state.operations.push({ type: "heading", level, text });
+        const headingDeltas = inline ? renderInline(inline.children ?? []) : [];
+        const text = deltaToString(headingDeltas).trim();
+        state.operations.push({ type: "heading", level, text, deltas: headingDeltas });
         i = close + 1;
         break;
       }
@@ -487,9 +527,10 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
           break;
         }
 
-        const text = deltaToString(renderInline(children)).trim();
+        const paragraphDeltas = renderInline(children);
+        const text = deltaToString(paragraphDeltas).trim();
         if (text.length > 0) {
-          state.operations.push({ type: "paragraph", text });
+          state.operations.push({ type: "paragraph", text, deltas: paragraphDeltas });
         }
         i = close + 1;
         break;
@@ -517,12 +558,13 @@ function parseTokens(tokens: TokenLike[], start: number, end: number, state: Par
           i += 1;
           break;
         }
-        const quoteText = collectQuoteText(tokens, i + 1, close).trim();
+        const quoteResult = collectQuoteText(tokens, i + 1, close);
+        const quoteText = quoteResult.text.trim();
         const calloutText = parseCalloutAdmonition(quoteText);
         if (calloutText !== null) {
-          state.operations.push({ type: "callout", text: calloutText });
+          state.operations.push({ type: "callout", text: calloutText, deltas: stripFirstDeltaLine(quoteResult.deltas) });
         } else if (quoteText.length > 0) {
-          state.operations.push({ type: "quote", text: quoteText });
+          state.operations.push({ type: "quote", text: quoteText, deltas: quoteResult.deltas });
         }
         i = close + 1;
         break;

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -16,18 +16,22 @@ export type MarkdownOperation =
       type: "heading";
       text: string;
       level: 1 | 2 | 3 | 4 | 5 | 6;
+      deltas?: TextDelta[];
     }
   | {
       type: "paragraph";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "quote";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "callout";
       text: string;
+      deltas?: TextDelta[];
     }
   | {
       type: "list";

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1339,7 +1339,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
               ? "quote"
               : "text";
         block.set("prop:type", blockType);
-        block.set("prop:text", makeText(content));
+        block.set("prop:text", makeText(normalized.deltas ?? content));
         return { blockId, block, flavour: "affine:paragraph", blockType };
       }
       case "list": {
@@ -1378,7 +1378,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         textBlock.set("sys:parent", null);
         textBlock.set("sys:children", new Y.Array<string>());
         textBlock.set("prop:type", "text");
-        textBlock.set("prop:text", makeText(content));
+        textBlock.set("prop:text", makeText(normalized.deltas ?? content));
         calloutChildren.push([textBlockId]);
         block.set("sys:children", calloutChildren);
         block.set("prop:icon", { type: "emoji", unicode: "💡" });
@@ -1815,6 +1815,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           type: "heading",
           text: operation.text,
           level: operation.level,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1824,6 +1825,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "paragraph",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1833,6 +1835,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "quote",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -1842,6 +1845,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId,
           type: "callout",
           text: operation.text,
+          deltas: operation.deltas,
           strict,
           placement,
         };

--- a/tests/test-markdown-rich-text-import.mjs
+++ b/tests/test-markdown-rich-text-import.mjs
@@ -21,7 +21,14 @@ if (!PASSWORD) {
 
 const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || "60000");
 const MARKDOWN = [
+  "## A **bold** heading",
+  "",
   "Intro **paragraph** text",
+  "",
+  "> A **bold** blockquote",
+  "",
+  "> [!NOTE]",
+  "> A **bold** callout",
   "",
   "- **Top level** item",
   "  - **Nested level** item",
@@ -122,6 +129,43 @@ function tableCellDeltas(tableBlock) {
   return result;
 }
 
+/**
+ * Collect deltas from affine:paragraph blocks matching a given prop:type
+ * (e.g. "text", "quote", "h1"–"h6").
+ */
+function paragraphBlockDeltas(blocks, propType) {
+  const deltas = [];
+  for (const [, block] of blocks) {
+    if (!(block instanceof Y.Map)) continue;
+    if (block.get("sys:flavour") !== "affine:paragraph") continue;
+    if (block.get("prop:type") !== propType) continue;
+    const text = block.get("prop:text");
+    if (!(text instanceof Y.Text)) continue;
+    deltas.push(text.toDelta());
+  }
+  return deltas;
+}
+
+/**
+ * Collect deltas from the child paragraph blocks inside affine:callout blocks.
+ */
+function calloutChildDeltas(blocks) {
+  const deltas = [];
+  for (const [, block] of blocks) {
+    if (!(block instanceof Y.Map)) continue;
+    if (block.get("sys:flavour") !== "affine:callout") continue;
+    const children = block.get("sys:children");
+    for (const childId of childIdsFrom(children)) {
+      const child = blocks.get(childId);
+      if (!(child instanceof Y.Map)) continue;
+      const text = child.get("prop:text");
+      if (!(text instanceof Y.Text)) continue;
+      deltas.push(text.toDelta());
+    }
+  }
+  return deltas;
+}
+
 async function loadLiveDoc(workspaceId, docId, cookie) {
   const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(`${BASE_URL}/graphql`), cookie, undefined);
   try {
@@ -190,6 +234,24 @@ async function main() {
 
     const createdDoc = await loadLiveDoc(workspaceId, createdDocId, cookie);
     const createdBlocks = getBlocks(createdDoc);
+
+    // --- Heading ---
+    const createdHeadingDeltas = paragraphBlockDeltas(createdBlocks, "h2");
+    expect(createdHeadingDeltas.some(delta => hasBoldRun(delta, "bold")), "heading did not preserve bold");
+
+    // --- Paragraph ---
+    const createdParagraphDeltas = paragraphBlockDeltas(createdBlocks, "text");
+    expect(createdParagraphDeltas.some(delta => hasBoldRun(delta, "paragraph")), "paragraph did not preserve bold");
+
+    // --- Quote ---
+    const createdQuoteDeltas = paragraphBlockDeltas(createdBlocks, "quote");
+    expect(createdQuoteDeltas.some(delta => hasBoldRun(delta, "bold")), "quote did not preserve bold");
+
+    // --- Callout ---
+    const createdCalloutDeltas = calloutChildDeltas(createdBlocks);
+    expect(createdCalloutDeltas.some(delta => hasBoldRun(delta, "bold")), "callout did not preserve bold");
+
+    // --- List ---
     const createdListDeltas = listBlockDeltas(createdBlocks);
     expect(createdListDeltas.some(delta => hasBoldRun(delta, "Top level")), "top-level list item did not preserve bold");
     expect(createdListDeltas.some(delta => hasBoldRun(delta, "Nested level")), "nested list item did not preserve bold");
@@ -216,6 +278,24 @@ async function main() {
 
     const replacedDoc = await loadLiveDoc(workspaceId, replaceDocId, cookie);
     const replacedBlocks = getBlocks(replacedDoc);
+
+    // --- Heading ---
+    const replacedHeadingDeltas = paragraphBlockDeltas(replacedBlocks, "h2");
+    expect(replacedHeadingDeltas.some(delta => hasBoldRun(delta, "bold")), "replace_doc_with_markdown heading lost bold");
+
+    // --- Paragraph ---
+    const replacedParagraphDeltas = paragraphBlockDeltas(replacedBlocks, "text");
+    expect(replacedParagraphDeltas.some(delta => hasBoldRun(delta, "paragraph")), "replace_doc_with_markdown paragraph lost bold");
+
+    // --- Quote ---
+    const replacedQuoteDeltas = paragraphBlockDeltas(replacedBlocks, "quote");
+    expect(replacedQuoteDeltas.some(delta => hasBoldRun(delta, "bold")), "replace_doc_with_markdown quote lost bold");
+
+    // --- Callout ---
+    const replacedCalloutDeltas = calloutChildDeltas(replacedBlocks);
+    expect(replacedCalloutDeltas.some(delta => hasBoldRun(delta, "bold")), "replace_doc_with_markdown callout lost bold");
+
+    // --- List ---
     const replacedListDeltas = listBlockDeltas(replacedBlocks);
     expect(replacedListDeltas.some(delta => hasBoldRun(delta, "Top level")), "replace_doc_with_markdown top-level list item lost bold");
     expect(replacedListDeltas.some(delta => hasBoldRun(delta, "Nested level")), "replace_doc_with_markdown nested list item lost bold");

--- a/tests/test-markdown-roundtrip.mjs
+++ b/tests/test-markdown-roundtrip.mjs
@@ -59,12 +59,74 @@ function testParseAdmonitionAsCallout() {
     {
       type: 'callout',
       text: 'Callout body',
+      deltas: [{ insert: 'Callout body' }],
     },
   ], 'admonition-style blockquotes should import as callout operations');
   assert.equal(parsed.lossy, false, 'callout import should not be lossy');
   assert.deepEqual(parsed.warnings, [], 'callout import should not emit warnings');
 }
 
+// ---------------------------------------------------------------------------
+// Delta preservation tests for heading / paragraph / quote / callout
+// ---------------------------------------------------------------------------
+
+function hasDelta(deltas, insert, attrs) {
+  return deltas.some(d =>
+    d.insert === insert &&
+    (attrs === undefined || Object.entries(attrs).every(([k, v]) => d.attributes?.[k] === v))
+  );
+}
+
+function testHeadingDeltas() {
+  const parsed = parseMarkdownToOperations('## A **bold** heading');
+  assert.equal(parsed.operations.length, 1);
+  const op = parsed.operations[0];
+  assert.equal(op.type, 'heading');
+  assert.equal(op.level, 2);
+  assert.equal(op.text, 'A bold heading');
+  assert.ok(op.deltas, 'heading should have deltas');
+  assert.ok(hasDelta(op.deltas, 'bold', { bold: true }), 'heading deltas should contain bold run');
+  assert.ok(hasDelta(op.deltas, 'A '), 'heading deltas should contain plain prefix');
+  assert.ok(hasDelta(op.deltas, ' heading'), 'heading deltas should contain plain suffix');
+}
+
+function testParagraphDeltas() {
+  const parsed = parseMarkdownToOperations('A **bold** paragraph with *italic* text');
+  assert.equal(parsed.operations.length, 1);
+  const op = parsed.operations[0];
+  assert.equal(op.type, 'paragraph');
+  assert.equal(op.text, 'A bold paragraph with italic text');
+  assert.ok(op.deltas, 'paragraph should have deltas');
+  assert.ok(hasDelta(op.deltas, 'bold', { bold: true }), 'paragraph deltas should contain bold run');
+  assert.ok(hasDelta(op.deltas, 'italic', { italic: true }), 'paragraph deltas should contain italic run');
+}
+
+function testQuoteDeltas() {
+  const parsed = parseMarkdownToOperations('> A **bold** blockquote');
+  assert.equal(parsed.operations.length, 1);
+  const op = parsed.operations[0];
+  assert.equal(op.type, 'quote');
+  assert.equal(op.text, 'A bold blockquote');
+  assert.ok(op.deltas, 'quote should have deltas');
+  assert.ok(hasDelta(op.deltas, 'bold', { bold: true }), 'quote deltas should contain bold run');
+}
+
+function testCalloutDeltas() {
+  const parsed = parseMarkdownToOperations('> [!NOTE]\n> A **bold** callout');
+  assert.equal(parsed.operations.length, 1);
+  const op = parsed.operations[0];
+  assert.equal(op.type, 'callout');
+  assert.equal(op.text, 'A bold callout');
+  assert.ok(op.deltas, 'callout should have deltas');
+  assert.ok(hasDelta(op.deltas, 'bold', { bold: true }), 'callout deltas should contain bold run');
+  // Marker line ([!NOTE]) should be stripped from deltas
+  assert.ok(!hasDelta(op.deltas, '[!NOTE]'), 'callout deltas should not contain marker line');
+}
+
 testRenderCalloutAsAdmonition();
 testParseAdmonitionAsCallout();
+testHeadingDeltas();
+testParagraphDeltas();
+testQuoteDeltas();
+testCalloutDeltas();
 console.log('Markdown round-trip tests passed');


### PR DESCRIPTION
## Summary

#114 (`7c13f81`) added `TextDelta[]` support for **list items** and **table cells**, but four block types were left behind — paragraphs, headings, quotes, and callouts still received plain `string` content, stripping all inline formatting (bold, italic, code, strikethrough, links).

This PR wires `TextDelta[]` through those four remaining types using the exact same pattern already established for lists.

## Changes

### `src/markdown/types.ts`
- Added optional `deltas?: TextDelta[]` to the `heading`, `paragraph`, `quote`, and `callout` variants of `MarkdownOperation`.

### `src/markdown/parse.ts`
- **Heading**: capture `renderInline()` result as `headingDeltas`, derive `text` from it, emit `deltas` on the operation.
- **Paragraph**: same pattern — capture `paragraphDeltas`, derive `text`, emit `deltas`.
- **`collectQuoteText()`**: refactored return type from `string` to `{ text: string; deltas: TextDelta[] }`. Collects deltas from inline tokens (joined with `\n` separators) and plain-text deltas for fence/code blocks.
- **Blockquote callsite**: destructure `quoteResult`, pass `quoteResult.deltas` for quotes and `stripFirstDeltaLine(quoteResult.deltas)` for callouts.
- **`stripFirstDeltaLine()`**: new helper that strips deltas for the first line (up to and including the first `\n`), used to remove the `[!NOTE]`/`[!TIP]`/etc. marker line from callout deltas.

### `src/tools/docs.ts`
- **`markdownOperationToAppendInput`**: pass `deltas: operation.deltas` for heading, paragraph, quote, and callout cases.
- **`createBlockYMap`**: paragraph/heading/quote case and callout case now use `makeText(normalized.deltas ?? content)` instead of `makeText(content)`.

## Validation

```
✅ npx tsc --noEmit         — 0 errors
✅ npm run build             — clean
✅ npm run test:tool-manifest — 76 tools, ok: true
✅ npm run pack:check        — packages correctly
```

## Checklist

- [x] Tool names are unique and use snake_case — N/A, no new tools
- [x] Tool manifest updated — N/A, no tool changes
- [x] README updated — N/A, no behavior change visible to users
- [x] Backward compatible — `deltas` is optional; plain-string fallback preserved via `normalized.deltas ?? content`