### PR TITLE
fix(hierarchy): include inline LinkedPage refs in doc tree tools

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -26,6 +26,31 @@ import {
   stackRelativeTo,
 } from "../edgeless/layout.js";
 
+function collectLinkedChildIds(blocks: Y.Map<any>): string[] {
+  const ids: string[] = [];
+  for (const [, raw] of blocks) {
+    if (!(raw instanceof Y.Map)) continue;
+    const flavour = raw.get("sys:flavour");
+    if (flavour === "affine:embed-linked-doc" || flavour === "affine:embed-synced-doc") {
+      const pid = raw.get("prop:pageId");
+      if (typeof pid === "string" && pid) ids.push(pid);
+    }
+    const propText = raw.get("prop:text");
+    if (propText instanceof Y.Text) {
+      const delta = propText.toDelta();
+      if (Array.isArray(delta)) {
+        for (const d of delta) {
+          const reference = (d as any).attributes?.reference;
+          if (reference?.type === "LinkedPage" && typeof reference.pageId === "string" && reference.pageId) {
+            ids.push(reference.pageId);
+          }
+        }
+      }
+    }
+  }
+  return ids;
+}
+
 const WorkspaceId = z.string().min(1, "workspaceId required");
 const DocId = z.string().min(1, "docId required");
 const MarkdownContent = z.string().min(1, "markdown required");
@@ -5696,11 +5721,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
         const blocks = doc.getMap("blocks") as Y.Map<any>;
         const kids: string[] = [];
