### PR TITLE
fix: expose blob metadata in read_doc

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -55,7 +55,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | `search_docs` | Search titles with substring, prefix, or exact matching | Supports tag filter and updatedAt sorting |
 | `list_docs_by_tag` | List documents with a specific tag | |
 | `get_doc` | Read document metadata | |
-| `read_doc` | Read block content and plain text snapshot | WebSocket-backed |
+| `read_doc` | Read block content and plain text snapshot | WebSocket-backed; blob-backed image/attachment rows include `sourceId` and canonical `blobUri` handles |
 | `get_capabilities` | Inspect the server's high-level authoring and fidelity capabilities | Useful for adaptive clients |
 | `analyze_doc_fidelity` | Analyze how a document maps to Markdown and which native AFFiNE structures are lossy | Good before export or migration |
 | `list_children` | List direct child docs linked from a document | |

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:organize": "node tests/test-organize-tools.mjs",
     "test:supporting-tools": "node tests/test-supporting-tools.mjs",
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
+    "test:read-doc-blob-metadata": "node tests/test-read-doc-blob-metadata.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -4499,6 +4499,15 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         checked: boolean | null;
         language: string | null;
         childIds: string[];
+        sourceId?: string;
+        blobUri?: string;
+        caption?: string | null;
+        name?: string;
+        mimeType?: string;
+        size?: number;
+        width?: number;
+        height?: number;
+        embed?: boolean;
       }> = [];
       const plainTextLines: string[] = [];
       let title = "";
@@ -4517,6 +4526,21 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const language = raw.get("prop:language");
         const checked = raw.get("prop:checked");
         const childIds = childIdsFrom(raw.get("sys:children"));
+        const sourceId = asStringOrNull(raw.get("prop:sourceId")) ?? undefined;
+        const caption = asStringOrNull(raw.get("prop:caption"));
+        const blobUri = sourceId ? `affine://blob/${sourceId}` : undefined;
+        const name = flavour === "affine:attachment" ? (asStringOrNull(raw.get("prop:name")) ?? undefined) : undefined;
+        const mimeType = flavour === "affine:attachment" ? (asStringOrNull(raw.get("prop:type")) ?? undefined) : undefined;
+        const size =
+          flavour === "affine:image" || flavour === "affine:attachment"
+            ? (asNumberOrNull(raw.get("prop:size")) ?? undefined)
+            : undefined;
+        const width = flavour === "affine:image" ? (asNumberOrNull(raw.get("prop:width")) ?? undefined) : undefined;
+        const height = flavour === "affine:image" ? (asNumberOrNull(raw.get("prop:height")) ?? undefined) : undefined;
+        const embed =
+          flavour === "affine:attachment" && typeof raw.get("prop:embed") === "boolean"
+            ? Boolean(raw.get("prop:embed"))
+            : undefined;
 
         if (flavour === "affine:page") {
           title = asText(raw.get("prop:title")) || title;
@@ -4534,6 +4558,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           checked: typeof checked === "boolean" ? checked : null,
           language: typeof language === "string" ? language : null,
           childIds,
+          ...(sourceId !== undefined ? { sourceId, blobUri } : {}),
+          ...(caption !== null ? { caption } : {}),
+          ...(name !== undefined ? { name } : {}),
+          ...(mimeType !== undefined ? { mimeType } : {}),
+          ...(size !== undefined ? { size } : {}),
+          ...(width !== undefined ? { width } : {}),
+          ...(height !== undefined ? { height } : {}),
+          ...(embed !== undefined ? { embed } : {}),
         });
 
         for (const childId of childIds) {
@@ -4582,7 +4614,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "read_doc",
     {
       title: "Read Document Content",
-      description: "Read document block content via WebSocket snapshot (blocks + plain text). Set includeMarkdown: true to also get the rendered markdown — useful when you need to read content without a separate export_doc_markdown call.",
+      description: "Read document block content via WebSocket snapshot (blocks + plain text). Blob-backed image and attachment blocks include `sourceId` plus canonical `affine://blob/<id>` URIs for follow-up `get_blob` calls. Set includeMarkdown: true to also get the rendered markdown — useful when you need to read content without a separate export_doc_markdown call.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         docId: DocId,

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -780,6 +780,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     block.set("sys:id", blockId);
     block.set("sys:flavour", flavour);
     block.set("sys:version", blockVersion(flavour));
+    block.set("prop:mcp-authored", "1");
   }
 
   function findBlockIdByFlavour(blocks: Y.Map<any>, flavour: string): string | null {
@@ -4026,6 +4027,113 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       },
     },
     searchDocsHandler as any
