### PR TITLE
chore: sync v2.0.0 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-07
+
 ### Added
 - First-class edgeless canvas support on the native BlockSuite schema (no overlay types). Eight new tools cover the full surface: `add_surface_element`, `list_surface_elements`, `update_surface_element`, `delete_surface_element` (shapes, connectors, canvas text, groups on `affine:surface` → `prop:elements`), plus `update_edgeless_block`, `delete_block`, `update_frame_children`, and `get_edgeless_canvas` — closing the gap where notes, frames, and edgeless-text blocks were append-only.
 - Layout helpers on `append_block`: `x` / `y` for canvas blocks, `stackAfter` for direction-aware placement relative to one or more siblings (default gap 80px horizontal / 40px vertical, orthogonal-axis centering), `childElementIds` to write `prop:childElementIds` like the editor's drag-into-frame flow so dragging the frame drags every owned member. When `y` is omitted, new edgeless blocks stack below the bottommost existing block.
@@ -15,11 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Markdown-seeded notes: `append_block(type="note", markdown: "...")` parses into heading / paragraph / list / code child blocks, mirroring BlockSuite's paste-into-note behavior. `append_block(type="edgeless_text", text: "…")` auto-attaches a child paragraph so the block renders glyphs.
 - `src/edgeless/layout.ts` — dependency-free pure-function layout module (`pickConnectorSides`, `stackRelativeTo`, `encloseBounds`, `estimateNoteHeightForMarkdown`, `sortByFractionalIndex`, …).
 - `docs/edgeless-canvas-cookbook.md` worked walkthrough; `tests/test-canvas-tool-map-demo.mjs` doubles as the regression guard for stacking, frame ownership, connector snapping, and label seeding, wired into `tests/run-e2e.sh`.
+- Tool surface profiles via `AFFINE_TOOL_PROFILE=full`, `read_only`, `core`, or `authoring` for least-privilege deployments.
+
+### Changed
+- Breaking: the public tool surface was reduced from the unreleased 95 registered tools to 84 canonical tools by removing redundant convenience tools and consolidating overlapping flows behind the canonical APIs.
+- `get_capabilities`, `tool-manifest.json`, and `tools/list` now report the same public surface, including profile-filtered views.
 
 ### Fixed
 - `extractTableData` now reads `affine:table` blocks stored with flat dot-notation Y.js keys (`prop:rows.{rowId}.order`, `prop:columns.{colId}.order`, `prop:cells.{rowId}:{colId}.text`) used by self-hosted AFFiNE instances. Previously `block.get("prop:rows")` returned `undefined` for this schema, causing all table exports to show empty tables with `had no readable cell data` warnings.
-- Caller-supplied note `background` strings are no longer silently replaced with the default Y.Map. The default-background helper is now shared across `ensureNoteBlock`, `batch_create_docs`, and template instantiation so they can't drift — closes the PR #142 review blocker.
+- Caller-supplied note `background` strings are no longer silently replaced with the default Y.Map. The default-background helper is now shared across note creation and template instantiation so they cannot drift.
 - Default stroke and text colors on surface connectors, canvas text, and edgeless-text blocks moved off hardcoded `#000000` onto `--affine-text-primary-color`, restoring legibility in dark mode. Shape labels stay at `#000000` to match AFFiNE's native `shapeTextColor` (shape fills are fixed palette colors).
+- Tool filtering now fails closed when profiles or disabled-tool configuration reference unknown tools.
+
+### Removed
+- Removed redundant public tools: `append_paragraph`, `batch_create_docs`, `cleanup_orphan_embeds`, `create_doc_from_template`, `duplicate_doc`, `find_and_replace`, `get_doc_by_title`, `get_docs_by_tag`, `list_backlinks`, `list_unresolved_threads`, and `update_database_cell`.
+
+### Tests
+- Added focused coverage for tool surface profile filtering and manifest consistency.
 
 ## [1.13.0] - 2026-04-10
 
