### PR TITLE
chore: configure CodeRabbit develop reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - "develop"
+      - "release/.*"


### PR DESCRIPTION
## Summary

Enable CodeRabbit automatic reviews for pull requests targeting `develop` and `release/.*`.

## Changes

- Add a root `.coderabbit.yaml` configuration file.
- Keep auto review enabled and extend reviewed base branches beyond the default branch.

## Validation

Commands executed:

```bash
ruby -e 'require "yaml"; data = YAML.load_file(".coderabbit.yaml"); abort("missing reviews") unless data.dig("reviews", "auto_review", "base_branches")&.include?("develop"); puts "YAML OK"'
LC_ALL=C rg -n '[^[:ascii:]]' .coderabbit.yaml
```

Not run: `npm run build`, `npm run test:tool-manifest`. This change only adds CodeRabbit configuration.

## Checklist

- [x] Tool names remain unique and `snake_case` (no tool changes)
- [x] `tool-manifest.json` updated if tool list changed (not applicable)
- [x] `README.md` updated if behavior/user-facing API changed (not applicable)
- [x] Backward compatibility impact described (no runtime impact)