### PR TITLE
fix(markdown): preserve inline rich text formatting on export

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
+    "test:markdown-rich-text-export": "node tests/test-markdown-rich-text-export.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
     "ci": "npm run build && npm run test:tool-manifest && npm run pack:check",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
+    "test:markdown-rich-text-import-live": "node tests/test-markdown-rich-text-import-live.mjs",
     "test:markdown-rich-text-export": "node tests/test-markdown-rich-text-export.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:markdown-rich-text-import-live": "node tests/test-markdown-rich-text-import-live.mjs",
+    "test:markdown-stdio-live": "node tests/test-markdown-stdio-live.mjs",
     "test:markdown-rich-text-export": "node tests/test-markdown-rich-text-export.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -1,4 +1,4 @@
-import type { MarkdownRenderResult, MarkdownRenderableBlock } from "./types.js";
+import type { MarkdownRenderResult, MarkdownRenderableBlock, TextDelta } from "./types.js";
 
 type RenderState = {
   blocksById: Map<string, MarkdownRenderableBlock>;
@@ -65,6 +65,49 @@ function renderTable(tableData: string[][]): string[] {
   ];
 }
 
+export function deltasToMarkdown(deltas: TextDelta[]): string {
+  // Bold and italic markers are streamed across adjacent runs so that shared
+  // formatting is not closed and reopened at every boundary.
+  // e.g. [{bold}, {bold+italic}, {bold}] → "**text *inner* text**"
+  // Code, link, and strike are always self-contained wrappers.
+  let result = "";
+  let boldOpen = false;
+  let italicOpen = false;
+
+  const flushBoldItalic = () => {
+    if (italicOpen) { result += "*"; italicOpen = false; }
+    if (boldOpen) { result += "**"; boldOpen = false; }
+  };
+
+  for (const d of deltas) {
+    const attrs = d.attributes ?? {};
+    const wantBold = attrs.bold === true;
+    const wantItalic = attrs.italic === true;
+
+    if (attrs.code || attrs.link || attrs.strike) {
+      flushBoldItalic();
+      let inner = d.insert;
+      if (attrs.code) { result += `\`${inner}\``; continue; }
+      if (wantBold && wantItalic) { inner = `***${inner}***`; }
+      else if (wantBold) { inner = `**${inner}**`; }
+      else if (wantItalic) { inner = `*${inner}*`; }
+      if (attrs.link) { inner = `[${inner.replace(/]/g, "\\]")}](${attrs.link})`; }
+      if (attrs.strike) { inner = `~~${inner}~~`; }
+      result += inner;
+      continue;
+    }
+
+    if (italicOpen && !wantItalic) { result += "*"; italicOpen = false; }
+    if (boldOpen && !wantBold) { result += "**"; boldOpen = false; }
+    if (wantBold && !boldOpen) { result += "**"; boldOpen = true; }
+    if (wantItalic && !italicOpen) { result += "*"; italicOpen = true; }
+    result += d.insert;
+  }
+
+  flushBoldItalic();
+  return result;
+}
+
 function childList(block: MarkdownRenderableBlock): string[] {
   return Array.isArray(block.childIds) ? block.childIds : [];
 }
@@ -86,7 +129,9 @@ function renderBlock(
     return { lines: [], isList: false };
   }
 
-  const text = (block.text ?? "").trim();
+  const text = (block.deltas && block.deltas.length > 0
+    ? deltasToMarkdown(block.deltas)
+    : (block.text ?? "")).trim();
   const flavour = block.flavour ?? "";
   const type = block.type ?? "";
   const children = childList(block);

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -36,7 +36,11 @@ function escapePipe(value: string): string {
   return value.replace(/\|/g, "\\|");
 }
 
-function renderTable(tableData: string[][]): string[] {
+function renderCell(text: string, deltas: TextDelta[] | undefined): string {
+  return escapePipe(deltas && deltas.length > 0 ? deltasToMarkdown(deltas) : text);
+}
+
+function renderTable(tableData: string[][], tableCellDeltas?: TextDelta[][][]): string[] {
   if (tableData.length === 0) {
     return ["| |", "| --- |"];
   }
@@ -54,9 +58,13 @@ function renderTable(tableData: string[][]): string[] {
     return copy;
   });
 
-  const header = normalized[0].map(escapePipe);
+  const header = normalized[0].map((cell, colIdx) =>
+    renderCell(cell, tableCellDeltas?.[0]?.[colIdx])
+  );
   const separator = new Array(columns).fill("---");
-  const body = normalized.slice(1).map(row => `| ${row.map(cell => escapePipe(cell ?? "")).join(" | ")} |`);
+  const body = normalized.slice(1).map((row, rowIdx) =>
+    `| ${row.map((cell, colIdx) => renderCell(cell, tableCellDeltas?.[rowIdx + 1]?.[colIdx])).join(" | ")} |`
+  );
 
   return [
     `| ${header.join(" | ")} |`,
@@ -66,45 +74,22 @@ function renderTable(tableData: string[][]): string[] {
 }
 
 export function deltasToMarkdown(deltas: TextDelta[]): string {
-  // Bold and italic markers are streamed across adjacent runs so that shared
-  // formatting is not closed and reopened at every boundary.
-  // e.g. [{bold}, {bold+italic}, {bold}] → "**text *inner* text**"
-  // Code, link, and strike are always self-contained wrappers.
+  // Each run is wrapped in its own self-contained markers so that partially
+  // overlapping bold/italic sequences (e.g. bold→bold+italic→italic) always
+  // produce valid, unambiguous markdown. `_` is used for italic and `**` for
+  // bold so the two delimiter characters never collide at run boundaries.
   let result = "";
-  let boldOpen = false;
-  let italicOpen = false;
-
-  const flushBoldItalic = () => {
-    if (italicOpen) { result += "*"; italicOpen = false; }
-    if (boldOpen) { result += "**"; boldOpen = false; }
-  };
-
   for (const d of deltas) {
     const attrs = d.attributes ?? {};
-    const wantBold = attrs.bold === true;
-    const wantItalic = attrs.italic === true;
-
-    if (attrs.code || attrs.link || attrs.strike) {
-      flushBoldItalic();
-      let inner = d.insert;
-      if (attrs.code) { result += `\`${inner}\``; continue; }
-      if (wantBold && wantItalic) { inner = `***${inner}***`; }
-      else if (wantBold) { inner = `**${inner}**`; }
-      else if (wantItalic) { inner = `*${inner}*`; }
-      if (attrs.link) { inner = `[${inner.replace(/]/g, "\\]")}](${attrs.link})`; }
-      if (attrs.strike) { inner = `~~${inner}~~`; }
-      result += inner;
-      continue;
-    }
-
-    if (italicOpen && !wantItalic) { result += "*"; italicOpen = false; }
-    if (boldOpen && !wantBold) { result += "**"; boldOpen = false; }
-    if (wantBold && !boldOpen) { result += "**"; boldOpen = true; }
-    if (wantItalic && !italicOpen) { result += "*"; italicOpen = true; }
-    result += d.insert;
+    let inner = d.insert;
+    if (attrs.code) { result += `\`${inner}\``; continue; }
+    if (attrs.bold && attrs.italic) { inner = `**_${inner}_**`; }
+    else if (attrs.bold) { inner = `**${inner}**`; }
+    else if (attrs.italic) { inner = `_${inner}_`; }
+    if (attrs.link) { inner = `[${inner.replace(/]/g, "\\]")}](${attrs.link})`; }
+    if (attrs.strike) { inner = `~~${inner}~~`; }
+    result += inner;
   }
-
-  flushBoldItalic();
   return result;
 }
 
@@ -227,7 +212,7 @@ function renderBlock(
         return { lines: ["| |", "| --- |"], isList: false };
       }
       return {
-        lines: renderTable(block.tableData),
+        lines: renderTable(block.tableData, block.tableCellDeltas),
         isList: false,
       };
     }

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -73,21 +73,88 @@ function renderTable(tableData: string[][], tableCellDeltas?: TextDelta[][][]): 
   ];
 }
 