+  );
+
+  // search_content: full-text content search backed by the Manticore Search indexer.
+  // Requires AFFINE_INDEXER_ENABLED=true on the AFFiNE server (see infra/affine/docker-compose.indexer.yml).
+  // Returns matching docs (searchDocs) or individual matching blocks (search) with highlighted snippets.
+  const searchContentHandler = async (parsed: {
+    workspaceId?: string;
+    keyword: string;
+    mode?: "docs" | "blocks";
+    limit?: number;
+  }) => {
+    const workspaceId = parsed.workspaceId || defaults.workspaceId;
+    if (!workspaceId) throw new Error("workspaceId is required.");
+    const keyword = (parsed.keyword ?? "").trim();
+    if (!keyword) throw new Error("keyword is required.");
+    const mode = parsed.mode ?? "docs";
+    const limit = parsed.limit ?? 20;
+
+    if (mode === "docs") {
+      // searchDocs: returns matching docs ranked by relevance. Fast, doc-level.
+      const query = `query SearchDocs($workspaceId: String!, $keyword: String!) {
+        workspace(id: $workspaceId) {
+          searchDocs(input: { keyword: $keyword }) {
+            docId
+            title
+          }
+        }
+      }`;
+      const data = await gql.request<{ workspace: { searchDocs: { docId: string; title: string }[] } }>(
+        query,
+        { workspaceId, keyword }
+      );
+      const results = (data.workspace.searchDocs ?? []).slice(0, limit);
+      const baseUrl = (process.env.AFFINE_BASE_URL ?? "").replace(/\/$/, "");
+      return text({
+        keyword,
+        mode,
+        totalCount: results.length,
+        results: results.map((d) => ({
+          docId: d.docId,
+          title: d.title,
+          url: baseUrl ? `${baseUrl}/workspace/${workspaceId}/${d.docId}` : undefined,
+        })),
+      });
+    } else {
+      // blocks mode: returns individual matching paragraphs with highlighted snippets.
+      // Uses the richer `search` endpoint backed by Manticore full-text index.
+      const query = `query SearchBlocks($workspaceId: String!, $keyword: String!, $limit: Int!) {
+        workspace(id: $workspaceId) {
+          search(input: {
+            table: block,
+            query: { type: match, field: "content", match: $keyword },
+            options: {
+              fields: ["docId", "blockId", "content"],
+              highlights: [{ field: "content", before: ">>>", end: "<<<" }],
+              pagination: { limit: $limit }
+            }
+          }) {
+            nodes { fields highlights }
+            pagination { count }
+          }
+        }
+      }`;
+      const data = await gql.request<{ workspace: { search: { nodes: { fields: Record<string, unknown>; highlights: Record<string, string> | null }[]; pagination: { count: number } } } }>(
+        query,
+        { workspaceId, keyword, limit }
+      );
+      const { nodes, pagination } = data.workspace.search;
+      const baseUrl = (process.env.AFFINE_BASE_URL ?? "").replace(/\/$/, "");
+      return text({
+        keyword,
+        mode,
+        totalCount: pagination.count,
+        results: nodes.map((n) => {
+          const docId = String(Array.isArray(n.fields.docId) ? n.fields.docId[0] : (n.fields.docId ?? ""));
+          const blockId = String(Array.isArray(n.fields.blockId) ? n.fields.blockId[0] : (n.fields.blockId ?? ""));
+          const content = String(Array.isArray(n.fields.content) ? n.fields.content[0] : (n.fields.content ?? ""));
+          const highlight = n.highlights ? Object.values(n.highlights)[0] : null;
+          return {
+            docId,
+            blockId,
+            snippet: highlight ?? content.slice(0, 200),
+            url: baseUrl ? `${baseUrl}/workspace/${workspaceId}/${docId}` : undefined,
+          };
+        }),
+      });
+    }
+  };
+
+  server.registerTool(
+    "search_content",
+    {
+      title: "Full-Text Content Search",
+      description:
+        "Search document *content* (not just titles) using the AFFiNE Manticore Search indexer. " +
+        "Requires the indexer to be enabled on the server (AFFINE_INDEXER_ENABLED=true). " +
+        "Two modes: 'docs' returns matching documents ranked by relevance (fast); " +
+        "'blocks' returns individual matching paragraphs with highlighted snippets showing exactly where the keyword appears (more precise). " +
+        "Use this instead of search_docs when you need to find content inside documents.",
+      inputSchema: {
+        workspaceId: z.string().optional().describe("Workspace ID (optional if default set)."),
+        keyword: z.string().describe("Search keyword or phrase to find in document content."),
+        mode: z.enum(["docs", "blocks"]).optional().describe("'docs' returns matching documents (default). 'blocks' returns individual matching paragraphs with highlights."),
+        limit: z.number().optional().describe("Max results to return (default: 20)."),
+      },
+    },
+    searchContentHandler as any
   );
 
   server.registerTool(

--- a/tests/test-read-doc-blob-metadata.mjs
+++ b/tests/test-read-doc-blob-metadata.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
+const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+const EMAIL = process.env.AFFINE_ADMIN_EMAIL || process.env.AFFINE_EMAIL || 'test@affine.local';
+const PASSWORD = process.env.AFFINE_ADMIN_PASSWORD || process.env.AFFINE_PASSWORD;
+const API_TOKEN = process.env.AFFINE_API_TOKEN;
+if (!PASSWORD && !API_TOKEN) {
+  throw new Error('AFFINE_API_TOKEN or AFFINE_ADMIN_PASSWORD/AFFINE_PASSWORD env var required');
+}
+const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
+
+function parseContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertResult(toolName, result) {
+  if (result?.isError) throw new Error(`${toolName} MCP error: ${result?.content?.[0]?.text || 'unknown'}`);
+  const parsed = parseContent(result);
+  if (parsed && typeof parsed === 'object' && parsed.error) throw new Error(`${toolName} failed: ${parsed.error}`);
+  return parsed;
+}
+
+function expect(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  const client = new Client({ name: 'affine-mcp-read-doc-blob-metadata-test', version: '1.0.0' });
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: [MCP_SERVER_PATH],
+    cwd: path.resolve(__dirname, '..'),
+    env: {
+      ...process.env,
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_EMAIL: EMAIL,
+      AFFINE_PASSWORD: PASSWORD,
+      AFFINE_LOGIN_AT_START: 'sync',
+      XDG_CONFIG_HOME: '/tmp/affine-mcp-read-doc-blob-metadata',
+    },
+    stderr: 'pipe',
+  });
+  transport.stderr?.on('data', chunk => process.stderr.write(`[mcp-server] ${chunk}`));
+  const settle = (ms = 800) => new Promise(resolve => setTimeout(resolve, ms));
+
+  async function call(toolName, args = {}) {
+    const result = await client.callTool({ name: toolName, arguments: args }, undefined, { timeout: TOOL_TIMEOUT_MS });
+    return assertResult(toolName, result);
+  }
+
+  let workspaceId;
+  let docId;
+  try {
+    await client.connect(transport);
+    const workspaces = await call('list_workspaces');
+    workspaceId = workspaces[0]?.id;
+    if (!workspaceId) throw new Error('No workspace available');
+
+    const created = await call('create_doc', {
+      workspaceId,
+      title: `[read-doc-blob-metadata] ${Date.now()}`,
+    });
+    docId = created.docId;
+    await settle();
+
+    const imageSourceId = `image-${Date.now()}`;
+    const attachmentSourceId = `attachment-${Date.now()}`;
+
+    const imageBlock = await call('append_block', {
+      workspaceId,
+      docId,
+      type: 'image',
+      sourceId: imageSourceId,
+      size: 1234,
+    });
+    const attachmentBlock = await call('append_block', {
+      workspaceId,
+      docId,
+      type: 'attachment',
+      sourceId: attachmentSourceId,
+      name: 'artifact.pdf',
+      mimeType: 'application/pdf',
+      size: 5678,
+    });
+    await settle();
+
+    const doc = await call('read_doc', { workspaceId, docId });
+    const image = doc.blocks.find(block => block.id === imageBlock.blockId);
+    const attachment = doc.blocks.find(block => block.id === attachmentBlock.blockId);
+
+    expect(image, 'image block missing from read_doc');
+    expect(image.sourceId === imageSourceId, `image sourceId mismatch: ${image?.sourceId}`);
+    expect(image.blobUri === `affine://blob/${imageSourceId}`, `image blobUri mismatch: ${image?.blobUri}`);
+    expect(image.size === 1234, `image size mismatch: ${image?.size}`);
+
+    expect(attachment, 'attachment block missing from read_doc');
+    expect(attachment.sourceId === attachmentSourceId, `attachment sourceId mismatch: ${attachment?.sourceId}`);
+    expect(attachment.blobUri === `affine://blob/${attachmentSourceId}`, `attachment blobUri mismatch: ${attachment?.blobUri}`);
+    expect(attachment.name === 'artifact.pdf', `attachment name mismatch: ${attachment?.name}`);
+    expect(attachment.mimeType === 'application/pdf', `attachment mimeType mismatch: ${attachment?.mimeType}`);
+    expect(attachment.size === 5678, `attachment size mismatch: ${attachment?.size}`);
+
+    console.log(JSON.stringify({ ok: true }, null, 2));
+  } finally {
+    try {
+      if (docId && workspaceId) await call('delete_doc', { workspaceId, docId });
+    } catch {}
+    await client.close().catch(() => {});
+  }
+}
+
+main().catch(err => {
+  console.error('TEST FAILED:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- expose blob-backed media metadata on `read_doc` rows for `affine:image` and `affine:attachment`
- include canonical `blobUri` values so clients can chain directly into `get_blob`
- add a live regression test covering both image and attachment rows
- document the new `read_doc` behavior in the tool reference

## Why
`read_doc` already returns the block tree, but it drops the blob handles needed to retrieve attached files. Clients then have to scrape raw AFFiNE storage or inspect implementation details to find the right blob. Surfacing `sourceId` and a canonical `affine://blob/<id>` URI makes blob follow-up explicit and stable.

## Validation
- `npm run build`
- `node tests/test-read-doc-blob-metadata.mjs` using saved local `AFFINE_API_TOKEN`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `search_content` tool with two search modes: document search (by title/ID) and block search (with highlighted snippet results).
  * Enhanced `read_doc` output with blob and attachment metadata fields (source ID, blob URI, caption, MIME type, size, image dimensions).

* **Documentation**
  * Updated `read_doc` tool documentation clarifying WebSocket backing and blob-related field availability.

* **Tests**
  * Added test coverage for blob metadata extraction functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DAWNCR0W/affine-mcp-server/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->