### PR TITLE
ci: disable Docker workflow on develop PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  pull_request:
-    branches:
-      - develop
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Stop the Docker workflow from running on pull requests that target `develop`.

## Changes

- Removed the `pull_request` trigger from `.github/workflows/docker.yml`.
- Kept Docker publishing available for semver tag pushes.
- Kept manual `workflow_dispatch` available.

## Validation

Commands executed:

```bash
git diff --check
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker.yml'); puts 'YAML parse OK'"
```

Also checked the repository for non-English text; no matches were found.

## Checklist

- [x] Tool names remain unique and `snake_case`
- [x] `tool-manifest.json` updated if tool list changed: not applicable
- [x] `README.md` updated if behavior/user-facing API changed: not applicable
- [x] Backward compatibility impact described: Docker release publishing remains tag-based; develop PRs no longer run Docker validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to trigger on version releases and support manual execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->