-export function deltasToMarkdown(deltas: TextDelta[]): string {
-  // Each run is wrapped in its own self-contained markers so that partially
-  // overlapping bold/italic sequences (e.g. bold→bold+italic→italic) always
-  // produce valid, unambiguous markdown. `_` is used for italic and `**` for
-  // bold so the two delimiter characters never collide at run boundaries.
-  let result = "";
+function attrsEqual(a: TextDelta["attributes"], b: TextDelta["attributes"]): boolean {
+  const aA = a ?? {};
+  const bA = b ?? {};
+  return (
+    !!aA.bold === !!bA.bold &&
+    !!aA.italic === !!bA.italic &&
+    !!aA.strike === !!bA.strike &&
+    !!aA.code === !!bA.code &&
+    (aA.link ?? null) === (bA.link ?? null)
+  );
+}
+
+// Coalesce adjacent runs with identical attributes and drop empty inserts.
+// Adjacent same-attribute runs would otherwise produce delimiter doublings
+// (e.g. `**A****B**`), which CommonMark parses as literal asterisks inside
+// the span.  An empty-insert run with marks would emit floating delimiters
+// for nothing — easiest to skip outright.
+function coalesceDeltas(deltas: TextDelta[]): TextDelta[] {
+  const result: TextDelta[] = [];
   for (const d of deltas) {
+    if (d.insert === "") continue;
+    const last = result[result.length - 1];
+    if (last && attrsEqual(last.attributes, d.attributes)) {
+      result[result.length - 1] = { ...last, insert: last.insert + d.insert };
+    } else {
+      result.push(d);
+    }
+  }
+  return result;
+}
+
+// Build a code span with a backtick fence longer than any run of backticks in
+// the content, padding with spaces if the content starts or ends with a
+// backtick (CommonMark strips one leading/trailing space when both are present).
+function emitCodeFence(content: string): string {
+  let max = 0;
+  let cur = 0;
+  for (let i = 0; i < content.length; i += 1) {
+    if (content[i] === "`") {
+      cur += 1;
+      if (cur > max) max = cur;
+    } else {
+      cur = 0;
+    }
+  }
+  const fence = "`".repeat(max + 1);
+  const pad = content.startsWith("`") || content.endsWith("`") ? " " : "";
+  return `${fence}${pad}${content}${pad}${fence}`;
+}
+
+export function deltasToMarkdown(deltas: TextDelta[]): string {
+  // Each run is wrapped in standard CommonMark delimiters: `**bold**`,
+  // `_italic_`, and `***bold+italic***`.  Concatenating per-run keeps boundary
+  // parsing unambiguous — e.g. `**A*****B***_C_` parses as
+  // <strong>A</strong><em><strong>B</strong></em><em>C</em>, which round-trips
+  // back through parseMarkdownToOperations to the original delta structure.
+  // Underscore is used for standalone italic so it never sits next to a `**`
+  // bold delimiter; `***` for bold+italic avoids any `_` inside a `**...**`
+  // span (which CommonMark's intra-word-underscore rule would treat as literal).
+  let result = "";
+  for (const d of coalesceDeltas(deltas)) {
     const attrs = d.attributes ?? {};
     let inner = d.insert;
-    if (attrs.code) { result += `\`${inner}\``; continue; }
-    if (attrs.bold && attrs.italic) { inner = `**_${inner}_**`; }
-    else if (attrs.bold) { inner = `**${inner}**`; }
-    else if (attrs.italic) { inner = `_${inner}_`; }
-    if (attrs.link) { inner = `[${inner.replace(/]/g, "\\]")}](${attrs.link})`; }
-    if (attrs.strike) { inner = `~~${inner}~~`; }
+    if (attrs.code) {
+      inner = emitCodeFence(inner);
+    } else {
+      if (attrs.bold && attrs.italic) inner = `***${inner}***`;
+      else if (attrs.bold) inner = `**${inner}**`;
+      else if (attrs.italic) inner = `_${inner}_`;
+    }
+    if (attrs.link) {
+      const label = inner.replace(/]/g, "\\]");
+      // URLs with whitespace or angle brackets aren't valid in the
+      // non-angle-bracket destination form; switch to <…> and percent-encode
+      // any inner < or > so the destination remains parseable.
+      const needsAngle = /[\s<>]/.test(attrs.link);
+      const href = needsAngle
+        ? `<${attrs.link.replace(/</g, "%3C").replace(/>/g, "%3E")}>`
+        : attrs.link;
+      inner = `[${label}](${href})`;
+    }
+    if (attrs.strike) inner = `~~${inner}~~`;
     result += inner;
   }
   return result;

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -85,6 +85,7 @@ export type MarkdownRenderableBlock = {
   sourceId: string | null;
   caption: string | null;
   tableData: string[][] | null;
+  deltas?: TextDelta[];
 };
 
 export type MarkdownRenderResult = {

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -85,6 +85,7 @@ export type MarkdownRenderableBlock = {
   sourceId: string | null;
   caption: string | null;
   tableData: string[][] | null;
+  tableCellDeltas?: TextDelta[][][];
   deltas?: TextDelta[];
 };
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -391,6 +391,28 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return "";
   }
 
+  function asDeltaArray(value: unknown): TextDelta[] | undefined {
+    if (!(value instanceof Y.Text)) return undefined;
+    const raw = value.toDelta() as Array<{ insert?: unknown; attributes?: Record<string, unknown> }>;
+    if (!raw.length) return undefined;
+    const result: TextDelta[] = [];
+    for (const d of raw) {
+      if (typeof d.insert !== "string") continue;
+      const td: TextDelta = { insert: d.insert };
+      if (d.attributes) {
+        const attrs: NonNullable<TextDelta["attributes"]> = {};
+        if (d.attributes.bold === true) attrs.bold = true;
+        if (d.attributes.italic === true) attrs.italic = true;
+        if (d.attributes.strike === true) attrs.strike = true;
+        if (d.attributes.code === true) attrs.code = true;
+        if (typeof d.attributes.link === "string") attrs.link = d.attributes.link;
+        if (Object.keys(attrs).length > 0) td.attributes = attrs;
+      }
+      result.push(td);
+    }
+    return result.length ? result : undefined;
+  }
+
   function childIdsFrom(value: unknown): string[] {
     if (!(value instanceof Y.Array)) return [];
     const childIds: string[] = [];
@@ -2590,6 +2612,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         sourceId: asStringOrNull(block.get("prop:sourceId")),
         caption: asStringOrNull(block.get("prop:caption")),
         tableData: block.get("sys:flavour") === "affine:table" ? extractTableData(block) : null,
+        deltas: asDeltaArray(block.get("prop:text")),
       };
       blocksById.set(blockId, entry);
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2551,6 +2551,58 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return tableData;
   }
 
