### PR TITLE
fix: harden create_doc folder placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:http-bearer": "node tests/test-http-bearer.mjs",
     "test:oauth-http": "node tests/test-oauth-http.mjs",
     "test:organize": "node tests/test-organize-tools.mjs",
-    "test:folder-placement": "node tests/test-foo-bar-baz.mjs",
+    "test:create-doc-folder-placement": "node tests/test-create-doc-folder-placement.mjs",
     "test:supporting-tools": "node tests/test-supporting-tools.mjs",
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -8,7 +8,7 @@ import * as Y from "yjs";
 import { parseMarkdownToOperations } from "../markdown/parse.js";
 import { renderBlocksToMarkdown } from "../markdown/render.js";
 import type { MarkdownOperation, MarkdownRenderableBlock, TextDelta } from "../markdown/types.js";
-import { specialWorkspaceDbDocId, readOrganizeNodes, organizeNodeMap, ensureNodeIsFolder, nextOrganizeIndex, ensureRecord } from "./organize.js";
+import { addOrganizeLinkToFolder } from "./organize.js";
 import {
   type Bound,
   DEFAULT_NOTE_XYWH,
@@ -4779,6 +4779,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       context: "create_doc",
     });
     const warnings = mergeWarnings(created.warnings ?? [], placement.warnings);
