### PR TITLE
docs: productize README and split docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AFFiNE MCP Server
 
-A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted or cloud). It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`).
+A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
 [![Version](https://img.shields.io/badge/version-1.12.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
@@ -11,121 +11,117 @@ A Model Context Protocol (MCP) server that integrates with AFFiNE (self‑hosted
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@DAWNCR0W/affine-mcp-server/badge" alt="AFFiNE Server MCP server" />
 </a>
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Choose Your Path](#choose-your-path)
+- [Quick Start](#quick-start)
+- [Compatibility Matrix](#compatibility-matrix)
+- [Tool Surface](#tool-surface)
+- [Documentation Map](#documentation-map)
+- [Verify Your Setup](#verify-your-setup)
+- [Security and Scope](#security-and-scope)
+- [Development](#development)
+- [Release Notes](#release-notes)
+- [License](#license)
+- [Support](#support)
+
 ## Overview
 
-- Purpose: Manage AFFiNE workspaces and documents through MCP
-- Transport: stdio (default) and optional HTTP (`/mcp`) for remote MCP deployments
-- Auth: Token, Cookie, or Email/Password (priority order)
-- Tools: 76 focused tools with WebSocket-based document editing
-- Status: Active
- 
+AFFiNE MCP Server is designed for three common scenarios:
+
+- Run a local stdio MCP server for Claude Code, Codex CLI, Cursor, or Claude Desktop
+- Expose a remote HTTP MCP endpoint for hosted or browser-connected clients
+- Automate AFFiNE workspace, document, database, and comment workflows through a stable MCP tool surface
+
+Highlights:
+
+- Supports AFFiNE Cloud and self-hosted AFFiNE instances
+- Supports stdio and HTTP transports
+- Supports token, cookie, and email/password authentication
+- Exposes 76 canonical MCP tools backed by AFFiNE GraphQL and WebSocket APIs
+- Includes Docker images, health probes, and end-to-end test coverage
+
+Scope boundaries:
+
+- This server can access only server-backed AFFiNE workspaces
+- Browser-local workspaces stored only in local storage are not available through AFFiNE server APIs
+- AFFiNE Cloud requires API-token-based access for MCP usage; programmatic email/password sign-in is blocked by Cloudflare
+
 > New in v1.12.0: Added linked documents on database rows, restored MCP CRUD for rows created in the AFFiNE UI, fixed self-hosted table exports, and documented GHCR Docker releases.
 
-## Features
+## Choose Your Path
 
-- Workspace: create (with initial doc), read, update, delete
-- Documents: list/get/read/publish/revoke + create/append/replace/delete + markdown import/export + tags (WebSocket‑based)
-- Sidebar data: collections, folders, and organize links for AFFiNE workspace trees
-- Database workflows: create database blocks, inspect schema, add/update/delete rows, and read or update cell values via MCP tools
-- Comments: full CRUD and resolve
-- Version History: list
-- Users & Tokens: current user, sign in, profile/settings, and personal access tokens
-- Notifications: list and mark as read
-- Blob storage: upload/delete/cleanup
-
-## Requirements
-
-- Node.js 18+
-- An AFFiNE instance (self‑hosted or cloud)
-- Valid AFFiNE credentials or access token
-
-## Installation
-
-```bash
-# Global install (recommended)
-npm i -g affine-mcp-server
-
-# Or run ad‑hoc via npx (no install)
-npx -y -p affine-mcp-server affine-mcp -- --version
-```
-
-The package installs a CLI named `affine-mcp` that runs the MCP server over stdio.
-
-Note: From v1.2.2+ the CLI wrapper (`bin/affine-mcp`) ensures Node runs the ESM entrypoint, preventing shell from misinterpreting JS.
-
-## Configuration
-
-### Interactive login (recommended)
-
-The easiest way to configure credentials:
-
-```bash
-npm i -g affine-mcp-server
-affine-mcp login
-```
-
-This stores credentials in `~/.config/affine-mcp/config` (mode 600). The MCP server reads them automatically — no environment variables needed.
-
-**AFFiNE Cloud** (`app.affine.pro`): you'll be prompted to paste an API token from Settings → Integrations → MCP Server.
-
-**Self-hosted instances**: you can choose between email/password (recommended — auto-generates an API token) or pasting a token manually.
-
-```
-$ affine-mcp login
-Affine MCP Server — Login
-
-Affine URL [https://app.affine.pro]: https://my-affine.example.com
-
-Auth method — [1] Email/password (recommended)  [2] Paste API token: 1
-Email: user@example.com
-Password: ****
-Signing in...
-✓ Signed in as: User Name <user@example.com>
-
-Generating API token...
-✓ Created token: ut_abc123... (name: affine-mcp-2026-02-18)
-
-Detecting workspaces...
-  Found 1 workspace: abc-def-123  (by User Name, 1 member, 2/10/2026)
-  Auto-selected.
-
-✓ Saved to /home/user/.config/affine-mcp/config (mode 600)
-The MCP server will use these credentials automatically.
-```
-
-Other CLI commands:
-- `affine-mcp --help` / `-h` / `help` — show command help
-- `affine-mcp status` — show current config and test connection
-- `affine-mcp status --json` — machine-readable status output
-- `affine-mcp doctor` — run config and connectivity diagnostics
-- `affine-mcp show-config` — print the effective config with secrets redacted
-- `affine-mcp config-path` — print the config file path
-- `affine-mcp snippet <claude|cursor|codex|all> [--env]` — print ready-to-paste client configuration snippets
-- `affine-mcp logout` — remove stored credentials
-- `affine-mcp --version` / `-v` / `version` — print the installed CLI version and exit
-
-Non-interactive login helpers:
-- `affine-mcp login --url <url> --token <token> --workspace-id <id> --force`
-
-### Environment variables
-
-You can also configure via environment variables (they override the config file):
-
-- Required: `AFFINE_BASE_URL`
-- Auth (choose one): `AFFINE_API_TOKEN` | `AFFINE_COOKIE` | `AFFINE_EMAIL` + `AFFINE_PASSWORD`
-- Optional: `AFFINE_GRAPHQL_PATH` (default `/graphql`), `AFFINE_WORKSPACE_ID`, `AFFINE_LOGIN_AT_START` (set `sync` only when you must block startup)
-- Tool filtering: `AFFINE_DISABLED_GROUPS`, `AFFINE_DISABLED_TOOLS` (see [Filtering Exposed Tools](#filtering-exposed-tools))
-
-Authentication priority:
-1) `AFFINE_API_TOKEN` → 2) `AFFINE_COOKIE` → 3) `AFFINE_EMAIL` + `AFFINE_PASSWORD`
-
-> **Cloudflare note**: `AFFINE_EMAIL`/`AFFINE_PASSWORD` auth requires programmatic access to `/api/auth/sign-in`. AFFiNE Cloud (`app.affine.pro`) is behind Cloudflare, which blocks these requests. Use `AFFINE_API_TOKEN` for cloud, or use `affine-mcp login` which handles this automatically. Email/password works for self-hosted instances without Cloudflare.
+| Goal | Start here |
+| --- | --- |
+| Set up a local stdio server with the least friction | [docs/getting-started.md](docs/getting-started.md) |
+| Run the server in Docker or another OCI runtime | [docs/getting-started.md#path-c-run-from-the-docker-image](docs/getting-started.md#path-c-run-from-the-docker-image) |
+| Configure Claude Code, Claude Desktop, Codex CLI, or Cursor | [docs/client-setup.md](docs/client-setup.md) |
+| Run the server remotely over HTTP or behind OAuth | [docs/configuration-and-deployment.md](docs/configuration-and-deployment.md) |
+| Lock down tool exposure for least-privilege deployments | [docs/configuration-and-deployment.md#least-privilege-tool-exposure](docs/configuration-and-deployment.md#least-privilege-tool-exposure) |
+| Learn common AFFiNE workflows and tool sequences | [docs/workflow-recipes.md](docs/workflow-recipes.md) |
+| Browse the tool catalog by domain | [docs/tool-reference.md](docs/tool-reference.md) |
 
 ## Quick Start
 
-### Claude Code
+### 1. Install the CLI
 
-After running `affine-mcp login`, add to your project's `.mcp.json`:
+```bash
+npm i -g affine-mcp-server
+affine-mcp --version
+```
+
+You can also run the package ad hoc:
+
+```bash
+npx -y -p affine-mcp-server affine-mcp -- --version
+```
+
+### 2. Or run the server in Docker
+
+```bash
+docker run -d \
+  -p 3000:3000 \
+  -e MCP_TRANSPORT=http \
+  -e AFFINE_BASE_URL=https://your-affine-instance.com \
+  -e AFFINE_API_TOKEN=ut_your_token \
+  -e AFFINE_MCP_AUTH_MODE=bearer \
+  -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
+  ghcr.io/dawncr0w/affine-mcp-server:latest
+```
+
+Then point your client at:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer your-strong-secret"
+      }
+    }
+  }
+}
+```
+
+For Docker, health checks, and remote deployment details, see [docs/configuration-and-deployment.md#docker](docs/configuration-and-deployment.md#docker).
+
+### 3. Save credentials with interactive login
+
+```bash
+affine-mcp login
+```
+
+This stores credentials in `~/.config/affine-mcp/config` with mode `600`.
+
+- For AFFiNE Cloud, use an API token from `Settings -> Integrations -> MCP Server`
+- For self-hosted AFFiNE, you can use either an API token or email/password
+
+### 4. Register the server with your client
+
+Claude Code project config:
 
 ```json
 {
@@ -137,400 +133,95 @@ After running `affine-mcp login`, add to your project's `.mcp.json`:
 }
 ```
 
-No `env` block needed — the server reads `~/.config/affine-mcp/config` automatically.
-
-If you prefer explicit env vars instead of the config file:
-
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "command": "affine-mcp",
-      "env": {
-        "AFFINE_BASE_URL": "https://app.affine.pro",
-        "AFFINE_API_TOKEN": "ut_xxx"
-      }
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Add to your Claude Desktop configuration:
-
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-- Linux: `~/.config/Claude/claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "command": "affine-mcp",
-      "env": {
-        "AFFINE_BASE_URL": "https://app.affine.pro",
-        "AFFINE_API_TOKEN": "ut_xxx"
-      }
-    }
-  }
-}
-```
-
-Or with email/password for self-hosted instances (not supported on AFFiNE Cloud — see Cloudflare note above):
-
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "command": "affine-mcp",
-      "env": {
-        "AFFINE_BASE_URL": "https://your-self-hosted-affine.com",
-        "AFFINE_EMAIL": "you@example.com",
-        "AFFINE_PASSWORD": "secret!"
-      }
-    }
-  }
-}
-```
-
-Tips
-- Prefer `affine-mcp login` or `AFFINE_API_TOKEN` for zero‑latency startup.
-- If your password contains `!` (zsh history expansion), wrap it in single quotes in shells or use the JSON config above.
-- `affine-mcp doctor` is the fastest way to confirm that your saved config still works.
-- `affine-mcp snippet claude --env` and `affine-mcp snippet codex --env` can generate ready-to-paste client setup from your current config.
-- `affine-mcp snippet all --env` prints Claude, Cursor, and Codex setup in one shot.
-
-### Codex CLI
-
-Register the MCP server with Codex:
-
-- With config file (after `affine-mcp login`):
-  - `codex mcp add affine -- affine-mcp`
-
-- With API token:
-  - `codex mcp add affine --env AFFINE_BASE_URL=https://app.affine.pro --env AFFINE_API_TOKEN=ut_xxx -- affine-mcp`
-
-- With email/password (self-hosted only):
-  - `codex mcp add affine --env AFFINE_BASE_URL=https://your-self-hosted-affine.com --env 'AFFINE_EMAIL=you@example.com' --env 'AFFINE_PASSWORD=secret!' -- affine-mcp`
-
-### Cursor
-
-Cursor also supports MCP over stdio with `mcp.json`.
-
-Project-local (`.cursor/mcp.json`) example:
-
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "command": "affine-mcp",
-      "env": {
-        "AFFINE_BASE_URL": "https://app.affine.pro",
-        "AFFINE_API_TOKEN": "ut_xxx"
-      }
-    }
-  }
-}
-```
-
-If you prefer `npx`:
-
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "command": "npx",
-      "args": ["-y", "-p", "affine-mcp-server", "affine-mcp"],
-      "env": {
-        "AFFINE_BASE_URL": "https://app.affine.pro",
-        "AFFINE_API_TOKEN": "ut_xxx"
-      }
-    }
-  }
-}
-```
-
-### Docker
-
-Pre-built multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry on every release tag:
-
-```
-ghcr.io/dawncr0w/affine-mcp-server:latest      # latest release
-ghcr.io/dawncr0w/affine-mcp-server:1.12.0      # specific version
-```
-
-Quick start:
+Codex CLI:
 
 ```bash
-docker run -d \
-  -p 3000:3000 \
-  -e AFFINE_BASE_URL=https://your-affine-instance.com \
-  -e AFFINE_API_TOKEN=ut_your_token \
-  -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
-  ghcr.io/dawncr0w/affine-mcp-server:latest
+codex mcp add affine -- affine-mcp
 ```
 