-        for (const [, raw] of blocks) {
-          if (!(raw instanceof Y.Map)) continue;
-          if (raw.get("sys:flavour") !== "affine:embed-linked-doc") continue;
-          const pid = raw.get("prop:pageId");
-          if (typeof pid === "string" && pid && titleById.has(pid)) {
+        for (const pid of collectLinkedChildIds(blocks)) {
+          if (titleById.has(pid) && !kids.includes(pid)) {
             kids.push(pid);
             allChildren.add(pid);
           }
@@ -5748,11 +5770,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const doc = new Y.Doc();
         Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
         const blocks = doc.getMap("blocks") as Y.Map<any>;
-        for (const [, raw] of blocks) {
-          if (!(raw instanceof Y.Map)) continue;
-          if (raw.get("sys:flavour") !== "affine:embed-linked-doc") continue;
-          const pageId = raw.get("prop:pageId");
-          if (typeof pageId === "string" && pageId) allChildren.add(pageId);
+        for (const pageId of collectLinkedChildIds(blocks)) {
+          allChildren.add(pageId);
         }
       }
       const baseUrl = (process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, "")).replace(/\/$/, "");
@@ -5768,7 +5787,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   };
   server.registerTool("get_orphan_docs", {
     title: "Get Orphan Documents",
-    description: "Find all documents that have no parent (not linked from any other doc via embed_linked_doc). Useful for workspace hygiene. Note: scans all docs — O(n).",
+    description: "Find all documents that have no parent (not linked from any other doc via embed_linked_doc / embed_synced_doc blocks or inline LinkedPage references). Useful for workspace hygiene. Note: scans all docs — O(n).",
     inputSchema: { workspaceId: z.string().optional() },
   }, getOrphanDocsHandler as any);
 
@@ -5795,21 +5814,19 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
       const blocks = doc.getMap("blocks") as Y.Map<any>;
       const children: Array<{ docId: string; title: string | null; url: string }> = [];
-      for (const [, raw] of blocks) {
-        if (!(raw instanceof Y.Map)) continue;
-        if (raw.get("sys:flavour") !== "affine:embed-linked-doc") continue;
-        const pageId = raw.get("prop:pageId");
-        if (typeof pageId === "string" && pageId) {
-          children.push({ docId: pageId, title: titleById.get(pageId) ?? null,
-            url: `${(process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '')}/workspace/${workspaceId}/${pageId}` });
-        }
+      const seen = new Set<string>();
+      for (const pageId of collectLinkedChildIds(blocks)) {
+        if (seen.has(pageId)) continue;
+        seen.add(pageId);
+        children.push({ docId: pageId, title: titleById.get(pageId) ?? null,
+          url: `${(process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '')}/workspace/${workspaceId}/${pageId}` });
       }
       return text({ docId: parsed.docId, count: children.length, children });
     } finally { socket.disconnect(); }
   };
   server.registerTool("list_children", {
     title: "List Document Children",
-    description: "List the direct children of a document in the sidebar (embed_linked_doc blocks). Returns docId, title, and URL for each child.",
+    description: "List the direct children of a document in the sidebar (embed_linked_doc / embed_synced_doc blocks and inline LinkedPage references). Returns docId, title, and URL for each child.",
     inputSchema: {
       workspaceId: z.string().optional(),
       docId: z.string().describe("The parent doc whose children to list."),

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -27,14 +27,30 @@ import {
 } from "../edgeless/layout.js";
 
 function collectLinkedChildIds(blocks: Y.Map<any>): string[] {
-  const ids: string[] = [];
+  const databaseRowIds = new Set<string>();
   for (const [, raw] of blocks) {
+    if (!(raw instanceof Y.Map)) continue;
+    if (raw.get("sys:flavour") !== "affine:database") continue;
+    const rows = raw.get("sys:children");
+    if (rows instanceof Y.Array) {
+      rows.forEach((entry: unknown) => {
+        if (typeof entry === "string") databaseRowIds.add(entry);
+        else if (Array.isArray(entry)) {
+          for (const child of entry) if (typeof child === "string") databaseRowIds.add(child);
+        }
+      });
+    }
+  }
+
+  const ids: string[] = [];
+  for (const [blockId, raw] of blocks) {
     if (!(raw instanceof Y.Map)) continue;
     const flavour = raw.get("sys:flavour");
     if (flavour === "affine:embed-linked-doc" || flavour === "affine:embed-synced-doc") {
       const pid = raw.get("prop:pageId");
       if (typeof pid === "string" && pid) ids.push(pid);
     }
+    if (databaseRowIds.has(String(blockId))) continue;
     const propText = raw.get("prop:text");
     if (propText instanceof Y.Text) {
       const delta = propText.toDelta();
@@ -5800,11 +5816,15 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     try {
       await joinWorkspace(socket, workspaceId);
       const titleById = new Map<string, string>();
+      const workspacePageIds = new Set<string>();
+      let hasWorkspaceMetadata = false;
       const wsSnap = await loadDoc(socket, workspaceId, workspaceId);
       if (wsSnap.missing) {
+        hasWorkspaceMetadata = true;
         const wsDoc = new Y.Doc();
         Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
         for (const page of getWorkspacePageEntries(wsDoc.getMap("meta"))) {
+          workspacePageIds.add(page.id);
           if (page.title) titleById.set(page.id, page.title);
         }
       }
@@ -5816,6 +5836,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const children: Array<{ docId: string; title: string | null; url: string }> = [];
       const seen = new Set<string>();
       for (const pageId of collectLinkedChildIds(blocks)) {
+        if (hasWorkspaceMetadata && !workspacePageIds.has(pageId)) continue;
         if (seen.has(pageId)) continue;
         seen.add(pageId);
         children.push({ docId: pageId, title: titleById.get(pageId) ?? null,


### PR DESCRIPTION
## Summary
The document-hierarchy tools (`list_children`, `list_workspace_tree`, `get_orphan_docs`)
only treated `affine:embed-linked-doc` blocks as sidebar children. AFFiNE also nests a
doc under another via an inline `@`-mention (LinkedPage) reference inside a list item /
paragraph (stored in `prop:text`, not as a block). Those references were ignored, so docs
nested that way appeared flat / orphaned and their real parent looked childless.

Builds on #196, which exposed inline refs in `read_doc` (via `extractLinkedPageRefs` +
`linkedDocIds`). This PR applies the same extraction to the three hierarchy tools, which
still only scanned embed blocks.

## Changes
- Add a module-level `collectLinkedChildIds(blocks)` helper that resolves child doc ids
  from both embed cards (`affine:embed-linked-doc` / `affine:embed-synced-doc` via
  `prop:pageId`) and inline LinkedPage references in block `prop:text`.
- Use it in `list_children`, `list_workspace_tree`, and `get_orphan_docs` (with
  de-duplication), so inline-nested docs are reported correctly.
- Update the `list_children` and `get_orphan_docs` tool descriptions to mention inline
  references.
- Backward compatible: output shapes are unchanged; the tools simply return the
  inline-linked children they previously missed (and fewer false orphans). No tools
  added / removed / renamed.

## Validation
Commands executed:
```bash
npm run build              # tsc — passed (exit 0)
npm run test:tool-manifest # passed (exit 0); tool list unchanged
```
`npm run test:comprehensive` boots a local Docker AFFiNE stack and was not run in this
environment. The change was instead verified against a live self-hosted AFFiNE: a doc
nested via an inline `@`-link now appears under its parent in `list_children` /
`list_workspace_tree` and is no longer returned by `get_orphan_docs`.

## Checklist
- [x] Tool names remain unique and `snake_case`
- [x] `tool-manifest.json` updated if tool list changed _(no tools added/removed/renamed — manifest unchanged; `test:tool-manifest` passes)_
- [ ] `README.md` updated if behavior/user-facing API changed _(tool descriptions updated in-code; no API signature change — optionally note in `docs/tool-reference.md`)_
- [x] Backward compatibility impact described (if any) _(fully backward compatible — see Changes)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace hierarchy detection to include both embedded-linked documents and inline linked-page references, so the sidebar and document relationship views now reflect the full set of connected documents.
  * Orphaned document detection is more accurate, preventing valid linked documents from being incorrectly marked as orphans.

* **Refactor**
  * Updated hierarchy and child-document listing to use a unified relationship collection approach and avoid duplicate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->