+  function extractTableCellDeltas(block: Y.Map<any>): TextDelta[][][] | null {
+    const rowsValue = block.get("prop:rows");
+    const columnsValue = block.get("prop:columns");
+    const cellsValue = block.get("prop:cells");
+
+    let rowEntries = mapEntries(rowsValue)
+      .map(([rowId, payload]) => ({
+        rowId,
+        order: payload && typeof payload === "object" && typeof (payload as any).order === "string"
+          ? (payload as any).order : rowId,
+      }))
+      .sort((a, b) => a.order.localeCompare(b.order));
+
+    let columnEntries = mapEntries(columnsValue)
+      .map(([columnId, payload]) => ({
+        columnId,
+        order: payload && typeof payload === "object" && typeof (payload as any).order === "string"
+          ? (payload as any).order : columnId,
+      }))
+      .sort((a, b) => a.order.localeCompare(b.order));
+
+    let cellDeltas = new Map<string, TextDelta[]>();
+
+    if (rowEntries.length === 0 || columnEntries.length === 0) {
+      const flatRows = new Map<string, string>();
+      const flatColumns = new Map<string, string>();
+      block.forEach((value: unknown, key: string) => {
+        const rowMatch = key.match(/^prop:rows\.([^.]+)\.order$/);
+        if (rowMatch) { flatRows.set(rowMatch[1], typeof value === "string" ? value : rowMatch[1]); return; }
+        const colMatch = key.match(/^prop:columns\.([^.]+)\.order$/);
+        if (colMatch) { flatColumns.set(colMatch[1], typeof value === "string" ? value : colMatch[1]); return; }
+        const cellMatch = key.match(/^prop:cells\.([^.]+:[^.]+)\.text$/);
+        if (cellMatch) { cellDeltas.set(cellMatch[1], asDeltaArray(value) ?? []); }
+      });
+      if (flatRows.size > 0 && flatColumns.size > 0) {
+        rowEntries = Array.from(flatRows.entries()).map(([rowId, order]) => ({ rowId, order })).sort((a, b) => a.order.localeCompare(b.order));
+        columnEntries = Array.from(flatColumns.entries()).map(([columnId, order]) => ({ columnId, order })).sort((a, b) => a.order.localeCompare(b.order));
+      }
+    } else {
+      for (const [cellKey, payload] of mapEntries(cellsValue)) {
+        if (payload instanceof Y.Map) { cellDeltas.set(cellKey, asDeltaArray(payload.get("text")) ?? []); continue; }
+        if (payload && typeof payload === "object" && "text" in payload) { cellDeltas.set(cellKey, asDeltaArray((payload as any).text) ?? []); }
+      }
+    }
+
+    if (rowEntries.length === 0 || columnEntries.length === 0) return null;
+
+    return rowEntries.map(({ rowId }) =>
+      columnEntries.map(({ columnId }) => cellDeltas.get(`${rowId}:${columnId}`) ?? [])
+    );
+  }
+
   function collectDocForMarkdown(
     doc: Y.Doc,
     tagOptionsById: Map<string, WorkspaceTagOption> = new Map()
@@ -2612,6 +2664,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         sourceId: asStringOrNull(block.get("prop:sourceId")),
         caption: asStringOrNull(block.get("prop:caption")),
         tableData: block.get("sys:flavour") === "affine:table" ? extractTableData(block) : null,
+        tableCellDeltas: block.get("sys:flavour") === "affine:table" ? extractTableCellDeltas(block) ?? undefined : undefined,
         deltas: asDeltaArray(block.get("prop:text")),
       };
       blocksById.set(blockId, entry);