-Then add to your MCP client config:
+More client-specific setup is in [docs/client-setup.md](docs/client-setup.md).
 
-```json
-{
-  "mcpServers": {
-    "affine": {
-      "type": "http",
-      "url": "http://localhost:3000/mcp",
-      "headers": { "Authorization": "Bearer your-strong-secret" }
-    }
-  }
-}
-```
-
-The container runs as a non-root user and exposes `/healthz` and `/readyz` for liveness/readiness probes.
-
-### Remote Server
-
-If you want to host the server remotely (e.g., using Render, Railway, Docker, or a VPS) and connect via HTTP MCP (Streamable HTTP on `/mcp`) instead of local `stdio`, run the server in HTTP mode.
-
-#### Environment variables (HTTP mode)
-
-Required:
-- `MCP_TRANSPORT=http`
-- `AFFINE_BASE_URL` (example: `https://app.affine.pro`)
-- `AFFINE_MCP_AUTH_MODE=bearer` (default) or `AFFINE_MCP_AUTH_MODE=oauth`
-
-Bearer mode backend auth:
-- `AFFINE_API_TOKEN` (recommended), or `AFFINE_COOKIE`, or `AFFINE_EMAIL` + `AFFINE_PASSWORD`
-
-OAuth mode backend auth:
-- `AFFINE_API_TOKEN` (required service credential for AFFiNE backend access)
-
-Recommended for remote/public deployments:
-- `AFFINE_MCP_HTTP_HOST=0.0.0.0`
-- `AFFINE_MCP_HTTP_ALLOWED_ORIGINS=<comma-separated-origins>` (for browser clients)
-
-Optional:
-- `PORT` (defaults to `3000`; many platforms like Render inject this automatically)
-- `AFFINE_WORKSPACE_ID`
-- `AFFINE_GRAPHQL_PATH` (defaults to `/graphql`)
-- `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS=true` (testing only)
-
-Bearer-mode only:
-- `AFFINE_MCP_HTTP_TOKEN=<strong-random-token>` (protects `/mcp`, `/sse`, `/messages`)
-
-OAuth-mode only:
-- `AFFINE_MCP_PUBLIC_BASE_URL=https://mcp.yourdomain.com`
-- `AFFINE_OAUTH_ISSUER_URL=https://auth.yourdomain.com`
-- `AFFINE_OAUTH_SCOPES=mcp` (defaults to `mcp`)
-
-#### HTTP auth modes
-
-`AFFINE_MCP_AUTH_MODE=bearer` keeps the current static bearer-token behavior.
+### 5. Verify the connection
 
 ```bash
-export MCP_TRANSPORT=http
-export AFFINE_MCP_AUTH_MODE=bearer
-export AFFINE_API_TOKEN="your_token..."
-export AFFINE_MCP_HTTP_HOST="0.0.0.0"
-export AFFINE_MCP_HTTP_TOKEN="your-super-secret-token"
-export PORT=3000
-
-npm run start:http
+affine-mcp status
+affine-mcp doctor
 ```
 
