### PR TITLE
fix(table): use valid fractional-indexing keys for row/column order

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { generateKeyBetween } from "fractional-indexing";
+import { generateKeyBetween, generateNKeysBetween } from "fractional-indexing";
 import { GraphQLClient } from "../graphqlClient.js";
 import { receipt, text } from "../util/mcp.js";
 import { wsUrlFromGraphQLEndpoint, connectWorkspaceSocket, joinWorkspace, loadDoc, pushDocUpdate, deleteDoc as wsDeleteDoc } from "../ws.js";
@@ -1682,16 +1682,24 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const columnIds: string[] = [];
         const tableData = normalized.tableData ?? [];
 
+        // Row/column `order` must be valid fractional-indexing keys. AFFiNE's
+        // editor computes the next order with generateKeyBetween(prevOrder, ...)
+        // when inserting a row/column; plain strings like "r0000" render but make
+        // that call throw "invalid order key", so rows/columns cannot be added in
+        // the UI. Use real keys (a0, a1, ...) so insertion works.
+        const rowOrders = generateNKeysBetween(null, null, normalized.rows);
+        const columnOrders = generateNKeysBetween(null, null, normalized.columns);
+
         for (let i = 0; i < normalized.rows; i++) {
           const rowId = generateId();
           block.set(`prop:rows.${rowId}.rowId`, rowId);
-          block.set(`prop:rows.${rowId}.order`, `r${String(i).padStart(4, "0")}`);
+          block.set(`prop:rows.${rowId}.order`, rowOrders[i]);
           rowIds.push(rowId);
         }
         for (let i = 0; i < normalized.columns; i++) {
           const columnId = generateId();
           block.set(`prop:columns.${columnId}.columnId`, columnId);
-          block.set(`prop:columns.${columnId}.order`, `c${String(i).padStart(4, "0")}`);
+          block.set(`prop:columns.${columnId}.order`, columnOrders[i]);
           columnIds.push(columnId);
         }
         for (let rowIndex = 0; rowIndex < rowIds.length; rowIndex += 1) {


### PR DESCRIPTION
## Problem

Tables created through the MCP render correctly in AFFiNE but **cannot be extended in the UI** — clicking "add row" / "add column" does nothing. This affects both creation paths:

- `append_block` with `type: "table"`
- markdown import (`create_doc_from_markdown`, `append_markdown`, `replace_doc_with_markdown`)

## Root cause

In `src/tools/docs.ts`, the `case "table"` builder writes row/column `order` as plain padded strings:

```ts
block.set(`prop:rows.${rowId}.order`, `r${String(i).padStart(4, "0")}`);   // "r0000"
block.set(`prop:columns.${columnId}.order`, `c${String(i).padStart(4, "0")}`); // "c0000"
```

These sort lexicographically (so rendering looks fine), but they are **not valid fractional-indexing keys**. AFFiNE/blocksuite's table data manager computes the order for an inserted row/column with `generateFractionalIndexingKeyBetween(prevOrder, …)`, which calls `generateKeyBetween(prevOrder, …)` from the `fractional-indexing` package. With `prevOrder = "r0009"` that throws:

```
generateKeyBetween("r0009", null) => Error: invalid order key: r0009
```

So the editor's insert-row/insert-column handler throws and the operation is a no-op. (Reference: blocksuite `affine:table` model — `packages/affine/model/src/blocks/table/table-model.ts`, `isFlatData: true`; insertion logic in `packages/affine/blocks/table/src/table-data-manager.ts`.)

## Fix

Generate real fractional-indexing keys with `generateNKeysBetween(null, null, n)` (the same library already imported in this file), which yields `["a0", "a1", "a2", …]`. These render in order **and** validate, so `generateKeyBetween(lastOrder, null)` succeeds and rows/columns can be inserted.

```ts
const rowOrders = generateNKeysBetween(null, null, normalized.rows);
const columnOrders = generateNKeysBetween(null, null, normalized.columns);
// …
block.set(`prop:rows.${rowId}.order`, rowOrders[i]);
block.set(`prop:columns.${columnId}.order`, columnOrders[i]);
```

The flat dot-notation key layout (`prop:rows.{id}.order`, etc.) is unchanged — only the `order` **value format** is corrected.

## Verification

- `generateKeyBetween("r0009", null)` throws `invalid order key`; `generateKeyBetween("a2", null)` succeeds — confirming the format is the cause.
- Built and tested against a self-hosted AFFiNE instance: after the fix, **rows and columns can be added** to MCP-created tables, via both `append_block type="table"` and markdown import. Existing rendering is unchanged.

## Scope

One file (`src/tools/docs.ts`): one import widened, two `order` assignments changed. No API/tool-surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row and column insertion in tables to use proper ordering keys, ensuring correct positioning when adding new rows or columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->