### PR TITLE
chore: migrate npm publish to trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,16 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      id-token: write
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install deps
         run: npm ci
@@ -39,6 +41,4 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: .


### PR DESCRIPTION
> Base branch must be `develop`. Pull requests targeting other branches are closed automatically.

## Summary

Migrate the npm publish workflow from a long-lived `NPM_TOKEN` secret to npm Trusted Publishing through GitHub Actions OIDC.

## Changes

- Grant the release workflow `id-token: write` so npm can verify the GitHub Actions publisher.
- Run the publish job on Node.js 24 to satisfy npm Trusted Publishing requirements.
- Disable automatic package-manager caching in the publish job.
- Remove the `NODE_AUTH_TOKEN` / `NPM_TOKEN` publish secret from the workflow.

## Validation

Commands executed:

```bash
git diff --check
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish.yml'); puts 'yaml ok'"
rg -n "NPM_TOKEN|NODE_AUTH_TOKEN" .github package.json README.md CHANGELOG.md RELEASE_NOTES.md || true
rg -n "[가-힣]" --hidden --glob '!.git/*' /Users/dawncrow/.codex/worktrees/555a/affine-mcp-server || true
npm ci
npm run ci
```

## Checklist

- [x] Tool names remain unique and `snake_case`
- [x] `tool-manifest.json` updated if tool list changed
- [x] `README.md` updated if behavior/user-facing API changed
- [x] Backward compatibility impact described (if any)

No tool names, tool manifest entries, README content, or runtime API behavior changed.