+    let linkedFolderId: string | null = null;
     let folderNodeId: string | null = null;
     if (parsed.folderId) {
       const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
@@ -4786,26 +4787,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
       try {
         await joinWorkspace(socket, created.workspaceId);
-        const foldersDocId = specialWorkspaceDbDocId(created.workspaceId, "folders");
-        const snapshot = await loadDoc(socket, created.workspaceId, foldersDocId);
-        const foldersDoc = new Y.Doc();
-        if (snapshot.missing) {
-          Y.applyUpdate(foldersDoc, Buffer.from(snapshot.missing, "base64"));
-        }
-        const nodes = readOrganizeNodes(foldersDoc);
-        const nodeMap = organizeNodeMap(nodes);
-        ensureNodeIsFolder(nodeMap, parsed.folderId);
-        const linkId = generateId();
-        const record = ensureRecord(foldersDoc, linkId);
-        record.set("id", linkId);
-        record.set("type", "doc");
-        record.set("data", created.docId);
-        record.set("parentId", parsed.folderId);
-        record.set("index", nextOrganizeIndex(nodes, parsed.folderId));
-        record.delete("$$DELETED");
-        const update = Y.encodeStateAsUpdate(foldersDoc);
-        await pushDocUpdate(socket, created.workspaceId, foldersDocId, Buffer.from(update).toString("base64"));
-        folderNodeId = linkId;
+        const link = await addOrganizeLinkToFolder(socket, created.workspaceId, {
+          folderId: parsed.folderId,
+          type: "doc",
+          targetId: created.docId,
+        });
+        linkedFolderId = link.parentId;
+        folderNodeId = link.id;
       } catch (err: any) {
         warnings.push(`Doc created but could not be placed in folder "${parsed.folderId}": ${err?.message ?? "unknown error"}`);
       } finally {
@@ -4818,7 +4806,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       title: created.title,
       parentDocId: placement.parentDocId,
       linkedToParent: placement.linkedToParent,
-      folderId: folderNodeId !== null ? (parsed.folderId ?? null) : null,
+      folderId: linkedFolderId,
       folderLinked: folderNodeId !== null,
       folderNodeId,
       warnings,

--- a/src/tools/organize.ts
+++ b/src/tools/organize.ts
@@ -181,7 +181,7 @@ function normalizeOrganizeNode(value: unknown): OrganizeNodeRecord | null {
   };
 }
 
-export function specialWorkspaceDbDocId(workspaceId: string, tableName: string): string {
+function specialWorkspaceDbDocId(workspaceId: string, tableName: string): string {
   return `db$${workspaceId}$${tableName}`;
 }
 
@@ -189,7 +189,7 @@ function isDeletedRecord(record: Y.Map<any>): boolean {
   return record.get("$$DELETED") === true || record.size === 0;
 }
 
-export function ensureRecord(doc: Y.Doc, id: string): Y.Map<any> {
+function ensureRecord(doc: Y.Doc, id: string): Y.Map<any> {
   return doc.getMap(id);
 }
 
@@ -225,7 +225,7 @@ function findCollectionIndex(array: Y.Array<any>, id: string): number {
   return -1;
 }
 
-export function readOrganizeNodes(doc: Y.Doc): OrganizeNodeRecord[] {
+function readOrganizeNodes(doc: Y.Doc): OrganizeNodeRecord[] {
   const nodes: OrganizeNodeRecord[] = [];
   for (const key of doc.share.keys()) {
     if (!doc.share.has(key)) {
@@ -243,7 +243,7 @@ export function readOrganizeNodes(doc: Y.Doc): OrganizeNodeRecord[] {
   return nodes;
 }
 
-export function organizeNodeMap(nodes: OrganizeNodeRecord[]): Map<string, OrganizeNodeRecord> {
+function organizeNodeMap(nodes: OrganizeNodeRecord[]): Map<string, OrganizeNodeRecord> {
   return new Map(nodes.map(node => [node.id, node] as const));
 }
 
@@ -525,7 +525,7 @@ function ensureFolderParent(
   }
 }
 
-export function ensureNodeIsFolder(nodes: Map<string, OrganizeNodeRecord>, nodeId: string): OrganizeNodeRecord {
+function ensureNodeIsFolder(nodes: Map<string, OrganizeNodeRecord>, nodeId: string): OrganizeNodeRecord {
   const node = nodes.get(nodeId);
   if (!node || node.type !== "folder") {
     throw new Error(`Folder '${nodeId}' was not found.`);
@@ -559,7 +559,7 @@ function isAncestor(
   }
 }
 
-export function nextOrganizeIndex(
+function nextOrganizeIndex(
   nodes: OrganizeNodeRecord[],
   parentId: string | null
 ): string {
@@ -568,6 +568,71 @@ export function nextOrganizeIndex(
     .sort((left, right) => left.index.localeCompare(right.index));
   const last = siblings.at(-1);
   return generateFractionalIndexingKeyBetween(last?.index ?? null, null);
+}
+
+type OrganizeLinkType = "doc" | "tag" | "collection";
+
+type OrganizeLinkResult = {
+  id: string;
+  parentId: string;
+  type: OrganizeLinkType;
+  data: string;
+  index: string;
+  storageDocId: string;
+};
+
+async function loadFoldersDoc(socket: any, workspaceId: string) {
+  const docId = specialWorkspaceDbDocId(workspaceId, "folders");
+  const snapshot = await loadDoc(socket, workspaceId, docId);
+  const doc = new Y.Doc();
+  if (snapshot.missing) {
+    Y.applyUpdate(doc, Buffer.from(snapshot.missing, "base64"));
+  }
+  return { docId, doc, snapshot };
+}
+
+async function saveFoldersDoc(socket: any, workspaceId: string, docId: string, doc: Y.Doc) {
+  const update = Y.encodeStateAsUpdate(doc);
+  await pushDocUpdate(socket, workspaceId, docId, Buffer.from(update).toString("base64"));
+}
+
+export async function addOrganizeLinkToFolder(
+  socket: any,
+  workspaceId: string,
+  {
+    folderId,
+    type,
+    targetId,
+    index,
+  }: {
+    folderId: string;
+    type: OrganizeLinkType;
+    targetId: string;
+    index?: string;
+  }
+): Promise<OrganizeLinkResult> {
+  const { docId, doc } = await loadFoldersDoc(socket, workspaceId);
+  const nodes = readOrganizeNodes(doc);
+  const nodeMap = organizeNodeMap(nodes);
+  ensureNodeIsFolder(nodeMap, folderId);
+  const linkId = generateId();
+  const nextIndex = index ?? nextOrganizeIndex(nodes, folderId);
+  const record = ensureRecord(doc, linkId);
+  record.set("id", linkId);
+  record.set("type", type);
+  record.set("data", targetId);
+  record.set("parentId", folderId);
+  record.set("index", nextIndex);
+  record.delete("$$DELETED");
+  await saveFoldersDoc(socket, workspaceId, docId, doc);
+  return {
+    id: linkId,
+    parentId: folderId,
+    type,
+    data: targetId,
+    index: nextIndex,
+    storageDocId: docId,
+  };
 }
 
 export function registerOrganizeTools(
@@ -597,21 +662,6 @@ export function registerOrganizeTools(
     const update = Y.encodeStateAsUpdate(doc);
     await pushDocUpdate(socket, workspaceId, workspaceId, Buffer.from(update).toString("base64"));
   }
-
-  async function loadFoldersDoc(socket: any, workspaceId: string) {
-    const docId = specialWorkspaceDbDocId(workspaceId, "folders");
-    const snapshot = await loadDoc(socket, workspaceId, docId);
-    const doc = new Y.Doc();
-    if (snapshot.missing) {
-      Y.applyUpdate(doc, Buffer.from(snapshot.missing, "base64"));
-    }
-    return { docId, doc, snapshot };
-  }
-
-async function saveFoldersDoc(socket: any, workspaceId: string, docId: string, doc: Y.Doc) {
-  const update = Y.encodeStateAsUpdate(doc);
-  await pushDocUpdate(socket, workspaceId, docId, Buffer.from(update).toString("base64"));
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -1408,28 +1458,13 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     const { socket } = await getSocketContext();
     try {
       await joinWorkspace(socket, resolvedWorkspaceId);
-      const { docId, doc } = await loadFoldersDoc(socket, resolvedWorkspaceId);
-      const nodes = readOrganizeNodes(doc);
-      const nodeMap = organizeNodeMap(nodes);
-      ensureNodeIsFolder(nodeMap, folderId);
-      const linkId = generateId();
-      const nextIndex = index ?? nextOrganizeIndex(nodes, folderId);
-      const record = ensureRecord(doc, linkId);
-      record.set("id", linkId);
-      record.set("type", type);
-      record.set("data", targetId);
-      record.set("parentId", folderId);
-      record.set("index", nextIndex);
-      record.delete("$$DELETED");
-      await saveFoldersDoc(socket, resolvedWorkspaceId, docId, doc);
-      return text({
-        id: linkId,
-        parentId: folderId,
+      const link = await addOrganizeLinkToFolder(socket, resolvedWorkspaceId, {
+        folderId,
         type,
-        data: targetId,
-        index: nextIndex,
-        storageDocId: docId,
+        targetId,
+        index,
       });
+      return text(link);
     } finally {
       socket.disconnect();
     }

--- a/tests/test-create-doc-folder-placement.mjs
+++ b/tests/test-create-doc-folder-placement.mjs
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 /**
- * Integration test: create folder "bar", create doc "baz" placed inside it via
- * folderId, create folder "foo", then move "bar" into "foo".
+ * Integration test for create_doc folder placement.
  *
  * Steps:
  *   1. Create workspace
  *   2. Create folder "bar"
- *   3. Create doc "baz" placed in "bar" (folderId parameter)
- *   4. Create folder "foo"
- *   5. Move "bar" into "foo"
- *   6. Verify final tree: foo → bar → baz
- *   7. Clean up workspace
+ *   3. Create doc "baz" placed in "bar" with folderId
+ *   4. Create doc with a missing folderId and verify the failure contract
+ *   5. Create folder "foo"
+ *   6. Move "bar" into "foo"
+ *   7. Verify final tree
+ *   8. Clean up workspace
  */
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,7 +24,7 @@ const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
 const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
 const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
 const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
-if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
+if (!PASSWORD) throw new Error('AFFINE_ADMIN_PASSWORD env var required - run: . tests/generate-test-env.sh');
 const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
 const NO_CLEANUP = process.env.NO_CLEANUP === '1' || process.argv.includes('--no-cleanup');
 
@@ -44,13 +44,26 @@ function expectEqual(actual, expected, message) {
   }
 }
 
+function expectArray(value, message) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${message}: expected array, got ${JSON.stringify(value)}`);
+  }
+}
+
+function expectWarningIncludes(warnings, expected, message) {
+  expectArray(warnings, `${message} warnings`);
+  if (!warnings.some(warning => typeof warning === 'string' && warning.includes(expected))) {
+    throw new Error(`${message}: expected warning containing ${JSON.stringify(expected)}, got ${JSON.stringify(warnings)}`);
+  }
+}
+
 async function main() {
-  console.log('=== foo / bar / baz folder placement test ===');
+  console.log('=== Create Doc Folder Placement Test ===');
   console.log(`Base URL: ${BASE_URL}`);
   console.log(`Server:   ${MCP_SERVER_PATH}`);
   console.log();
 
-  const client = new Client({ name: 'affine-mcp-foo-bar-baz-test', version: '1.0.0' });
+  const client = new Client({ name: 'affine-mcp-create-doc-folder-placement', version: '1.0.0' });
   const transport = new StdioClientTransport({
     command: 'node',
     args: [MCP_SERVER_PATH],
@@ -60,7 +73,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-foo-bar-baz-noconfig',
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-create-doc-folder-placement-noconfig',
     },
     stderr: 'pipe',
   });
@@ -68,7 +81,7 @@ async function main() {
   transport.stderr?.on('data', chunk => process.stderr.write(`[mcp-server] ${chunk}`));
 
   async function call(toolName, args = {}) {
-    console.log(`  → ${toolName}(${JSON.stringify(args)})`);
+    console.log(`  -> ${toolName}(${JSON.stringify(args)})`);
     const result = await client.callTool(
       { name: toolName, arguments: args },
       undefined,
@@ -78,7 +91,7 @@ async function main() {
     const parsed = parseContent(result);
     if (parsed && typeof parsed === 'object' && parsed.error) throw new Error(`${toolName} failed: ${parsed.error}`);
     if (typeof parsed === 'string' && /^(GraphQL error:|Error:|MCP error)/i.test(parsed)) throw new Error(`${toolName} failed: ${parsed}`);
-    console.log('    ✓ OK');
+    console.log('    OK');
     return parsed;
   }
 
@@ -86,34 +99,57 @@ async function main() {
 
   let workspaceId;
   try {
-    // ── 1. Workspace ──────────────────────────────────────────────────────────
     console.log('\n[1] Create workspace');
-    const workspace = await call('create_workspace', { name: `foo-bar-baz-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: `folder-placement-${Date.now()}` });
     workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'workspace id');
 
-    // ── 2. Create folder "bar" ────────────────────────────────────────────────
     console.log('\n[2] Create folder "bar"');
     const bar = await call('create_folder', { workspaceId, name: 'bar' });
     const barFolderId = bar?.id;
     expectTruthy(barFolderId, 'bar folder id');
     expectEqual(bar?.data, 'bar', 'bar folder name');
 
-    // ── 3. Create doc "baz" inside folder "bar" via folderId ──────────────────
     console.log('\n[3] Create doc "baz" in folder "bar"');
     const baz = await call('create_doc', { workspaceId, title: 'baz', folderId: barFolderId });
     const bazDocId = baz?.docId;
     expectTruthy(bazDocId, 'baz docId');
+    expectEqual(baz?.folderId, barFolderId, 'create_doc folderId');
+    expectEqual(baz?.folderLinked, true, 'create_doc folderLinked');
+    expectTruthy(baz?.folderNodeId, 'create_doc folderNodeId');
+    expectArray(baz?.warnings, 'create_doc warnings');
+    expectEqual(baz.warnings.length, 0, 'create_doc warning count');
 
-    // ── 4. Create folder "foo" ────────────────────────────────────────────────
-    console.log('\n[4] Create folder "foo"');
+    console.log('\n[4] Create doc with missing folderId');
+    const missingFolderId = `missing-folder-${Date.now()}`;
+    const unplaced = await call('create_doc', {
+      workspaceId,
+      title: 'not placed',
+      folderId: missingFolderId,
+    });
+    const unplacedDocId = unplaced?.docId;
+    expectTruthy(unplacedDocId, 'unplaced docId');
+    expectEqual(unplaced?.folderId, null, 'unplaced folderId');
+    expectEqual(unplaced?.folderLinked, false, 'unplaced folderLinked');
+    expectEqual(unplaced?.folderNodeId, null, 'unplaced folderNodeId');
+    expectWarningIncludes(
+      unplaced?.warnings,
+      `Doc created but could not be placed in folder "${missingFolderId}"`,
+      'unplaced warning message'
+    );
+    expectWarningIncludes(
+      unplaced?.warnings,
+      `Folder '${missingFolderId}' was not found.`,
+      'unplaced missing folder warning'
+    );
+
+    console.log('\n[5] Create folder "foo"');
     const foo = await call('create_folder', { workspaceId, name: 'foo' });
     const fooFolderId = foo?.id;
     expectTruthy(fooFolderId, 'foo folder id');
     expectEqual(foo?.data, 'foo', 'foo folder name');
 
-    // ── 5. Move "bar" into "foo" ──────────────────────────────────────────────
-    console.log('\n[5] Move "bar" into "foo"');
+    console.log('\n[6] Move "bar" into "foo"');
     const movedBar = await call('move_organize_node', {
       workspaceId,
       nodeId: barFolderId,
@@ -122,8 +158,7 @@ async function main() {
     expectEqual(movedBar?.id, barFolderId, 'moved bar id');
     expectEqual(movedBar?.parentId, fooFolderId, 'bar is now inside foo');
 
-    // ── 6. Verify final tree: foo → bar → baz ────────────────────────────────
-    console.log('\n[6] Verify organize tree');
+    console.log('\n[7] Verify organize tree');
     const { nodes = [] } = await call('list_organize_nodes', { workspaceId });
 
     const fooNode = nodes.find(n => n?.id === fooFolderId);
@@ -137,11 +172,13 @@ async function main() {
     const bazNode = nodes.find(n => n?.type === 'doc' && n?.data === bazDocId);
     expectTruthy(bazNode, 'baz doc node present in organize tree');
     expectEqual(bazNode?.parentId, barFolderId, 'baz is inside bar');
+    if (nodes.some(n => n?.type === 'doc' && n?.data === unplacedDocId)) {
+      throw new Error('unplaced doc should not have an organize link');
+    }
 
-    console.log('\n✓ Tree confirmed: foo → bar → baz');
+    console.log('\nTree confirmed: foo -> bar -> baz');
 
-    // ── 7. Move "baz" directly under "foo" ───────────────────────────────────
-    console.log('\n[7] Move "baz" to under "foo"');
+    console.log('\n[8] Move "baz" to under "foo"');
     const movedBaz = await call('move_organize_node', {
       workspaceId,
       nodeId: bazNode.id,
@@ -150,8 +187,7 @@ async function main() {
     expectEqual(movedBaz?.id, bazNode.id, 'moved baz id');
     expectEqual(movedBaz?.parentId, fooFolderId, 'baz is now inside foo');
 
-    // ── 8. Verify final tree: foo → bar (empty), foo → baz ───────────────────
-    console.log('\n[8] Verify final tree');
+    console.log('\n[9] Verify final tree');
     const { nodes: finalNodes = [] } = await call('list_organize_nodes', { workspaceId });
 
     const finalBarNode = finalNodes.find(n => n?.id === barFolderId);
@@ -167,7 +203,7 @@ async function main() {
       throw new Error(`bar should be empty after moving baz, found ${barChildren.length} child(ren)`);
     }
 
-    console.log('\n✓ Tree confirmed: foo → bar (empty), foo → baz');
+    console.log('\nTree confirmed: foo -> bar (empty), foo -> baz');
 
   } finally {
     if (workspaceId && !NO_CLEANUP) {
@@ -183,6 +219,6 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('\n✗', err.message);
+  console.error('\nFAILED:', err.message);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Centralize organize-link creation behind `addOrganizeLinkToFolder` so `create_doc` reuses the same folder link path as `add_organize_link`.
- Keep failed `folderId` placement responses explicit with `folderId: null`, `folderLinked: false`, `folderNodeId: null`, and warnings.
- Rename the folder placement integration script and add response-contract assertions for successful and failed folder placement.

## Validation
- `npm run build`
- `npm test`
- `npm run pack:check`
- `rg -n "[가-힣]" --hidden --glob '!.git/*' /Users/dawncrow/.codex/worktrees/b14a/affine-mcp-server`

## Notes
- `npm run test:create-doc-folder-placement` was attempted locally and stopped before execution because `AFFINE_ADMIN_PASSWORD` is not set in this environment.