-`AFFINE_MCP_AUTH_MODE=oauth` turns the MCP endpoint into an OAuth-protected resource for web MCP clients. In this mode:
-- the server exposes `/.well-known/oauth-protected-resource`
-- unauthenticated `/mcp` requests return `401` with a `WWW-Authenticate` challenge
-- `AFFINE_MCP_HTTP_TOKEN` and `?token=` are disabled
-- `sign_in` is not registered
-- `AFFINE_API_TOKEN` is still required so the server can call AFFiNE as a service credential
+If you want to expose the server remotely over HTTP instead of stdio, start with [docs/configuration-and-deployment.md](docs/configuration-and-deployment.md).
 
-```bash
-export MCP_TRANSPORT=http
-export AFFINE_MCP_AUTH_MODE=oauth
-export AFFINE_API_TOKEN="your-affine-service-token"
-export AFFINE_MCP_HTTP_HOST="0.0.0.0"
-export AFFINE_MCP_PUBLIC_BASE_URL="https://mcp.yourdomain.com"
-export AFFINE_OAUTH_ISSUER_URL="https://auth.yourdomain.com"
-export AFFINE_OAUTH_SCOPES="mcp"
-export PORT=3000
+## Compatibility Matrix
 
-npm run start:http
-```
+| Target | Transport | Recommended auth | Recommended path |
+| --- | --- | --- | --- |
+| Claude Code | stdio | Saved config or API token | [docs/client-setup.md#claude-code](docs/client-setup.md#claude-code) |
+| Claude Desktop | stdio | Saved config or API token | [docs/client-setup.md#claude-desktop](docs/client-setup.md#claude-desktop) |
+| Codex CLI | stdio | Saved config or API token | [docs/client-setup.md#codex-cli](docs/client-setup.md#codex-cli) |
+| Cursor | stdio | Saved config or API token | [docs/client-setup.md#cursor](docs/client-setup.md#cursor) |
+| Containerized remote deployment | HTTP | Bearer token or OAuth | [docs/getting-started.md#path-c-run-from-the-docker-image](docs/getting-started.md#path-c-run-from-the-docker-image) |
+| Remote MCP clients | HTTP | Bearer token or OAuth | [docs/configuration-and-deployment.md#http-mode](docs/configuration-and-deployment.md#http-mode) |
+| AFFiNE Cloud | stdio or HTTP | API token | [docs/configuration-and-deployment.md#auth-strategy-matrix](docs/configuration-and-deployment.md#auth-strategy-matrix) |
+| Self-hosted AFFiNE | stdio or HTTP | API token, cookie, or email/password | [docs/configuration-and-deployment.md#auth-strategy-matrix](docs/configuration-and-deployment.md#auth-strategy-matrix) |
 
-Notes for OAuth mode:
-- use HTTPS for non-local deployments
-- `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS=true` is rejected in OAuth mode
-- tokens are validated against the issuer discovery metadata and JWKS
-- the protected resource metadata is also served at `/.well-known/oauth-protected-resource/mcp` for path-specific discovery
-- `GET /healthz` and `GET /readyz` are available for deployment diagnostics
+## Tool Surface
 
-#### Recommended presets
+`tool-manifest.json` is the source of truth for canonical tool names. The MCP server exposes those tools through `tools/list` and `tools/call`.
 
-Local testing (HTTP mode):
-- `MCP_TRANSPORT=http`
-- `AFFINE_MCP_AUTH_MODE=bearer`
-- `AFFINE_MCP_HTTP_HOST=127.0.0.1`
-- `AFFINE_MCP_HTTP_TOKEN=<token>` (recommended even locally)
-- `AFFINE_MCP_HTTP_ALLOWED_ORIGINS=http://localhost:3000` (if testing from a browser app)
+Domains:
 
-Docker / container runtime:
-- `MCP_TRANSPORT=http`
-- `AFFINE_MCP_AUTH_MODE=bearer`
-- `AFFINE_MCP_HTTP_HOST=0.0.0.0`
-- `PORT=3000` (or container/platform port)
-- `AFFINE_MCP_HTTP_TOKEN=<strong-token>`
-- `AFFINE_MCP_HTTP_ALLOWED_ORIGINS=<your app origin(s)>`
+- Workspace: create, inspect, update, delete, and traverse workspaces
+- Organization: collections and experimental organize/folder helpers
+- Documents: search, read, create, publish, move, tag, import/export, and text mutation
+- Databases: create columns, add rows, update cells, inspect schema, and read cell values
+- Comments: list, create, update, delete, and resolve comments
+- History: version history listing
+- Users and tokens: current user, sign-in, profile/settings, personal access tokens
+- Notifications: list and mark notifications as read
+- Blob storage: upload, delete, and cleanup blobs
 
-Render / Railway / VPS (public endpoint):
-- `MCP_TRANSPORT=http`
-- `AFFINE_MCP_AUTH_MODE=bearer` or `oauth`
-- `AFFINE_MCP_HTTP_HOST=0.0.0.0`
-- `AFFINE_MCP_HTTP_TOKEN=<strong-token>` (bearer mode)
-- `AFFINE_MCP_PUBLIC_BASE_URL=<public base URL>` (OAuth mode)
-- `AFFINE_OAUTH_ISSUER_URL=<issuer URL>` (OAuth mode)
-- `AFFINE_MCP_HTTP_ALLOWED_ORIGINS=<your client origin(s)>`
+For the grouped catalog, notes, and operational caveats, see [docs/tool-reference.md](docs/tool-reference.md).
 
-Endpoints currently available:
-- `/mcp` - MCP server (Streamable HTTP)
-- `/sse` - SSE endpoint (old protocol compatible)
-- `/messages` - Messages endpoint (old protocol compatible)
-- `/healthz` - HTTP liveness probe
-- `/readyz` - HTTP readiness probe
+## Documentation Map
 
+| Document | Purpose |
+| --- | --- |
+| [docs/getting-started.md](docs/getting-started.md) | First-run setup paths and verification |
+| [docs/client-setup.md](docs/client-setup.md) | Client-specific configuration snippets and tips |
+| [docs/configuration-and-deployment.md](docs/configuration-and-deployment.md) | Environment variables, auth modes, Docker, HTTP mode, and deployment guidance |
+| [docs/workflow-recipes.md](docs/workflow-recipes.md) | End-to-end workflows and example tool sequences |
+| [docs/tool-reference.md](docs/tool-reference.md) | Tool catalog grouped by domain |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow |
+| [SECURITY.md](SECURITY.md) | Security reporting |
 
-## Available Tools
+## Verify Your Setup
 
-### Workspace
-- `list_workspaces` – list all workspaces
-- `get_workspace` – get workspace details
-- `create_workspace` – create workspace with initial document
-- `update_workspace` – update workspace settings
-- `delete_workspace` – delete workspace permanently
-- `list_workspace_tree` – return the workspace document hierarchy as a tree
-- `get_orphan_docs` – find documents that are not linked from any parent doc in the sidebar tree
+Useful CLI commands:
 
-### Organization
-- `list_collections` – list workspace collections
-- `get_collection` – get a collection by id
-- `create_collection` – create a collection
-- `update_collection` – rename a collection
-- `delete_collection` – delete a collection
-- `add_doc_to_collection` – add a document to a collection allow-list
-- `remove_doc_from_collection` – remove a document from a collection allow-list
-- `list_organize_nodes` – experimental organize/folder tree dump
-- `create_folder` – experimental root or nested folder creation
-- `rename_folder` – experimental folder rename
-- `delete_folder` – experimental recursive folder delete
-- `move_organize_node` – experimental folder/link move
-- `add_organize_link` – experimental doc/tag/collection link under a folder
-- `delete_organize_link` – experimental doc/tag/collection link delete
+- `affine-mcp status` - test the effective configuration
+- `affine-mcp status --json` - machine-readable status output
+- `affine-mcp doctor` - diagnose config and connectivity issues
+- `affine-mcp show-config` - print the effective config with secrets redacted
+- `affine-mcp config-path` - print the config file path
+- `affine-mcp snippet <claude|cursor|codex|all> [--env]` - generate ready-to-paste client config
+- `affine-mcp logout` - remove stored credentials
 
+For common failures, see:
 
-### Documents
-- `list_docs` – list documents with pagination (includes `node.tags`)
-- `list_tags` – list all tags in a workspace
-- `search_docs` – fast title search with substring/prefix/exact matching, optional tag filtering, and updatedAt sorting
-- `list_docs_by_tag` – list documents that contain the requested tag
-- `get_docs_by_tag` – discover documents by case-insensitive tag substring and return `availableTags` when nothing matches
-- `get_doc` – get document metadata
-- `get_doc_by_title` – find a document by title and return its Markdown content
-- `read_doc` – read document block content and plain text snapshot (WebSocket)
-- `export_doc_markdown` – export document content as markdown
-- `publish_doc` – make document public
-- `revoke_doc` – revoke public access
-- `create_doc` – create a new document (WebSocket)
-- `create_doc_from_markdown` – create a document from markdown content
-- `create_doc_from_template` – clone a template doc, substitute `{{variables}}`, and optionally link it under a parent doc
-- `duplicate_doc` – clone a document into a new doc, optionally under a parent doc
-- `create_tag` – create a reusable workspace-level tag
-- `add_tag_to_doc` – attach a tag to a document
-- `remove_tag_from_doc` – detach a tag from a document
-- `update_doc_title` – rename a document in both workspace metadata and the internal page block
-- `append_paragraph` – append a paragraph block (WebSocket)
-- `append_block` – append canonical block types (text/list/code/media/embed/database/edgeless) with strict validation and placement control (`viewMode=kanban` enables preset-backed data views; `data_view` defaults to kanban)
-- `move_doc` – move a document in the sidebar by relinking it under a different parent
-- `batch_create_docs` – create up to 20 documents in a single call
-- `add_database_column` – add a column to a database block (`rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, `date`)
-- `add_database_row` – add a row to a database block with values mapped by column name/ID (`title` / `Title` updates the built-in row title)
-- `delete_database_row` – delete a row from a database block by row block id
-- `read_database_columns` – read database schema metadata including column IDs/types, select options, and table view column mappings
-- `read_database_cells` – read row titles plus decoded database cell values with optional row / column filters
-- `update_database_cell` – update a single database cell or the built-in row title (`createOption` defaults to `true` for select fields)
-- `update_database_row` – batch update multiple cells on a database row (`createOption` defaults to `true` for select fields)
-- `append_markdown` – append markdown content to an existing document
-- `replace_doc_with_markdown` – replace the main note content with markdown content
-- `list_children` – list the direct child docs linked from a document
-- `list_backlinks` – list the parent/reference docs that link to a document
-- `cleanup_orphan_embeds` – remove linked-doc embeds that point to missing docs
-- `find_and_replace` – preview or apply text replacement across a document
-- `delete_doc` – delete a document (WebSocket)
+- [docs/getting-started.md#common-first-run-failures](docs/getting-started.md#common-first-run-failures)
+- [docs/configuration-and-deployment.md#deployment-checklist](docs/configuration-and-deployment.md#deployment-checklist)
 
-### Comments
-- `list_comments`, `create_comment`, `update_comment`, `delete_comment`, `resolve_comment`
+## Security and Scope
 
-### Version History
-- `list_histories`
+- Never commit secrets or long-lived tokens
+- Prefer API tokens over cookies or passwords in production
+- Use HTTPS for non-local deployments
+- Rotate access tokens regularly
+- Restrict exposed tools with `AFFINE_DISABLED_GROUPS` and `AFFINE_DISABLED_TOOLS` for least-privilege setups
+- Use `/healthz` and `/readyz` when running the HTTP server behind a container platform or load balancer
 
-### Users & Tokens
-- `current_user`, `sign_in`, `update_profile`, `update_settings`
-- `list_access_tokens`, `generate_access_token`, `revoke_access_token`
+## Development
 
-### Notifications
-- `list_notifications`, `read_all_notifications`
-
-### Blob Storage
-- `upload_blob`, `delete_blob`, `cleanup_blobs`
-
-## Filtering Exposed Tools
-
-Optional environment variables to narrow the exposed surface. 
-
-### Group-level — `AFFINE_DISABLED_GROUPS`
-
-| Group name | Tools included |
-|---|---|
-| `workspaces` | `list_workspaces`, `get_workspace`, `create_workspace`, `update_workspace`, `delete_workspace` |
-| `docs` | `list_docs`, `read_doc`, `search_docs`, `create_doc`, `create_doc_from_markdown`, `create_doc_from_template`, `duplicate_doc`, `append_paragraph`, `append_block`, `append_markdown`, `replace_doc_with_markdown`, `delete_doc`, `publish_doc`, `revoke_doc`, `list_tags`, `list_docs_by_tag`, `create_tag`, `add_tag_to_doc`, `remove_tag_from_doc`, `list_workspace_tree`, `get_orphan_docs`, `list_children`, `update_doc_title`, `get_doc_by_title`, `get_docs_by_tag`, `list_backlinks`, `move_doc`, `batch_create_docs`, `cleanup_orphan_embeds`, `find_and_replace`, `add_database_column`, `add_database_row`, `delete_database_row`, `read_database_columns`, `read_database_cells`, `update_database_cell`, `update_database_row` |
-| `comments` | `list_comments`, `create_comment`, `update_comment`, `delete_comment`, `resolve_comment` |
-| `history` | `list_histories` |
-| `organize` | `list_collections`, `get_collection`, `create_collection`, `update_collection`, `delete_collection`, `add_doc_to_collection`, `remove_doc_from_collection`, `list_organize_nodes`, `create_folder`, `rename_folder`, `delete_folder`, `move_organize_node`, `add_organize_link`, `delete_organize_link` |
-| `users` | `current_user`, `sign_in`, `update_profile`, `update_settings` |
-| `access_tokens` | `list_access_tokens`, `generate_access_token`, `revoke_access_token` |
-| `blobs` | `upload_blob`, `delete_blob`, `cleanup_blobs` |
-| `notifications` | `list_notifications`, `read_all_notifications` |
-
-```json
-"env": {
-  "AFFINE_DISABLED_GROUPS": "comments,history,blobs,users"
-}
-```
-
-### Tool-level — `AFFINE_DISABLED_TOOLS`
-
-Disables individual tools by exact name (comma-separated). 
-
-```json
-"env": {
-  "AFFINE_DISABLED_TOOLS": "delete_workspace,delete_doc"
-}
-```
-
-## Use Locally (clone)
-
-```bash
-git clone https://github.com/dawncr0w/affine-mcp-server.git
-cd affine-mcp-server
-npm install
-npm run build
-# Run directly
-node dist/index.js
-
-# Or expose as a global CLI for Codex/Claude without publishing
-npm link
-# Now use `affine-mcp` like a global binary
-```
-
-## Quality Gates
+Run the main quality gates before opening a PR:
 
 ```bash
 npm run build
@@ -538,77 +229,36 @@ npm run test:tool-manifest
 npm run pack:check
 ```
 
-- `tool-manifest.json` is the source of truth for publicly exposed tool names.
-- CI validates that `registerTool(...)` declarations match the manifest exactly.
-- For full tool-surface verification, run `npm run test:comprehensive` (self-bootstraps a local Docker AFFiNE stack).
-- For pre-provisioned environments, use `npm run test:comprehensive:raw`.
-- For full environment verification, run `npm run test:e2e` (Docker + MCP + Playwright).
-- Additional focused runners: `npm run test:db-create`, `npm run test:db-cells`, `npm run test:db-schema`, `npm run test:supporting-tools`, `npm run test:organize`, `npm run test:bearer`, `npm run test:http-email-password`, `npm run test:http-bearer`, `npm run test:oauth-http`, `npm run test:doc-discovery`, `npm run test:cli-version`, `npm run test:cli-commands`, `npm run test:cli-live`, `npm run test:tool-filtering`, `npm run test:markdown-rich-text-import`, `npm run test:playwright`.
+Additional validation:
 
-## Troubleshooting
+- `npm run test:comprehensive` boots a local Docker AFFiNE stack and validates the tool surface
+- `npm run test:e2e` runs Docker, MCP, and Playwright together
+- `npm run test:playwright` runs the Playwright suite only
 
-Authentication
-- **Cloudflare (403 "Just a moment...")**: AFFiNE Cloud (`app.affine.pro`) uses Cloudflare protection, which blocks programmatic sign-in via `/api/auth/sign-in`. Use `AFFINE_API_TOKEN` instead, or run `affine-mcp login` which guides you through the right method automatically. Email/password auth only works for self-hosted instances.
-- Email/Password: only works on self-hosted instances without Cloudflare. Ensure your instance allows password auth and credentials are valid.
-- Cookie: copy cookies (e.g., `affine_session`, `affine_csrf`) from the browser DevTools after login
-- Token: generate a personal access token; verify it hasn't expired. Run `affine-mcp status` to test.
-- Startup timeouts: v1.2.2+ includes a CLI wrapper fix and default async login to avoid blocking the MCP handshake. Set `AFFINE_LOGIN_AT_START=sync` only if needed.
+Local clone flow:
 
-Connection
-- Confirm `AFFINE_BASE_URL` is reachable
-- GraphQL endpoint default is `/graphql`
-- Check firewall/proxy rules; verify CORS if self‑hosted
-
-Method not found
-- MCP tool names (for example `list_workspaces`) are not JSON-RPC top-level method names.
-- Use an MCP client (`tools/list`, `tools/call`) instead of sending direct JSON-RPC calls like `{\"method\":\"list_workspaces\"}`.
-- From v1.3.0, only canonical tool names are exposed (legacy `affine_*` aliases were removed).
-
-Workspace visibility
-- This MCP server can access server-backed workspaces only (AFFiNE cloud/self-hosted).
-- Browser local-storage workspaces are client-side data, so they are not visible via server GraphQL/WebSocket APIs.
-
-## Security Considerations
-
-- Never commit `.env` with secrets
-- Prefer environment variables in production
-- Rotate access tokens regularly
-- Use HTTPS
-- Store credentials in a secrets manager
+```bash
+git clone https://github.com/dawncr0w/affine-mcp-server.git
+cd affine-mcp-server
+npm install
+npm run build
+node dist/index.js
+```
 
 ## Release Notes
 
-- Changelog: [CHANGELOG.md](CHANGELOG.md)
-- Release notes: [RELEASE_NOTES.md](RELEASE_NOTES.md)
-- GitHub Releases: [Releases](https://github.com/dawncr0w/affine-mcp-server/releases)
-
-## Contributing
-
-Contributions are welcome!
-1. Read `CONTRIBUTING.md`
-2. Run `npm run ci` locally before opening PR
-3. Keep tool changes synced with `tool-manifest.json`
-4. Use issue/PR templates in `.github/`
-
-## Community Health
-
-- Code of Conduct: `CODE_OF_CONDUCT.md`
-- Security policy: `SECURITY.md`
-- Contributing guide: `CONTRIBUTING.md`
+- [CHANGELOG.md](CHANGELOG.md)
+- [RELEASE_NOTES.md](RELEASE_NOTES.md)
+- [GitHub Releases](https://github.com/dawncr0w/affine-mcp-server/releases)
 
 ## License
 
-MIT License - see LICENSE file for details
+MIT License - see [LICENSE](LICENSE).
 
 ## Support
 
-For issues and questions:
 - Open an issue on [GitHub](https://github.com/dawncr0w/affine-mcp-server/issues)
-- Check AFFiNE documentation at https://docs.affine.pro
-
-## Author
-
-**dawncr0w** - [GitHub](https://github.com/dawncr0w)
+- Review AFFiNE product documentation at [docs.affine.pro](https://docs.affine.pro)
 
 ## Acknowledgments
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,0 +1,174 @@
+# Client Setup
+
+This guide provides copy-paste configuration for the most common MCP clients.
+
+## Client matrix
+
+| Client | Transport | Recommended auth | Best starting point |
+| --- | --- | --- | --- |
+| Claude Code | stdio | Saved config or API token | `affine-mcp login` + `command: "affine-mcp"` |
+| Claude Desktop | stdio | Saved config or API token | Config JSON with `command: "affine-mcp"` |
+| Codex CLI | stdio | Saved config or API token | `codex mcp add affine -- affine-mcp` |
+| Cursor | stdio | Saved config or API token | `.cursor/mcp.json` |
+| Remote HTTP MCP clients | HTTP | Bearer token or OAuth | See [configuration and deployment](configuration-and-deployment.md#http-mode) |
+
+## Claude Code
+
+Project-local `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp"
+    }
+  }
+}
+```
+
+Explicit environment variables:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp",
+      "env": {
+        "AFFINE_BASE_URL": "https://app.affine.pro",
+        "AFFINE_API_TOKEN": "ut_xxx"
+      }
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+Typical config paths:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\\Claude\\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp",
+      "env": {
+        "AFFINE_BASE_URL": "https://app.affine.pro",
+        "AFFINE_API_TOKEN": "ut_xxx"
+      }
+    }
+  }
+}
+```
+
+Self-hosted email/password example:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp",
+      "env": {
+        "AFFINE_BASE_URL": "https://your-self-hosted-affine.com",
+        "AFFINE_EMAIL": "you@example.com",
+        "AFFINE_PASSWORD": "secret"
+      }
+    }
+  }
+}
+```
+
+## Codex CLI
+
+With saved config:
+
+```bash
+codex mcp add affine -- affine-mcp
+```
+
+With an API token:
+
+```bash
+codex mcp add affine \
+  --env AFFINE_BASE_URL=https://app.affine.pro \
+  --env AFFINE_API_TOKEN=ut_xxx \
+  -- affine-mcp
+```
+
+With self-hosted email/password:
+
+```bash
+codex mcp add affine \
+  --env AFFINE_BASE_URL=https://your-self-hosted-affine.com \
+  --env 'AFFINE_EMAIL=you@example.com' \
+  --env 'AFFINE_PASSWORD=secret' \
+  -- affine-mcp
+```
+
+## Cursor
+
+Project-local `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp",
+      "env": {
+        "AFFINE_BASE_URL": "https://app.affine.pro",
+        "AFFINE_API_TOKEN": "ut_xxx"
+      }
+    }
+  }
+}
+```
+
+`npx` variant:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "npx",
+      "args": ["-y", "-p", "affine-mcp-server", "affine-mcp"],
+      "env": {
+        "AFFINE_BASE_URL": "https://app.affine.pro",
+        "AFFINE_API_TOKEN": "ut_xxx"
+      }
+    }
+  }
+}
+```
+
+## Remote HTTP MCP clients
+
+If your client connects to MCP over HTTP instead of stdio, configure the server first by following [configuration and deployment](configuration-and-deployment.md#http-mode).
+
+If you want the fastest containerized setup, start with the Docker quick start in [getting started](getting-started.md#path-c-run-from-the-docker-image).
+
+Typical bearer-mode client config:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-strong-secret"
+      }
+    }
+  }
+}
+```
+
+## Setup tips
+
+- Prefer `affine-mcp login` for local development
+- Prefer `AFFINE_API_TOKEN` for AFFiNE Cloud
+- Prefer tokens over passwords for automated environments
+- If your shell treats `!` specially, wrap passwords in single quotes
+- Use `affine-mcp doctor` whenever a client config looks correct but the connection still fails

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -1,0 +1,208 @@
+# Configuration and Deployment
+
+This guide covers configuration precedence, environment variables, auth strategy, Docker, HTTP mode, and least-privilege deployment patterns.
+
+## Configuration precedence
+
+The server resolves configuration in this order:
+
+1. Environment variables
+2. Saved config file at `~/.config/affine-mcp/config`
+3. Built-in defaults
+
+Auth priority within the active configuration:
+
+1. `AFFINE_API_TOKEN`
+2. `AFFINE_COOKIE`
+3. `AFFINE_EMAIL` and `AFFINE_PASSWORD`
+
+## Environment variables
+
+### Core configuration
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `AFFINE_BASE_URL` | Yes | None | Base URL for AFFiNE Cloud or self-hosted AFFiNE |
+| `AFFINE_GRAPHQL_PATH` | No | `/graphql` | Override only if your AFFiNE deployment uses a custom GraphQL path |
+| `AFFINE_WORKSPACE_ID` | No | Auto-detected when possible | Pins the active workspace |
+| `AFFINE_LOGIN_AT_START` | No | async login behavior | Set to `sync` only when you must block startup on login |
+
+### Authentication
+
+| Variable | Use when | Notes |
+| --- | --- | --- |
+| `AFFINE_API_TOKEN` | Preferred for cloud and automation | Recommended default for stable operation |
+| `AFFINE_COOKIE` | You must reuse browser-authenticated state | Copy only from a trusted local browser session |
+| `AFFINE_EMAIL` | Self-hosted email/password sign-in | Must be paired with `AFFINE_PASSWORD` |
+| `AFFINE_PASSWORD` | Self-hosted email/password sign-in | Avoid for automated public deployments |
+
+### Tool filtering
+
+| Variable | Purpose |
+| --- | --- |
+| `AFFINE_DISABLED_GROUPS` | Disable entire tool groups by comma-separated group name |
+| `AFFINE_DISABLED_TOOLS` | Disable individual tools by exact canonical name |
+
+### HTTP mode
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `MCP_TRANSPORT` | Yes for HTTP mode | stdio | Set to `http` |
+| `PORT` | No | `3000` | Commonly injected by container platforms |
+| `AFFINE_MCP_AUTH_MODE` | No | `bearer` | `bearer` or `oauth` |
+| `AFFINE_MCP_HTTP_HOST` | No | platform default | Use `0.0.0.0` in containers |
+| `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` | No | none | Comma-separated list for browser clients |
+| `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS` | No | `false` | Testing only; rejected in OAuth mode |
+| `AFFINE_MCP_HTTP_TOKEN` | Required in bearer mode | none | Shared bearer token for `/mcp`, `/sse`, and `/messages` |
+| `AFFINE_MCP_PUBLIC_BASE_URL` | Required in OAuth mode | none | Public base URL for this MCP server |
+| `AFFINE_OAUTH_ISSUER_URL` | Required in OAuth mode | none | OAuth issuer discovery URL |
+| `AFFINE_OAUTH_SCOPES` | No | `mcp` | Scopes advertised for OAuth-protected access |
+
+## Auth strategy matrix
+
+| Environment | Recommended auth | Why |
+| --- | --- | --- |
+| AFFiNE Cloud + stdio | `AFFINE_API_TOKEN` or saved config from `affine-mcp login` | Cloud sign-in is blocked by Cloudflare |
+| AFFiNE Cloud + HTTP | `AFFINE_API_TOKEN` + bearer or OAuth at the MCP layer | Stable and automation-friendly |
+| Self-hosted + stdio | API token first, email/password second | Token reduces startup and sign-in failure modes |
+| Self-hosted + HTTP | API token first, cookie or email/password only if necessary | Better for unattended deployments |
+
+Important note for AFFiNE Cloud:
+
+- Programmatic email/password sign-in to `/api/auth/sign-in` is not supported because Cloudflare blocks those requests
+
+## Docker
+
+Prebuilt images are published to GHCR:
+
+- `ghcr.io/dawncr0w/affine-mcp-server:latest`
+- `ghcr.io/dawncr0w/affine-mcp-server:1.12.0`
+
+Example:
+
+```bash
+docker run -d \
+  -p 3000:3000 \
+  -e MCP_TRANSPORT=http \
+  -e AFFINE_BASE_URL=https://your-affine-instance.com \
+  -e AFFINE_API_TOKEN=ut_your_token \
+  -e AFFINE_MCP_AUTH_MODE=bearer \
+  -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
+  ghcr.io/dawncr0w/affine-mcp-server:latest
+```
+
+Health endpoints:
+
+- `/healthz`
+- `/readyz`
+
+## HTTP mode
+
+HTTP mode exposes:
+
+- `/mcp` - Streamable HTTP MCP endpoint
+- `/sse` - SSE endpoint for older-compatible clients
+- `/messages` - message endpoint for older-compatible clients
+- `/healthz` - liveness probe
+- `/readyz` - readiness probe
+
+### Bearer mode
+
+```bash
+export MCP_TRANSPORT=http
+export AFFINE_MCP_AUTH_MODE=bearer
+export AFFINE_BASE_URL="https://app.affine.pro"
+export AFFINE_API_TOKEN="ut_xxx"
+export AFFINE_MCP_HTTP_HOST="0.0.0.0"
+export AFFINE_MCP_HTTP_TOKEN="your-super-secret-token"
+export PORT=3000
+
+npm run start:http
+```
+
+Use bearer mode when:
+
+- the client can inject a shared secret header
+- you want the simplest remote deployment
+- you do not need OAuth discovery and token validation
+
+### OAuth mode
+
+```bash
+export MCP_TRANSPORT=http
+export AFFINE_MCP_AUTH_MODE=oauth
+export AFFINE_BASE_URL="https://app.affine.pro"
+export AFFINE_API_TOKEN="your-affine-service-token"
+export AFFINE_MCP_HTTP_HOST="0.0.0.0"
+export AFFINE_MCP_PUBLIC_BASE_URL="https://mcp.yourdomain.com"
+export AFFINE_OAUTH_ISSUER_URL="https://auth.yourdomain.com"
+export AFFINE_OAUTH_SCOPES="mcp"
+export PORT=3000
+
+npm run start:http
+```
+
+OAuth mode behavior:
+
+- exposes `/.well-known/oauth-protected-resource`
+- returns `401` + `WWW-Authenticate` challenge for unauthenticated `/mcp` requests
+- disables `AFFINE_MCP_HTTP_TOKEN` and `?token=`
+- does not register `sign_in`
+- still requires `AFFINE_API_TOKEN` so the server can call AFFiNE
+
+## Least-privilege tool exposure
+
+### Disable whole groups
+
+Example:
+
+```json
+{
+  "AFFINE_DISABLED_GROUPS": "comments,history,blobs,users"
+}
+```
+
+Current group names:
+
+- `workspaces`
+- `docs`
+- `comments`
+- `history`
+- `organize`
+- `users`
+- `access_tokens`
+- `blobs`
+- `notifications`
+
+### Disable specific tools
+
+Example:
+
+```json
+{
+  "AFFINE_DISABLED_TOOLS": "delete_workspace,delete_doc"
+}
+```
+
+Use tool-level filtering when you want a mostly complete tool surface but need to remove destructive operations.
+
+## Deployment checklist
+
+Before exposing the server remotely, confirm:
+
+- `AFFINE_BASE_URL` is reachable from the MCP host
+- `AFFINE_API_TOKEN` works through `affine-mcp status` or an equivalent health path
+- `MCP_TRANSPORT=http` is set
+- `AFFINE_MCP_AUTH_MODE` is correct for your client model
+- `AFFINE_MCP_HTTP_HOST=0.0.0.0` is set in containerized deployments
+- `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` is set for browser-based clients
+- `/healthz` and `/readyz` are wired into your platform checks
+- destructive tools are filtered if your deployment should be read-only or constrained
+
+## Troubleshooting pointers
+
+- Cloudflare / sign-in failures: switch to an API token
+- Startup timeouts: avoid `AFFINE_LOGIN_AT_START=sync` unless required
+- Missing tools: confirm filtering variables are not removing them
+- Browser CORS failures: verify `AFFINE_MCP_HTTP_ALLOWED_ORIGINS`
+- OAuth failures: verify issuer discovery metadata and JWKS availability

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,229 @@
+# Getting Started
+
+This guide is the fastest way to get AFFiNE MCP Server working and confirm that your MCP client can reach AFFiNE successfully.
+
+## Choose a setup path
+
+| Scenario | Recommended path |
+| --- | --- |
+| Local MCP client on your machine | Use the saved-config flow with `affine-mcp login` |
+| AFFiNE Cloud | Use an API token |
+| Self-hosted AFFiNE | Use an API token, or email/password if your instance allows it |
+| Temporary usage without a global install | Use `npx` |
+| Run the server in Docker | Use the GHCR image and HTTP transport |
+| Remote MCP deployment | Skip to [configuration and deployment](configuration-and-deployment.md) |
+
+## Path A: Saved config with interactive login
+
+This is the recommended local setup because it keeps client config minimal and avoids repeated environment-variable configuration.
+
+### 1. Install the CLI
+
+```bash
+npm i -g affine-mcp-server
+affine-mcp --version
+```
+
+### 2. Save credentials
+
+```bash
+affine-mcp login
+```
+
+What happens:
+
+- The CLI asks for your AFFiNE base URL
+- For AFFiNE Cloud, it prompts for an API token
+- For self-hosted AFFiNE, it can sign in with email/password and generate a token automatically
+- The effective config is stored at `~/.config/affine-mcp/config`
+
+### 3. Verify the saved config
+
+```bash
+affine-mcp status
+affine-mcp doctor
+```
+
+### 4. Register the server with a client
+
+Minimal stdio config:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "affine-mcp"
+    }
+  }
+}
+```
+
+See [client setup](client-setup.md) for full client-specific snippets.
+
+## Path B: Explicit environment variables
+
+Use this path when you prefer stateless or container-friendly setup instead of a saved config file.
+
+### Required variables
+
+- `AFFINE_BASE_URL`
+- One auth strategy:
+  - `AFFINE_API_TOKEN`
+  - `AFFINE_COOKIE`
+  - `AFFINE_EMAIL` and `AFFINE_PASSWORD`
+
+### Example: AFFiNE Cloud
+
+```bash
+export AFFINE_BASE_URL="https://app.affine.pro"
+export AFFINE_API_TOKEN="ut_xxx"
+affine-mcp status
+```
+
+### Example: self-hosted AFFiNE with email/password
+
+```bash
+export AFFINE_BASE_URL="https://your-affine.example.com"
+export AFFINE_EMAIL="you@example.com"
+export AFFINE_PASSWORD="secret"
+affine-mcp status
+```
+
+For the full environment-variable reference, see [configuration and deployment](configuration-and-deployment.md#environment-variables).
+
+## Path C: Run from the Docker image
+
+Use this when:
+
+- you want a containerized local or remote deployment
+- you prefer an HTTP MCP endpoint over stdio
+- you do not want to install Node.js on the target host
+
+```bash
+docker run -d \
+  -p 3000:3000 \
+  -e MCP_TRANSPORT=http \
+  -e AFFINE_BASE_URL=https://your-affine-instance.com \
+  -e AFFINE_API_TOKEN=ut_your_token \
+  -e AFFINE_MCP_AUTH_MODE=bearer \
+  -e AFFINE_MCP_HTTP_TOKEN=your-strong-secret \
+  ghcr.io/dawncr0w/affine-mcp-server:latest
+```
+
+Quick verification:
+
+```bash
+curl http://localhost:3000/healthz
+curl http://localhost:3000/readyz
+```
+
+Client-side MCP config:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "Authorization": "Bearer your-strong-secret"
+      }
+    }
+  }
+}
+```
+
+For OAuth mode, origin controls, and deployment hardening, continue with [configuration and deployment](configuration-and-deployment.md#docker).
+
+## Path D: Run from a local clone
+
+Use this when you want to inspect or modify the server locally.
+
+```bash
+git clone https://github.com/dawncr0w/affine-mcp-server.git
+cd affine-mcp-server
+npm install
+npm run build
+node dist/index.js
+```
+
+You can also expose a linked CLI locally:
+
+```bash
+npm link
+affine-mcp --version
+```
+
+## Verify your setup
+
+Use this sequence after any first-run setup:
+
+```bash
+affine-mcp status
+affine-mcp show-config
+affine-mcp doctor
+```
+
+If you are running the Docker image, also verify:
+
+```bash
+curl http://localhost:3000/healthz
+curl http://localhost:3000/readyz
+```
+
+Expected results:
+
+- `status` confirms the active base URL, auth source, and connection result
+- `show-config` prints the effective configuration with secrets redacted
+- `doctor` checks config shape and connectivity and points to the failing layer
+- `healthz` and `readyz` return successful probe responses when the HTTP server is healthy
+
+If you are onboarding another client, these helpers can generate snippets from the current config:
+
+```bash
+affine-mcp snippet claude --env
+affine-mcp snippet codex --env
+affine-mcp snippet all --env
+```
+
+## Common first-run failures
+
+### Cloudflare blocks email/password sign-in
+
+AFFiNE Cloud (`app.affine.pro`) is behind Cloudflare. Programmatic requests to `/api/auth/sign-in` are blocked.
+
+Use:
+
+- `AFFINE_API_TOKEN`
+- or `affine-mcp login`, which guides you toward the supported path
+
+### Saved config exists, but the client cannot connect
+
+Run:
+
+```bash
+affine-mcp status
+affine-mcp doctor
+```
+
+Then verify that the client is invoking `affine-mcp` from the same environment where the config file exists.
+
+### Workspace is missing
+
+This server can access only server-backed AFFiNE workspaces.
+
+It cannot access workspaces that exist only in browser local storage.
+
+### "Method not found" when calling a tool
+
+MCP tools are not JSON-RPC top-level method names. Use an MCP client that calls `tools/list` and `tools/call` instead of sending direct JSON-RPC methods such as `{"method":"list_workspaces"}`.
+
+### Self-hosted email/password does not work
+
+Confirm:
+
+- your instance exposes the standard auth endpoints
+- Cloudflare or another bot-protection layer is not blocking sign-in
+- the credentials are valid
+
+If in doubt, switch to an API token.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,0 +1,160 @@
+# Tool Reference
+
+`tool-manifest.json` is the source of truth for the canonical tool names exposed by this server.
+
+Use this document as a grouped catalog. For exact schemas, your MCP client should inspect `tools/list`.
+
+## Conventions
+
+- Canonical names only: legacy alias names are not part of the public tool surface
+- Document editing relies on AFFiNE WebSocket-backed operations where noted
+- Experimental organize tools are marked explicitly
+- Use tool filtering in production if you want a reduced or read-only surface
+
+## Workspace
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_workspaces` | List all available workspaces | Good first discovery step |
+| `get_workspace` | Read workspace details | Includes settings and metadata |
+| `create_workspace` | Create a workspace with an initial document | Destructive in the sense that it creates new server state |
+| `update_workspace` | Update workspace settings | Use carefully in shared workspaces |
+| `delete_workspace` | Permanently delete a workspace | Destructive |
+| `list_workspace_tree` | Return the workspace document hierarchy as a tree | Useful before moving docs |
+| `get_orphan_docs` | Find documents that are not linked from a parent doc | Useful for cleanup and audits |
+
+## Organization
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_collections` | List workspace collections | |
+| `get_collection` | Read a collection by id | |
+| `create_collection` | Create a collection | |
+| `update_collection` | Rename a collection | |
+| `delete_collection` | Delete a collection | Destructive |
+| `add_doc_to_collection` | Add a document to a collection allow-list | |
+| `remove_doc_from_collection` | Remove a document from a collection allow-list | |
+| `list_organize_nodes` | Dump the organize or folder tree | Experimental |
+| `create_folder` | Create a root or nested folder | Experimental |
+| `rename_folder` | Rename a folder | Experimental |
+| `delete_folder` | Delete a folder recursively | Experimental and destructive |
+| `move_organize_node` | Move a folder or link node | Experimental |
+| `add_organize_link` | Add a doc, tag, or collection link under a folder | Experimental |
+| `delete_organize_link` | Delete a doc, tag, or collection link | Experimental and destructive |
+
+## Documents
+
+### Discovery and metadata
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_docs` | List documents with pagination | Includes `node.tags` |
+| `list_tags` | List all tags in a workspace | |
+| `search_docs` | Search titles with substring, prefix, or exact matching | Supports tag filter and updatedAt sorting |
+| `list_docs_by_tag` | List documents with a specific tag | |
+| `get_docs_by_tag` | Search documents by case-insensitive tag substring | Returns `availableTags` when nothing matches |
+| `get_doc` | Read document metadata | |
+| `get_doc_by_title` | Find a document by title and return Markdown content | Useful for title-based lookup |
+| `read_doc` | Read block content and plain text snapshot | WebSocket-backed |
+| `list_children` | List direct child docs linked from a document | |
+| `list_backlinks` | List parent or reference docs that link to a document | |
+
+### Publish and visibility
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `publish_doc` | Make a document public | |
+| `revoke_doc` | Revoke public access | |
+
+### Create, duplicate, and move
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `create_doc` | Create a new document | WebSocket-backed |
+| `create_doc_from_markdown` | Create a document from Markdown content | |
+| `create_doc_from_template` | Clone a template doc and substitute `{{variables}}` | Can optionally link the new doc under a parent |
+| `duplicate_doc` | Clone a document into a new doc | Can optionally place the copy under a parent |
+| `move_doc` | Move a document in the sidebar by relinking it under another parent | |
+| `batch_create_docs` | Create up to 20 documents in one call | |
+| `delete_doc` | Delete a document | WebSocket-backed and destructive |
+
+### Content editing
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `update_doc_title` | Rename a document in workspace metadata and in the page block | |
+| `append_paragraph` | Append a paragraph block | WebSocket-backed |
+| `append_block` | Append canonical block types with validation and placement control | Supports text, media, embeds, database, and edgeless blocks |
+| `append_markdown` | Append Markdown content to an existing document | |
+| `replace_doc_with_markdown` | Replace the main note content with Markdown | Overwrites main note content |
+| `find_and_replace` | Preview or apply text replacement across a document | |
+| `cleanup_orphan_embeds` | Remove linked-doc embeds that point to missing docs | Cleanup-oriented |
+
+### Tags
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `create_tag` | Create a reusable workspace-level tag | |
+| `add_tag_to_doc` | Attach a tag to a document | |
+| `remove_tag_from_doc` | Detach a tag from a document | |
+
+### Markdown export
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `export_doc_markdown` | Export document content as Markdown | Useful for backup and automation |
+
+## Database blocks
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `add_database_column` | Add a column to a database block | Supports `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date` |
+| `add_database_row` | Add a row to a database block | Can set the built-in title field |
+| `delete_database_row` | Delete a row by row block id | Destructive |
+| `read_database_columns` | Read schema metadata, types, options, and view mappings | Useful before edits |
+| `read_database_cells` | Read row titles and decoded cell values | Supports row and column filters |
+| `update_database_cell` | Update a single cell or built-in title | `createOption` defaults to `true` for select-like fields |
+| `update_database_row` | Update multiple cells on a row at once | `createOption` defaults to `true` |
+
+## Comments
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_comments` | List comments on a document | |
+| `create_comment` | Create a comment on a document | |
+| `update_comment` | Update comment content | |
+| `delete_comment` | Delete a comment | Destructive |
+| `resolve_comment` | Resolve or unresolve a comment | |
+
+## Version History
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_histories` | List document history timestamps | |
+
+## Users and tokens
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `current_user` | Return the current signed-in user | |
+| `sign_in` | Sign in with email and password | Self-hosted flows only for direct programmatic sign-in |
+| `update_profile` | Update current user profile data | |
+| `update_settings` | Update user notification preferences | |
+| `list_access_tokens` | List personal access tokens | |
+| `generate_access_token` | Create a personal access token | Sensitive operation |
+| `revoke_access_token` | Revoke a personal access token | Destructive |
+
+## Notifications
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `list_notifications` | List notifications for the current user | |
+| `read_all_notifications` | Mark notifications as read | |
+
+## Blob storage
+
+| Tool | Purpose | Notes |
+| --- | --- | --- |
+| `upload_blob` | Upload a file or blob to workspace storage | |
+| `delete_blob` | Delete a blob from workspace storage | Destructive |
+| `cleanup_blobs` | Permanently remove deleted blobs | Cleanup-oriented |

--- a/docs/workflow-recipes.md
+++ b/docs/workflow-recipes.md
@@ -1,0 +1,147 @@
+# Workflow Recipes
+
+This guide shows practical tool sequences for common AFFiNE workflows.
+
+The exact JSON schema for each tool is discoverable from MCP `tools/list`. The recipes below focus on tool selection and ordering.
+
+## 1. Discover the right workspace and document
+
+Use when:
+
+- you are connecting to an AFFiNE instance for the first time
+- you need to locate a document before editing it
+
+Typical tool sequence:
+
+1. `list_workspaces`
+2. `list_docs` or `search_docs`
+3. `get_doc` or `read_doc`
+
+Prompt example:
+
+> List my workspaces, find the document titled "Launch Plan", and show me its current structure before editing anything.
+
+## 2. Create a document and place it in the sidebar tree
+
+Use when:
+
+- you need a new document under an existing parent doc
+- you want the new page to be visible in the workspace tree immediately
+
+Typical tool sequence:
+
+1. `search_docs` or `get_doc_by_title` to find the parent
+2. `create_doc` or `create_doc_from_markdown`
+3. `move_doc` if you created the doc before deciding its final parent
+4. `list_children` to verify placement
+
+Prompt example:
+
+> Create a document called "Q2 Notes" under "Team Wiki", then verify that it appears as a child page.
+
+## 3. Find documents by tag or title and clean up metadata
+
+Use when:
+
+- titles are inconsistent
+- tags exist but you are not sure which document to open
+
+Typical tool sequence:
+
+1. `list_tags`
+2. `get_docs_by_tag` or `list_docs_by_tag`
+3. `update_doc_title`
+4. `add_tag_to_doc` or `remove_tag_from_doc`
+
+Prompt example:
+
+> Show me documents related to onboarding, rename the outdated title, and make sure the page has the `Onboarding` tag.
+
+## 4. Append content or replace the main note
+
+Use when:
+
+- you need to add content incrementally
+- you already have Markdown content to import
+
+Typical tool sequence:
+
+1. `read_doc`
+2. `append_paragraph`, `append_block`, or `append_markdown`
+3. `replace_doc_with_markdown` only when you intend to overwrite the main note
+
+Prompt example:
+
+> Read the current document, append a short release checklist section, and leave the existing content intact.
+
+## 5. Work with database blocks
+
+Use when:
+
+- you want to inspect or update an AFFiNE database
+- you need to add rows or change schema
+
+Typical tool sequence:
+
+1. `read_doc` to inspect the page structure
+2. `read_database_columns` to inspect schema
+3. `add_database_column` if needed
+4. `add_database_row`
+5. `update_database_cell` or `update_database_row`
+6. `read_database_cells` to verify
+
+Prompt example:
+
+> Inspect the task database on this page, add a `Due Date` column if it is missing, then add a new task row and verify the final values.
+
+## 6. Review comments and resolve them
+
+Use when:
+
+- you need to triage feedback on a document
+- you want to update or resolve comments after an edit
+
+Typical tool sequence:
+
+1. `list_comments`
+2. `create_comment` or `update_comment`
+3. `resolve_comment`
+
+Prompt example:
+
+> List unresolved comments on the document, summarize them, and resolve the ones that are already addressed in the current draft.
+
+## 7. Publish a document or revoke public access
+
+Use when:
+
+- you are moving a document from draft to public view
+- you need to remove public access after review
+
+Typical tool sequence:
+
+1. `get_doc`
+2. `publish_doc` or `revoke_doc`
+3. `get_doc` again to confirm visibility state
+
+Prompt example:
+
+> Publish the final release notes page and confirm that public access is enabled.
+
+## 8. Export, duplicate, or clean up linked structure
+
+Use when:
+
+- you need a markdown backup
+- you want to clone a page
+- you need to remove stale linked-doc embeds
+
+Typical tool sequence:
+
+1. `export_doc_markdown` or `duplicate_doc`
+2. `list_backlinks` or `list_children` if you need structural context
+3. `cleanup_orphan_embeds` if linked-doc embeds reference deleted pages
+
+Prompt example:
+
+> Duplicate the template page under the current parent, export the original as Markdown, and clean up any orphaned linked-doc embeds on the copy.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   "files": [
     "bin",
     "dist",
+    "docs",
     "README.md",
+    "tool-manifest.json",
     "LICENSE"
   ],
   "engines": {


### PR DESCRIPTION
# TL;DR
- Rework the repository documentation into a product-style MCP onboarding flow.
- Split detailed setup, deployment, workflows, and tool catalog content into dedicated docs pages.
- Promote Docker to a first-class setup path instead of leaving it buried in deployment guidance.

# Context
The previous README had accurate setup and tool information, but it behaved more like a long reference dump than a product-grade entry point. Important paths such as Docker and remote HTTP deployment were documented, but they were not visible early enough for first-time users. This change makes the top-level README a landing page and moves detailed material into focused docs pages.

# Changes
- Convert `README.md` into a shorter landing page with a table of contents, a choose-your-path section, a quick start, a compatibility matrix, and a docs map.
- Add dedicated docs for getting started, client setup, configuration and deployment, workflow recipes, and grouped tool reference.
- Add Docker quick-start guidance to the README and getting-started flow, including health-check verification.
- Include `docs/` and `tool-manifest.json` in the published package contents.