@@ -423,6 +437,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[2.0.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.0.0
 [1.13.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.13.0
 [1.12.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.12.0
 [1.11.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.11.2
@@ -444,4 +459,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v2.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-1.13.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-2.0.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -38,7 +38,7 @@ Highlights:
 - Supports AFFiNE Cloud and self-hosted AFFiNE instances
 - Supports stdio and HTTP transports
 - Supports token, cookie, and email/password authentication
-- Exposes 87 canonical MCP tools backed by AFFiNE GraphQL and WebSocket APIs
+- Exposes 84 canonical MCP tools backed by AFFiNE GraphQL and WebSocket APIs
 - Includes semantic page composition, native template instantiation, database intent composition, capability and fidelity reporting, and workspace blueprint helpers
 - Includes Docker images, health probes, and end-to-end test coverage
 
@@ -48,7 +48,7 @@ Scope boundaries:
 - Browser-local workspaces stored only in local storage are not available through AFFiNE server APIs
 - AFFiNE Cloud requires API-token-based access for MCP usage; programmatic email/password sign-in is blocked by Cloudflare
 
-> New in v1.13.0: Added high-level semantic page, native template, fidelity, and workspace blueprint workflows, plus structured receipts and productized setup docs.
+> New in v2.0.0: Added native edgeless canvas tools and shipped a slimmer 84-tool public surface with least-privilege profiles for read-only, core, and authoring deployments.
 
 ## Choose Your Path
 | Goal | Start here |
@@ -178,7 +178,7 @@ Domains:
 - Notifications: list and mark notifications as read
 - Blob storage: upload, delete, and cleanup blobs
 
-Use `AFFINE_TOOL_PROFILE=read_only`, `core`, or `authoring` when a deployment should expose a smaller surface than the backward-compatible `full` default. You can also combine profiles with `AFFINE_DISABLED_GROUPS` such as `docs.database`, `destructive`, or `admin` for finer control.
+Use `AFFINE_TOOL_PROFILE=read_only`, `core`, or `authoring` when a deployment should expose a smaller surface than the complete `full` default. You can also combine profiles with `AFFINE_DISABLED_GROUPS` such as `docs.database`, `destructive`, or `admin` for finer control.
 
 For the grouped catalog, notes, and operational caveats, see [docs/tool-reference.md](docs/tool-reference.md).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## Version 2.0.0 (2026-05-07)
+
+### Highlights
+- Added native edgeless canvas coverage for surface elements, edgeless blocks, frame ownership, connector auto-snap, and canvas inspection.
+- Added least-privilege tool profiles for `full`, `read_only`, `core`, and `authoring` deployments.
+- Reduced the public MCP surface to 84 canonical tools by removing redundant convenience tools that overlapped with canonical document, search, database, comment, and template flows.
+- Hardened tool-surface reporting so `tools/list`, `get_capabilities`, and `tool-manifest.json` stay aligned.
+
+### What Changed
+- `src/edgeless/layout.ts`, `src/tools/docs.ts`
+  - Added native BlockSuite edgeless layout helpers, surface element CRUD, edgeless block updates, frame child ownership updates, and full canvas inspection.
+  - Added markdown-seeded note creation and deterministic canvas ordering for reliable round trips.
+- `src/index.ts`, `src/toolSurface.ts`, `tool-manifest.json`
+  - Added profile-aware tool registration and fail-closed filtering for unknown tool references.
+  - Reduced the canonical public manifest to 84 tools.
+  - Removed `append_paragraph`, `batch_create_docs`, `cleanup_orphan_embeds`, `create_doc_from_template`, `duplicate_doc`, `find_and_replace`, `get_doc_by_title`, `get_docs_by_tag`, `list_backlinks`, `list_unresolved_threads`, and `update_database_cell` from the public MCP surface.
+- `docs/configuration-and-deployment.md`, `docs/tool-reference.md`, `README.md`, `CHANGELOG.md`, `RELEASE_NOTES.md`
+  - Documented tool profiles, updated the public tool count, and refreshed release metadata for the breaking release.
+- `tests/test-tool-filtering.mjs`, `scripts/verify-tool-manifest.mjs`, `tests/test-canvas-tool-map-demo.mjs`
+  - Added regression coverage for profile counts, removed public tools, manifest consistency, and edgeless canvas layout behavior.
+- `package.json`, `package-lock.json`, `tool-manifest.json`, `README.md`, `CHANGELOG.md`, `RELEASE_NOTES.md`
+  - Bumped release metadata to `2.0.0`.
+
+### Validation Evidence
+- Release sanity gate passed:
+  - `npm run ci`
+- Focused verification passed:
+  - `npm run test:tool-filtering`
+  - `npm run test:cli-version`
+- Focused live verification previously passed on the release candidate changes:
+  - `npm run test:comprehensive`
+
 ## Version 1.13.0 (2026-04-10)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "1.13.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.0",
+  "version": "2.0.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
# TL;DR
Sync the v2.0.0 release metadata from the published `main` release back into `develop`.

# Context
The direct `main -> develop` sync PR could not be merged cleanly by GitHub because `main` contains the squashed release commit. This branch starts from `develop` and applies only the six release metadata files from the published v2.0.0 `main` state.

# Changes
- sync `package.json`, `package-lock.json`, `tool-manifest.json`, `README.md`, `CHANGELOG.md`, and `RELEASE_NOTES.md`
- keep `develop` aligned with the published v2.0.0 release metadata
- verify with `npm run ci` and a Hangul scan