--- a/tests/test-markdown-rich-text-export.mjs
+++ b/tests/test-markdown-rich-text-export.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for rich-text export fidelity (PR #176 review feedback).
+ *
+ * Two cases are covered:
+ *   1. Bold/italic partial overlap — the streaming marker state machine emitted
+ *      interleaved delimiters (e.g. **A*B**C*) that markdown parsers mis-read.
+ *      Self-contained per-run wrappers with `_` for italic fix both directions.
+ *   2. Table cell inline formatting — tableCellDeltas must be wired through the
+ *      renderer so bold/italic inside table cells survives export.
+ */
+import assert from 'node:assert/strict';
+import { deltasToMarkdown, renderBlocksToMarkdown } from '../dist/markdown/render.js';
+
+// ---------------------------------------------------------------------------
+// 1. Bold / italic partial overlap — direction A: bold → bold+italic → italic
+// ---------------------------------------------------------------------------
+function testBoldThenBoldItalicThenItalic() {
+  const deltas = [
+    { insert: 'A', attributes: { bold: true } },
+    { insert: 'B', attributes: { bold: true, italic: true } },
+    { insert: 'C', attributes: { italic: true } },
+  ];
+
+  const result = deltasToMarkdown(deltas);
+
+  // Each run is wrapped with self-contained markers; `_` is used for italic so
+  // that `**` (bold) and `_` (italic) delimiters never form ambiguous sequences.
+  assert.equal(result, '**A****_B_**_C_',
+    'bold → bold+italic → italic: self-contained per-run markers expected');
+
+  // Structural checks: bold marker wraps A and B, italic marker wraps B and C.
+  assert.ok(result.includes('**A**'), 'A should be wrapped in bold markers');
+  assert.ok(result.includes('**_B_**'), 'B should be wrapped in bold+italic markers');
+  assert.ok(result.includes('_C_'), 'C should be wrapped in italic markers');
+}
+
+// ---------------------------------------------------------------------------
+// 2. Bold / italic partial overlap — direction B: italic → bold+italic → bold
+// ---------------------------------------------------------------------------
+function testItalicThenBoldItalicThenBold() {
+  const deltas = [
+    { insert: 'A', attributes: { italic: true } },
+    { insert: 'B', attributes: { bold: true, italic: true } },
+    { insert: 'C', attributes: { bold: true } },
+  ];
+
+  const result = deltasToMarkdown(deltas);
+
+  assert.equal(result, '_A_**_B_****C**',
+    'italic → bold+italic → bold: self-contained per-run markers expected');
+
+  assert.ok(result.includes('_A_'), 'A should be wrapped in italic markers');
+  assert.ok(result.includes('**_B_**'), 'B should be wrapped in bold+italic markers');
+  assert.ok(result.includes('**C**'), 'C should be wrapped in bold markers');
+}
+
+// ---------------------------------------------------------------------------
+// 3. Table cells: inline formatting preserved via tableCellDeltas
+// ---------------------------------------------------------------------------
+function testTableCellRichText() {
+  const blocksById = new Map([
+    ['table-1', {
+      id: 'table-1',
+      parentId: null,
+      flavour: 'affine:table',
+      type: null,
+      text: null,
+      checked: null,
+      language: null,
+      childIds: [],
+      url: null,
+      sourceId: null,
+      caption: null,
+      // tableData provides the plain-text fallback
+      tableData: [
+        ['Name', 'Value'],
+        ['hello world', 'plain'],
+      ],
+      // tableCellDeltas carries inline formatting for each cell
+      tableCellDeltas: [
+        // Row 0 (header): "Name" bold, "Value" italic
+        [
+          [{ insert: 'Name', attributes: { bold: true } }],
+          [{ insert: 'Value', attributes: { italic: true } }],
+        ],
+        // Row 1: "hello " plain + "world" bold, "plain" unstyled
+        [
+          [{ insert: 'hello ' }, { insert: 'world', attributes: { bold: true } }],
+          [{ insert: 'plain' }],
+        ],
+      ],
+    }],
+  ]);
+
+  const result = renderBlocksToMarkdown({
+    rootBlockIds: ['table-1'],
+    blocksById,
+  });
+
+  const md = result.markdown;
+
+  // Header row must carry bold and italic markers
+  assert.ok(md.includes('**Name**'), 'header cell "Name" should be bold');
+  assert.ok(md.includes('_Value_'), 'header cell "Value" should be italic');
+
+  // Data row must have partially-bold cell text
+  assert.ok(md.includes('hello **world**'), 'data cell should have "world" in bold');
+
+  // Plain cell should pass through unchanged
+  assert.ok(md.includes('plain'), 'plain cell should appear unchanged');
+
+  // Separator row must be present
+  assert.ok(md.includes('| --- |'), 'table separator row must be present');
+}
+
+// ---------------------------------------------------------------------------
+// Run all tests
+// ---------------------------------------------------------------------------
+const tests = [
+  ['bold → bold+italic → italic (direction A)', testBoldThenBoldItalicThenItalic],
+  ['italic → bold+italic → bold (direction B)', testItalicThenBoldItalicThenBold],
+  ['table cell inline formatting via tableCellDeltas', testTableCellRichText],
+];
+
+let passed = 0;
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test-markdown-rich-text-export.mjs
+++ b/tests/test-markdown-rich-text-export.mjs
@@ -11,6 +11,29 @@
  */
 import assert from 'node:assert/strict';
 import { deltasToMarkdown, renderBlocksToMarkdown } from '../dist/markdown/render.js';
+import { parseMarkdownToOperations } from '../dist/markdown/parse.js';
+
+// Normalise a delta to only the truthy attributes so deepEqual comparisons
+// aren't sensitive to {bold: false} vs missing key.
+function normalizeDelta(d) {
+  const attrs = {};
+  if (d.attributes?.bold === true) attrs.bold = true;
+  if (d.attributes?.italic === true) attrs.italic = true;
+  if (d.attributes?.strike === true) attrs.strike = true;
+  if (d.attributes?.code === true) attrs.code = true;
+  if (d.attributes?.link) attrs.link = d.attributes.link;
+  return Object.keys(attrs).length > 0 ? { insert: d.insert, attributes: attrs } : { insert: d.insert };
+}
+
+// Parse the markdown string and return the deltas from the first operation.
+// Empty-insert deltas (which markdown-it emits between adjacent emphasis
+// spans) are dropped — they carry no content and aren't part of the original.
+function parsedDeltas(markdown) {
+  const result = parseMarkdownToOperations(markdown);
+  return (result.operations[0]?.deltas ?? [])
+    .filter(d => d.insert !== '')
+    .map(normalizeDelta);
+}
 
 // ---------------------------------------------------------------------------
 // 1. Bold / italic partial overlap — direction A: bold → bold+italic → italic
@@ -24,15 +47,14 @@ function testBoldThenBoldItalicThenItalic() {
 
   const result = deltasToMarkdown(deltas);
 
-  // Each run is wrapped with self-contained markers; `_` is used for italic so
-  // that `**` (bold) and `_` (italic) delimiters never form ambiguous sequences.
-  assert.equal(result, '**A****_B_**_C_',
-    'bold → bold+italic → italic: self-contained per-run markers expected');
+  // Standard per-run delimiters: **A** + ***B*** + _C_.  The concatenated
+  // `**A*****B***_C_` parses unambiguously through markdown-it.
+  assert.equal(result, '**A*****B***_C_',
+    'bold → bold+italic → italic: standard markdown delimiters expected');
 
-  // Structural checks: bold marker wraps A and B, italic marker wraps B and C.
-  assert.ok(result.includes('**A**'), 'A should be wrapped in bold markers');
-  assert.ok(result.includes('**_B_**'), 'B should be wrapped in bold+italic markers');
-  assert.ok(result.includes('_C_'), 'C should be wrapped in italic markers');
+  // Round-trip: markdown-it must parse back to the original delta structure.
+  assert.deepEqual(parsedDeltas(result), deltas.map(normalizeDelta),
+    'bold → bold+italic → italic: round-trip must preserve mark structure');
 }
 
 // ---------------------------------------------------------------------------
@@ -47,12 +69,14 @@ function testItalicThenBoldItalicThenBold() {
 
   const result = deltasToMarkdown(deltas);
 
-  assert.equal(result, '_A_**_B_****C**',
-    'italic → bold+italic → bold: self-contained per-run markers expected');
+  // Standard per-run delimiters: _A_ + ***B*** + **C**.  The concatenated
+  // `_A_***B*****C**` parses unambiguously through markdown-it.
+  assert.equal(result, '_A_***B*****C**',
+    'italic → bold+italic → bold: standard markdown delimiters expected');
 
-  assert.ok(result.includes('_A_'), 'A should be wrapped in italic markers');
-  assert.ok(result.includes('**_B_**'), 'B should be wrapped in bold+italic markers');
-  assert.ok(result.includes('**C**'), 'C should be wrapped in bold markers');
+  // Round-trip: markdown-it must parse back to the original delta structure.
+  assert.deepEqual(parsedDeltas(result), deltas.map(normalizeDelta),
+    'italic → bold+italic → bold: round-trip must preserve mark structure');
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +161,7 @@ function testCode() {
 // ---------------------------------------------------------------------------
 function testLinkBold() {
   const result = deltasToMarkdown([{ insert: 'text', attributes: { bold: true, link: 'https://example.com' } }]);
-  // bold wraps inner first, then link wraps the whole thing
+  // bold wraps the run text first, then link wraps the bold span.
   assert.equal(result, '[**text**](https://example.com)', 'bold+link should produce [**text**](url)');
 }
 
@@ -216,6 +240,110 @@ function testTableFallbackWithoutDeltas() {
 }
 
 // ---------------------------------------------------------------------------
+// 11. Corner cases — empty inputs, escape edges, mark combinations
+// ---------------------------------------------------------------------------
+function testEmptyDeltas() {
+  assert.equal(deltasToMarkdown([]), '', 'empty deltas array should produce empty markdown');
+}
+
+function testEmptyInsertSkipped() {
+  // An empty-insert run with marks would emit floating delimiters; it should
+  // be dropped, and surrounding runs coalesce naturally.
+  const deltas = [
+    { insert: 'A', attributes: { bold: true } },
+    { insert: '', attributes: { bold: true, italic: true } },
+    { insert: 'B', attributes: { italic: true } },
+  ];
+  const result = deltasToMarkdown(deltas);
+  assert.equal(result, '**A**_B_', 'empty insert should be skipped');
+  assert.deepEqual(parsedDeltas(result), [
+    { insert: 'A', attributes: { bold: true } },
+    { insert: 'B', attributes: { italic: true } },
+  ], 'empty-insert skip should round-trip cleanly');
+}
+
+function testAdjacentSameAttribute() {
+  // Adjacent runs sharing attributes coalesce so the output doesn't have
+  // back-to-back delimiter pairs that CommonMark would parse as literal.
+  const deltas = [
+    { insert: 'A', attributes: { bold: true } },
+    { insert: 'B', attributes: { bold: true } },
+  ];
+  assert.equal(deltasToMarkdown(deltas), '**AB**',
+    'adjacent same-attribute runs should coalesce');
+}
+
+function testUrlWithWhitespace() {
+  const result = deltasToMarkdown([{ insert: 'click', attributes: { link: 'https://example.com/with space' } }]);
+  assert.equal(result, '[click](<https://example.com/with space>)',
+    'URLs with whitespace should use angle-bracket form');
+}
+
+function testUrlWithAngles() {
+  const result = deltasToMarkdown([{ insert: 'click', attributes: { link: 'https://example.com/<x>' } }]);
+  assert.equal(result, '[click](<https://example.com/%3Cx%3E>)',
+    'URLs with < or > should use angle-bracket form with inner brackets percent-encoded');
+}
+
+function testLinkLabelWithBracket() {
+  const result = deltasToMarkdown([{ insert: 'foo]bar', attributes: { link: 'https://example.com' } }]);
+  assert.equal(result, '[foo\\]bar](https://example.com)',
+    'closing brackets in link label should be backslash-escaped');
+}
+
+function testNewlinePreserved() {
+  assert.equal(deltasToMarkdown([{ insert: 'foo\nbar' }]), 'foo\nbar',
+    'newlines inside insert should pass through');
+}
+
+function testCodeWithBacktick() {
+  // Content with a single backtick needs a double-backtick fence.
+  assert.equal(deltasToMarkdown([{ insert: 'a`b', attributes: { code: true } }]), '``a`b``',
+    'code containing a backtick should use a longer fence');
+}
+
+function testCodeLeadingBacktick() {
+  // Content starting/ending with backtick needs a space pad so the fence is
+  // distinguishable from the content (CommonMark strips one space if both ends have one).
+  assert.equal(deltasToMarkdown([{ insert: '`x', attributes: { code: true } }]), '`` `x ``',
+    'code starting with backtick should be space-padded inside fence');
+}
+
+function testStrikeCode() {
+  assert.equal(deltasToMarkdown([{ insert: 'x', attributes: { code: true, strike: true } }]), '~~`x`~~',
+    'strike should wrap a code span when both are set');
+}
+
+function testLinkCode() {
+  assert.equal(deltasToMarkdown([{ insert: 'x', attributes: { code: true, link: 'https://example.com' } }]),
+    '[`x`](https://example.com)',
+    'link should wrap a code span when both are set');
+}
+
+function testBoldWithLinkMid() {
+  // Round-trip a bold span containing a link mid-stream — the per-run
+  // **A**[**B**](url)**C** layout must survive parsing back into the same shape.
+  const deltas = [
+    { insert: 'A', attributes: { bold: true } },
+    { insert: 'B', attributes: { bold: true, link: 'https://example.com' } },
+    { insert: 'C', attributes: { bold: true } },
+  ];
+  const result = deltasToMarkdown(deltas);
+  assert.equal(result, '**A**[**B**](https://example.com)**C**',
+    'bold span with link mid-run should emit cleanly');
+  assert.deepEqual(parsedDeltas(result), deltas.map(normalizeDelta),
+    'bold + link + bold should round-trip preserving each run');
+}
+
+function testAllMarksCombined() {
+  // Order of wrapping: emphasis innermost, then link, then strike outermost.
+  assert.equal(
+    deltasToMarkdown([{ insert: 'x', attributes: { bold: true, italic: true, strike: true, link: 'https://example.com' } }]),
+    '~~[***x***](https://example.com)~~',
+    'all marks: strike wraps link wraps bold+italic');
+}
+
+// ---------------------------------------------------------------------------
 // Run all tests
 // ---------------------------------------------------------------------------
 const tests = [
@@ -229,6 +357,19 @@ const tests = [
   ['code takes priority over bold/italic', testCodeDropsOtherMarks],
   ['paragraph block with deltas via renderBlocksToMarkdown', testParagraphBlockWithDeltas],
   ['table without tableCellDeltas uses plain tableData fallback', testTableFallbackWithoutDeltas],
+  ['empty deltas array', testEmptyDeltas],
+  ['empty insert is skipped', testEmptyInsertSkipped],
+  ['adjacent same-attribute runs coalesce', testAdjacentSameAttribute],
+  ['URL with whitespace uses angle-bracket form', testUrlWithWhitespace],
+  ['URL with angle brackets percent-encoded inside <…>', testUrlWithAngles],
+  ['closing bracket in link label is escaped', testLinkLabelWithBracket],
+  ['newline inside insert is preserved', testNewlinePreserved],
+  ['code containing a backtick uses a longer fence', testCodeWithBacktick],
+  ['code starting with backtick is space-padded', testCodeLeadingBacktick],
+  ['strike + code combine', testStrikeCode],
+  ['link + code combine', testLinkCode],
+  ['bold span with link mid-run round-trips', testBoldWithLinkMid],
+  ['all marks combined (strike+link+bold+italic)', testAllMarksCombined],
 ];
 
 let passed = 0;

--- a/tests/test-markdown-rich-text-export.mjs
+++ b/tests/test-markdown-rich-text-export.mjs
@@ -115,12 +115,120 @@ function testTableCellRichText() {
 }
 
 // ---------------------------------------------------------------------------
+// 4. Individual mark types — strike, link, code
+// ---------------------------------------------------------------------------
+function testStrike() {
+  const result = deltasToMarkdown([{ insert: 'text', attributes: { strike: true } }]);
+  assert.equal(result, '~~text~~', 'strike should wrap with ~~');
+}
+
+function testLink() {
+  const result = deltasToMarkdown([{ insert: 'click here', attributes: { link: 'https://example.com' } }]);
+  assert.equal(result, '[click here](https://example.com)', 'link should produce markdown link syntax');
+}
+
+function testCode() {
+  const result = deltasToMarkdown([{ insert: 'foo()', attributes: { code: true } }]);
+  assert.equal(result, '`foo()`', 'code should wrap with backticks');
+}
+
+// ---------------------------------------------------------------------------
+// 5. link + bold combination — bold applied first, then wrapped in link
+// ---------------------------------------------------------------------------
+function testLinkBold() {
+  const result = deltasToMarkdown([{ insert: 'text', attributes: { bold: true, link: 'https://example.com' } }]);
+  // bold wraps inner first, then link wraps the whole thing
+  assert.equal(result, '[**text**](https://example.com)', 'bold+link should produce [**text**](url)');
+}
+
+// ---------------------------------------------------------------------------
+// 6. code priority — bold/italic are silently dropped when code is set
+//    because the code branch does an early `continue`
+// ---------------------------------------------------------------------------
+function testCodeDropsOtherMarks() {
+  const result = deltasToMarkdown([{ insert: 'x', attributes: { code: true, bold: true, italic: true } }]);
+  assert.equal(result, '`x`', 'code takes priority; bold and italic are dropped when code is set');
+}
+
+// ---------------------------------------------------------------------------
+// 7. Paragraph block with deltas via renderBlocksToMarkdown
+//    Verifies the deltas wiring in renderBlock() for non-table flavours
+// ---------------------------------------------------------------------------
+function testParagraphBlockWithDeltas() {
+  const blocksById = new Map([
+    ['para-1', {
+      id: 'para-1',
+      parentId: null,
+      flavour: 'affine:paragraph',
+      type: 'text',
+      text: 'fallback plain text',
+      checked: null,
+      language: null,
+      childIds: [],
+      url: null,
+      sourceId: null,
+      caption: null,
+      tableData: null,
+      deltas: [
+        { insert: 'Hello ' },
+        { insert: 'world', attributes: { bold: true } },
+      ],
+    }],
+  ]);
+
+  const result = renderBlocksToMarkdown({ rootBlockIds: ['para-1'], blocksById });
+  // deltas must win over the plain text field
+  assert.equal(result.markdown, 'Hello **world**',
+    'paragraph with deltas should render deltas, not the plain text fallback');
+}
+
+// ---------------------------------------------------------------------------
+// 8. Table without tableCellDeltas — plain tableData is used as fallback
+// ---------------------------------------------------------------------------
+function testTableFallbackWithoutDeltas() {
+  const blocksById = new Map([
+    ['table-2', {
+      id: 'table-2',
+      parentId: null,
+      flavour: 'affine:table',
+      type: null,
+      text: null,
+      checked: null,
+      language: null,
+      childIds: [],
+      url: null,
+      sourceId: null,
+      caption: null,
+      tableData: [
+        ['Name', 'Value'],
+        ['Alice', '42'],
+      ],
+      // no tableCellDeltas — must fall back to tableData strings
+    }],
+  ]);
+
+  const result = renderBlocksToMarkdown({ rootBlockIds: ['table-2'], blocksById });
+  const md = result.markdown;
+
+  assert.ok(md.includes('| Name | Value |'), 'header row should come from tableData fallback');
+  assert.ok(md.includes('| Alice | 42 |'), 'data row should come from tableData fallback');
+  assert.ok(md.includes('| --- |'), 'separator row must be present');
+}
+
+// ---------------------------------------------------------------------------
 // Run all tests
 // ---------------------------------------------------------------------------
 const tests = [
   ['bold → bold+italic → italic (direction A)', testBoldThenBoldItalicThenItalic],
   ['italic → bold+italic → bold (direction B)', testItalicThenBoldItalicThenBold],
   ['table cell inline formatting via tableCellDeltas', testTableCellRichText],
+  ['strike mark', testStrike],
+  ['link mark', testLink],
+  ['code mark', testCode],
+  ['link + bold combination', testLinkBold],
+  ['code takes priority over bold/italic', testCodeDropsOtherMarks],
+  ['paragraph block with deltas via renderBlocksToMarkdown', testParagraphBlockWithDeltas],
+  ['table without tableCellDeltas uses plain tableData fallback', testTableFallbackWithoutDeltas],
 ];
 
 let passed = 0;

--- a/tests/test-markdown-rich-text-import-live.mjs
+++ b/tests/test-markdown-rich-text-import-live.mjs
@@ -12,6 +12,7 @@
 import assert from 'node:assert/strict';
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { parseMarkdownToOperations } from "../dist/markdown/parse.js";
 
 const SERVER_URL = process.env.AFFINE_MCP_HTTP_URL;
 const TOKEN = process.env.AFFINE_MCP_HTTP_TOKEN;
@@ -45,11 +46,31 @@ try {
   console.log(exp.markdown);
   console.log();
 
+  // Parse the exported markdown once and walk every run so we can assert on
+  // the actual delta attributes rather than chasing fragile string patterns.
+  const allDeltas = parseMarkdownToOperations(exp.markdown)
+    .operations
+    .flatMap(op => op.deltas ?? []);
+  const findRun = (text) => allDeltas.find(d => d.insert === text);
+  const findRunContaining = (substr) => allDeltas.find(d => typeof d.insert === "string" && d.insert.includes(substr));
+
   const checks = [
-    ["**Bold text** preserved",          () => assert.ok(exp.markdown.includes("**Bold text**"))],
-    ["~~Strikethrough~~ preserved",       () => assert.ok(exp.markdown.includes("~~Strikethrough~~"))],
-    ["`Inline code` preserved",           () => assert.ok(exp.markdown.includes("`Inline code`"))],
-    ["bold+italic combination preserved", () => assert.ok(/\*{2,3}Bold and [\*_]italic[\*_]\*{2,3}/.test(exp.markdown))],
+    ["bold text run carries bold attribute",          () => assert.ok(findRun("Bold text")?.attributes?.bold)],
+    ["italic text run carries italic attribute",      () => assert.ok(findRun("Italic text")?.attributes?.italic)],
+    ["strikethrough run carries strike attribute",    () => assert.ok(findRun("Strikethrough")?.attributes?.strike)],
+    ["inline code run carries code attribute",        () => assert.ok(findRun("Inline code")?.attributes?.code)],
+    ["bold+italic 'italic' run carries both marks",   () => {
+      const r = findRun("italic");
+      assert.ok(r?.attributes?.bold && r?.attributes?.italic, "expected bold+italic on the 'italic' run");
+    }],
+    ["bold+italic 'Bold and' segment stays bold",     () => {
+      const r = findRunContaining("Bold and");
+      assert.ok(r?.attributes?.bold, "expected 'Bold and' segment to stay bold");
+    }],
+    ["bold+italic 'combined' segment stays bold",     () => {
+      const r = findRunContaining("combined");
+      assert.ok(r?.attributes?.bold, "expected 'combined' segment to stay bold");
+    }],
   ];
 
   for (const [name, fn] of checks) {

--- a/tests/test-markdown-rich-text-import-live.mjs
+++ b/tests/test-markdown-rich-text-import-live.mjs
@@ -1,0 +1,40 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const SERVER_URL = "http://nas.fairleadsoftware.com:3002/mcp";
+const TOKEN = process.env.AFFINE_MCP_HTTP_TOKEN;
+const WORKSPACE_ID = "cebf9206-76b3-4c77-a43f-2e72cb5ad426";
+
+const client = new Client({ name: "debug-exact", version: "1.0" });
+const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
+  requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
+});
+await client.connect(transport);
+
+const call = async (name, args) => {
+  const r = await client.callTool({ name, arguments: args });
+  return JSON.parse(r?.content?.[0]?.text);
+};
+
+// Exact markdown from the failing MCP call
+const markdown = "# Test\n\n**Bold text**\n*Italic text*\n~~Strikethrough~~\n`Inline code`\n\n**Bold and *italic* combined**";
+
+console.log("Input markdown:");
+console.log(markdown);
+console.log("\nCreating doc...");
+
+const doc = await call("create_doc_from_markdown", { workspaceId: WORKSPACE_ID, title: "Inline Formatting Test", markdown });
+console.log("created:", doc.docId);
+
+const exp = await call("export_doc_markdown", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+console.log("\nExported markdown:");
+console.log(exp.markdown);
+console.log("\nChecks:");
+console.log("**Bold text**:              ", exp.markdown.includes("**Bold text**"));
+console.log("*Italic text*:              ", exp.markdown.includes("*Italic text*"));
+console.log("~~Strikethrough~~:          ", exp.markdown.includes("~~Strikethrough~~"));
+console.log("`Inline code`:              ", exp.markdown.includes("`Inline code`"));
+console.log("**Bold and *italic*:        ", /\*\*Bold and \*italic\*/.test(exp.markdown));
+
+await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+await client.close();

--- a/tests/test-markdown-rich-text-import-live.mjs
+++ b/tests/test-markdown-rich-text-import-live.mjs
@@ -1,11 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Live integration test for markdown rich-text import/export round-trip.
+ *
+ * Requires environment variables:
+ *   AFFINE_MCP_HTTP_URL      - base MCP server URL, e.g. http://localhost:3002/mcp
+ *   AFFINE_MCP_HTTP_TOKEN    - bearer token
+ *   AFFINE_WORKSPACE_ID      - workspace ID to run the test against
+ *
+ * Creates a doc, exports it, asserts all marks survive, then deletes the doc.
+ */
+import assert from 'node:assert/strict';
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-const SERVER_URL = "http://nas.fairleadsoftware.com:3002/mcp";
+const SERVER_URL = process.env.AFFINE_MCP_HTTP_URL;
 const TOKEN = process.env.AFFINE_MCP_HTTP_TOKEN;
-const WORKSPACE_ID = "cebf9206-76b3-4c77-a43f-2e72cb5ad426";
+const WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID;
 
-const client = new Client({ name: "debug-exact", version: "1.0" });
+if (!SERVER_URL) throw new Error("AFFINE_MCP_HTTP_URL is required");
+if (!TOKEN) throw new Error("AFFINE_MCP_HTTP_TOKEN is required");
+if (!WORKSPACE_ID) throw new Error("AFFINE_WORKSPACE_ID is required");
+
+const client = new Client({ name: "test-markdown-rich-text-import-live", version: "1.0" });
 const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
   requestInit: { headers: { Authorization: `Bearer ${TOKEN}` } },
 });
@@ -16,25 +32,39 @@ const call = async (name, args) => {
   return JSON.parse(r?.content?.[0]?.text);
 };
 
-// Exact markdown from the failing MCP call
 const markdown = "# Test\n\n**Bold text**\n*Italic text*\n~~Strikethrough~~\n`Inline code`\n\n**Bold and *italic* combined**";
 
-console.log("Input markdown:");
-console.log(markdown);
-console.log("\nCreating doc...");
-
+console.log("Creating doc...");
 const doc = await call("create_doc_from_markdown", { workspaceId: WORKSPACE_ID, title: "Inline Formatting Test", markdown });
 console.log("created:", doc.docId);
 
-const exp = await call("export_doc_markdown", { workspaceId: WORKSPACE_ID, docId: doc.docId });
-console.log("\nExported markdown:");
-console.log(exp.markdown);
-console.log("\nChecks:");
-console.log("**Bold text**:              ", exp.markdown.includes("**Bold text**"));
-console.log("*Italic text*:              ", exp.markdown.includes("*Italic text*"));
-console.log("~~Strikethrough~~:          ", exp.markdown.includes("~~Strikethrough~~"));
-console.log("`Inline code`:              ", exp.markdown.includes("`Inline code`"));
-console.log("**Bold and *italic*:        ", /\*\*Bold and \*italic\*/.test(exp.markdown));
+let failed = false;
+try {
+  const exp = await call("export_doc_markdown", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+  console.log("\nExported markdown:");
+  console.log(exp.markdown);
+  console.log();
 
-await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
-await client.close();
+  const checks = [
+    ["**Bold text** preserved",          () => assert.ok(exp.markdown.includes("**Bold text**"))],
+    ["~~Strikethrough~~ preserved",       () => assert.ok(exp.markdown.includes("~~Strikethrough~~"))],
+    ["`Inline code` preserved",           () => assert.ok(exp.markdown.includes("`Inline code`"))],
+    ["bold+italic combination preserved", () => assert.ok(/\*{2,3}Bold and [\*_]italic[\*_]\*{2,3}/.test(exp.markdown))],
+  ];
+
+  for (const [name, fn] of checks) {
+    try {
+      fn();
+      console.log(`  ✓ ${name}`);
+    } catch {
+      console.error(`  ✗ ${name}`);
+      failed = true;
+    }
+  }
+} finally {
+  await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+  console.log("\ncleaned up doc", doc.docId);
+  await client.close();
+}
+
+if (failed) process.exit(1);

--- a/tests/test-markdown-stdio-live.mjs
+++ b/tests/test-markdown-stdio-live.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Live integration test for markdown round-trip over the stdio MCP transport.
+ *
+ * Complements test-markdown-rich-text-import-live.mjs (which uses HTTP):
+ * this variant boots a local stdio MCP server child process and exercises
+ * a broader markdown surface — headings, inline marks, lists, code blocks.
+ *
+ * Requires environment variables:
+ *   AFFINE_BASE_URL       - AFFiNE instance base URL
+ *   AFFINE_EMAIL          - login email
+ *   AFFINE_PASSWORD       - login password
+ *   AFFINE_WORKSPACE_ID   - workspace ID to run the test against
+ *
+ * Creates a doc, exports it, parses the result through parseMarkdownToOperations,
+ * asserts the structure survived, then deletes the doc.
+ */
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { parseMarkdownToOperations } from "../dist/markdown/parse.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const BASE_URL = process.env.AFFINE_BASE_URL;
+const EMAIL = process.env.AFFINE_EMAIL;
+const PASSWORD = process.env.AFFINE_PASSWORD;
+const WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID;
+
+if (!BASE_URL) throw new Error("AFFINE_BASE_URL is required");
+if (!EMAIL) throw new Error("AFFINE_EMAIL is required");
+if (!PASSWORD) throw new Error("AFFINE_PASSWORD is required");
+if (!WORKSPACE_ID) throw new Error("AFFINE_WORKSPACE_ID is required");
+
+const markdown = `# Markdown Formatting Test
+
+## Text Styling
+
+**Bold text**
+*Italic text*
+~~Strikethrough text~~
+\`Inline code\`
+
+## Lists
+
+- Bullet item 1
+- Bullet item 2
+- Bullet item 3
+
+1. Numbered item 1
+2. Numbered item 2
+3. Numbered item 3
+
+## Code Block
+
+\`\`\`python
+def hello():
+    print("Hello, Affine!")
+\`\`\``;
+
+const client = new Client({ name: "test-markdown-stdio-live", version: "1.0" });
+const transport = new StdioClientTransport({
+  command: "node",
+  args: [path.resolve(__dirname, "..", "dist", "index.js")],
+  env: {
+    ...process.env,
+    AFFINE_BASE_URL: BASE_URL,
+    AFFINE_EMAIL: EMAIL,
+    AFFINE_PASSWORD: PASSWORD,
+    AFFINE_LOGIN_AT_START: "sync",
+  },
+});
+await client.connect(transport);
+
+const call = async (name, args) => {
+  const r = await client.callTool({ name, arguments: args });
+  return JSON.parse(r?.content?.[0]?.text);
+};
+
+console.log("Creating doc...");
+const doc = await call("create_doc_from_markdown", { workspaceId: WORKSPACE_ID, title: "Formatting Test (stdio live)", markdown });
+console.log("created:", doc.docId);
+
+let failed = false;
+try {
+  const exp = await call("export_doc_markdown", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+  console.log("\nExported markdown:");
+  console.log(exp.markdown);
+  console.log();
+
+  const ops = parseMarkdownToOperations(exp.markdown).operations;
+  const allDeltas = ops.flatMap(op => op.deltas ?? []);
+  const findRun = (text) => allDeltas.find(d => d.insert === text);
+  const opsOfType = (type) => ops.filter(op => op.type === type);
+
+  const checks = [
+    ["heading present",                            () => assert.ok(opsOfType("heading").some(op => /Markdown Formatting Test/.test(op.text)), "expected a heading containing the title")],
+    ["bold run preserved",                         () => assert.ok(findRun("Bold text")?.attributes?.bold)],
+    ["italic run preserved",                       () => assert.ok(findRun("Italic text")?.attributes?.italic)],
+    ["strikethrough run preserved",                () => assert.ok(findRun("Strikethrough text")?.attributes?.strike)],
+    ["inline code run preserved",                  () => assert.ok(findRun("Inline code")?.attributes?.code)],
+    ["bulleted list items preserved",              () => assert.ok(opsOfType("list").some(op => op.style === "bulleted" && /Bullet item/.test(op.text)), "expected at least one bulleted list item")],
+    ["numbered list items preserved",              () => assert.ok(opsOfType("list").some(op => op.style === "numbered" && /Numbered item/.test(op.text)), "expected at least one numbered list item")],
+    ["fenced code block preserved with language",  () => {
+      const code = opsOfType("code").find(op => op.text.includes("Hello, Affine!"));
+      assert.ok(code, "expected a code block containing 'Hello, Affine!'");
+      assert.equal(code.language, "python", "code block language should be 'python'");
+    }],
+  ];
+
+  for (const [name, fn] of checks) {
+    try {
+      fn();
+      console.log(`  ✓ ${name}`);
+    } catch (err) {
+      console.error(`  ✗ ${name}`);
+      console.error(`    ${err.message}`);
+      failed = true;
+    }
+  }
+} finally {
+  await call("delete_doc", { workspaceId: WORKSPACE_ID, docId: doc.docId });
+  console.log("\ncleaned up doc", doc.docId);
+  await client.close();
+}
+
+if (failed) process.exit(1);


### PR DESCRIPTION
## Why this change is needed

AFFiNE stores paragraph text as **Y.Text delta arrays** — a sequence of \`{ insert, attributes }\` runs where \`attributes\` carries \`bold\`, \`italic\`, \`strike\`, \`code\`, and \`link\` markers. For example, the sentence \`Hello **world**\` is stored as two runs:

\`\`\`json
[
  { "insert": "Hello " },
  { "insert": "world", "attributes": { "bold": true } }
]
\`\`\`

The previous \`export_doc_markdown\` path read \`block.text\` from the serialised block, which is the **plain-text snapshot** — it strips every attribute and silently discards all inline formatting. A document full of bold, italic, and linked text would export as plain prose with no indication that any marks ever existed.

## What the fix does

### \`src/markdown/types.ts\`
Adds an optional \`deltas?: TextDelta[]\` field to \`MarkdownRenderableBlock\` so that collected blocks can carry the raw delta array from Y.Text alongside the plain-text fallback.

### \`src/tools/docs.ts\`
- Adds \`asDeltaArray(value: Y.Text | unknown): TextDelta[]\` — reads \`value.toDelta()\` when the value is a live Y.Text instance, returns an empty array otherwise.
- In \`collectDocForMarkdown\`, populates \`block.deltas\` from \`asDeltaArray(prop.value)\` for every text block.

### \`src/markdown/render.ts\`
- Adds \`deltasToMarkdown(deltas: TextDelta[]): string\` — converts a delta array to a markdown string. It streams bold/italic markers across adjacent runs to avoid doubled markers at run boundaries (e.g. \`**bold** **text**\` → \`**bold text**\`), and wraps code spans, strikethrough, and inline links correctly.
- \`blockToMarkdown\` now prefers \`block.deltas\` when present; falls back to \`block.text\` for blocks that do not carry a delta array.

## Impact

\`export_doc_markdown\`, \`duplicate_doc\`, and \`create_doc_from_template\` all call \`collectDocForMarkdown\`, so all three now emit correct markdown for documents with inline formatting. No schema or API surface changes.

## Test plan
- [ ] Export a document that contains bold, italic, strikethrough, inline code, and a hyperlink — verify the markdown output contains the expected markers
- [ ] Export a plain-text document — verify output is identical to before
- [ ] Run \`npm run build\` — no type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich-text formatting (bold, italic, strikethrough, code, links) preserved in markdown export for block content and table cells via delta-based rendering.

* **Tests**
  * Added a regression suite validating markdown rich-text export round-trips and delimiter correctness.
  * Added a live integration test verifying import/export round-trip preserves rich-text marks.

* **Chores**
  * Added two markdown-related test scripts to the project scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DAWNCR0W/affine-mcp-server/pull/176)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->