### PR TITLE
Feat: intrash flag

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -792,6 +792,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     title: string | null;
     createDate: number | null;
     updatedDate: number | null;
+    inTrash: boolean;
     entry: Y.Map<any>;
     tagsArray: Y.Array<string> | null;
   };
@@ -814,12 +815,20 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const title = value.get("title");
       const createDate = value.get("createDate");
       const updatedDate = value.get("updatedDate");
+      const inTrashRaw = value.get("inTrash");
+      const trashRaw = value.get("trash");
+      const trashDate = value.get("trashDate");
+      const inTrash =
+        typeof inTrashRaw === "boolean" ? inTrashRaw
+        : typeof trashRaw === "boolean" ? trashRaw
+        : (typeof trashDate === "number" && trashDate > 0);
       entries.push({
         index,
         id,
         title: typeof title === "string" ? title : null,
         createDate: typeof createDate === "number" ? createDate : null,
         updatedDate: typeof updatedDate === "number" ? updatedDate : null,
+        inTrash,
         entry: value,
         tagsArray: getTagArray(value),
       });
@@ -5728,6 +5737,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
       const pages = getWorkspacePageEntries(wsDoc.getMap("meta"));
       const titleById = new Map(pages.map(p => [p.id, p.title ?? "Untitled"]));
+      const trashById = new Map(pages.map(p => [p.id, p.inTrash]));
       const childrenOf = new Map<string, string[]>();
       const allChildren = new Set<string>();
       for (const page of pages) {
@@ -5750,6 +5760,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const buildNode = (id: string, depth: number): any => ({
         docId: id, title: titleById.get(id) ?? "Untitled",
         url: `${baseUrl}/workspace/${workspaceId}/${id}`,
+        inTrash: trashById.get(id) ?? false,
         children: depth < maxDepth ? (childrenOf.get(id) ?? []).map(cid => buildNode(cid, depth + 1)) : [],
       });
       return text({ workspaceId, totalDocs: pages.length, rootCount: roots.length, tree: roots.map(id => buildNode(id, 0)) });
@@ -5757,7 +5768,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   };
   server.registerTool("list_workspace_tree", {
     title: "List Workspace Tree",
-    description: "Returns the full document hierarchy as a tree (roots → children → grandchildren). Use depth to limit nesting (default: 3). Note: loads all docs — may be slow on large workspaces.",
+    description: "Returns the full document hierarchy as a tree (roots → children → grandchildren). Use depth to limit nesting (default: 3). Note: loads all docs — may be slow on large workspaces. Each node includes an inTrash flag.",
     inputSchema: {
       workspaceId: z.string().optional(),
       depth: z.number().optional().describe("Max nesting depth to return (default: 3)."),
@@ -5779,6 +5790,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
       const pages = getWorkspacePageEntries(wsDoc.getMap("meta"));
       const titleById = new Map(pages.map(p => [p.id, p.title ?? "Untitled"]));
+      const trashById = new Map(pages.map(p => [p.id, p.inTrash]));
       const allChildren = new Set<string>();
       for (const page of pages) {
         const snap = await loadDoc(socket, workspaceId, page.id);
@@ -5797,13 +5809,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           docId: p.id,
           title: titleById.get(p.id) ?? "Untitled",
           url: `${baseUrl}/workspace/${workspaceId}/${p.id}`,
+          inTrash: p.inTrash,
         }));
       return text({ count: orphans.length, orphans });
     } finally { socket.disconnect(); }
   };
   server.registerTool("get_orphan_docs", {
     title: "Get Orphan Documents",
-    description: "Find all documents that have no parent (not linked from any other doc via embed_linked_doc / embed_synced_doc blocks or inline LinkedPage references). Useful for workspace hygiene. Note: scans all docs — O(n).",
+    description: "Find all documents that have no parent (not linked from any other doc via embed_linked_doc / embed_synced_doc blocks or inline LinkedPage references). Useful for workspace hygiene. Note: scans all docs — O(n). Each doc includes an inTrash flag.",
     inputSchema: { workspaceId: z.string().optional() },
   }, getOrphanDocsHandler as any);
 
@@ -5816,6 +5829,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     try {
       await joinWorkspace(socket, workspaceId);
       const titleById = new Map<string, string>();
+      const trashById = new Map<string, boolean>();
       const workspacePageIds = new Set<string>();
       let hasWorkspaceMetadata = false;
       const wsSnap = await loadDoc(socket, workspaceId, workspaceId);
@@ -5825,6 +5839,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
         for (const page of getWorkspacePageEntries(wsDoc.getMap("meta"))) {
           workspacePageIds.add(page.id);
+          trashById.set(page.id, page.inTrash);
           if (page.title) titleById.set(page.id, page.title);
         }
       }
@@ -5833,21 +5848,22 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const doc = new Y.Doc();
       Y.applyUpdate(doc, Buffer.from(snap.missing, "base64"));
       const blocks = doc.getMap("blocks") as Y.Map<any>;
-      const children: Array<{ docId: string; title: string | null; url: string }> = [];
+      const children: Array<{ docId: string; title: string | null; url: string; inTrash: boolean }> = [];
       const seen = new Set<string>();
       for (const pageId of collectLinkedChildIds(blocks)) {
         if (hasWorkspaceMetadata && !workspacePageIds.has(pageId)) continue;
         if (seen.has(pageId)) continue;
         seen.add(pageId);
         children.push({ docId: pageId, title: titleById.get(pageId) ?? null,
-          url: `${(process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '')}/workspace/${workspaceId}/${pageId}` });
+          url: `${(process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '')).replace(/\/$/, '')}/workspace/${workspaceId}/${pageId}`,
+          inTrash: trashById.get(pageId) ?? false });
       }
       return text({ docId: parsed.docId, count: children.length, children });
     } finally { socket.disconnect(); }
   };
   server.registerTool("list_children", {
     title: "List Document Children",
-    description: "List the direct children of a document in the sidebar (embed_linked_doc / embed_synced_doc blocks and inline LinkedPage references). Returns docId, title, and URL for each child.",
+    description: "List the direct children of a document in the sidebar (embed_linked_doc / embed_synced_doc blocks and inline LinkedPage references). Returns docId, title, URL, and inTrash for each child.",
     inputSchema: {
       workspaceId: z.string().optional(),
       docId: z.string().describe("The parent doc whose children to list."),

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -3787,6 +3787,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
 
       const tagsByDocId = new Map<string, string[]>();
       const titlesByDocId = new Map<string, string>();
+      const inTrashByDocId = new Map<string, boolean>();
       let workspacePageCount: number | null = null;
       let workspacePageIds: Set<string> | null = null;
       const deletedDocIds = new Set<string>();
@@ -3811,6 +3812,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
               }
               const tagEntries = getStringArray(page.tagsArray);
               tagsByDocId.set(page.id, resolveTagLabels(tagEntries, byId));
+              inTrashByDocId.set(page.id, page.inTrash);
             }
           }
           const graphEdges = Array.isArray(docs?.edges) ? docs.edges : [];
@@ -3848,6 +3850,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
                 ...node,
                 title: titlesByDocId.get(node.id) || node.title,
                 tags: tagsByDocId.get(node.id) || [],
+                inTrash: inTrashByDocId.get(node.id) ?? false,
               },
             };
           })
@@ -3892,7 +3895,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "list_docs",
     {
       title: "List Documents",
-      description: "List documents in a workspace (GraphQL).",
+      description: "List documents in a workspace (GraphQL). Each doc includes an inTrash flag.",
       inputSchema: {
         workspaceId: z.string().describe("Workspace ID (optional if default set).").optional(),
         first: z.number().optional(),
@@ -5794,7 +5797,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       Y.applyUpdate(wsDoc, Buffer.from(wsSnap.missing, "base64"));
       const pages = getWorkspacePageEntries(wsDoc.getMap("meta"));
       const titleById = new Map(pages.map(p => [p.id, p.title ?? "Untitled"]));
-      const trashById = new Map(pages.map(p => [p.id, p.inTrash]));
       const allChildren = new Set<string>();
       for (const page of pages) {
         const snap = await loadDoc(socket, workspaceId, page.id);

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -4039,6 +4039,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             updatedAt: updatedTimestamp > 0 ? new Date(updatedTimestamp).toISOString() : null,
             updatedTimestamp,
             url: `${baseUrl}/workspace/${workspaceId}/${page.id}`,
+            inTrash: page.inTrash,
             rank,
           };
         })
@@ -4067,6 +4068,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           tags: entry.tags,
           updatedAt: entry.updatedAt,
           url: entry.url,
+          inTrash: entry.inTrash,
         }));
 
       return text({
@@ -4087,7 +4089,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "search_docs",
     {
       title: "Search Documents by Title",
-      description: "Fast search for documents by title using workspace metadata. Much faster than exporting each doc. Returns docId, title, and direct URL for each match.",
+      description: "Fast search for documents by title using workspace metadata. Much faster than exporting each doc. Returns docId, title, direct URL, and inTrash for each match.",
       inputSchema: {
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)."),
         query: z.string().describe("Search query — matched case-insensitively against doc titles."),
@@ -4139,7 +4141,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const meta = wsDoc.getMap("meta");
       const pages = getWorkspacePageEntries(meta);
 
-      type Match = { id: string; title: string; createdAt: string | null; updatedAt: string | null };
+      type Match = { id: string; title: string; createdAt: string | null; updatedAt: string | null; inTrash: boolean };
       const matches: Match[] = [];
       let truncated = false;
       for (const page of pages) {
@@ -4161,6 +4163,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           title: pageTitle,
           createdAt: page.createDate ? new Date(page.createDate).toISOString() : null,
           updatedAt: updatedTimestamp ? new Date(updatedTimestamp).toISOString() : null,
+          inTrash: page.inTrash,
         });
       }
 
@@ -4186,7 +4189,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         "Reads workspace metadata — fast, no per-doc fetch. " +
         "Unlike `search_docs` (which is always case-insensitive and capped at limit 20), this tool defaults to case-sensitive matching and returns up to `limit` matches (default 50, max 200). " +
         "Prefer this over `search_docs` when you know the exact title and want every match. " +
-        "Returns: { query, caseInsensitive, matches: [{ id, title, createdAt, updatedAt }], workspaceDocCount, truncated }.",
+        "Returns: { query, caseInsensitive, matches: [{ id, title, createdAt, updatedAt, inTrash }], workspaceDocCount, truncated }.",
       inputSchema: {
         workspaceId: z.string().optional().describe("Workspace ID (optional if AFFINE_WORKSPACE_ID is set)."),
         title: z.string().min(1).describe("The exact title to match."),
@@ -4243,6 +4246,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             updatedDate: page.updatedDate,
             tags,
             rawTags,
+            inTrash: page.inTrash,
           };
         })
         .filter((page) => hasTag(page.tags, tag, ignoreCase) || hasTag(page.rawTags, tag, ignoreCase))
@@ -4263,7 +4267,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "list_docs_by_tag",
     {
       title: "List Documents By Tag",
-      description: "List documents that contain the requested tag.",
+      description: "List documents that contain the requested tag. Each doc includes an inTrash flag.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         tag: z.string().min(1).describe("Tag name"),


### PR DESCRIPTION
## Summary
Workspace page metadata carries a trash flag (AFFiNE's "Move to Trash" sets it), but the MCP never surfaced it — so trashed docs showed up in tree / orphan / listing results with no indication they were in the trash. This adds an `inTrash: boolean` to the doc objects those tools return, computed from all known AFFiNE representations of the flag.

## Changes
- Add `inTrash: boolean` to `WorkspacePageEntry` and compute it once in `getWorkspacePageEntries`. Detection covers every known AFFiNE representation: boolean `inTrash`, legacy boolean `trash`, and numeric `trashDate`. Priority-based: an explicit boolean wins; `trashDate` is only a fallback when no boolean is present (avoids a false positive from a stale `trashDate` left after a restore).
- Surface `inTrash` on the returned objects of: `list_workspace_tree` (each node), `get_orphan_docs` (each doc), `list_children` (each child), `search_docs` (each result), `find_doc_by_title` (each match), `list_docs_by_tag` (each doc).
- Update the affected tool descriptions to mention the `inTrash` field.
- No filtering: trashed docs are still returned; the flag is just exposed so consumers can decide. Additive field only — no tools added / removed / renamed.

## Validation
Commands executed:
```bash
npm run build              # passed (exit 0)
npm run test:tool-manifest # passed (exit 0)
```
Additional checks: unit tests for the detection across all variants (`inTrash` / `trash` / `trashDate`, including the stale-`trashDate` edge case) pass. Verified live against a self-hosted AFFiNE — a doc moved to trash in the UI reports `inTrash: true` in `list_workspace_tree`; freshly created/tagged docs report `false` across the listing tools. `npm run test:comprehensive` boots a local Docker AFFiNE stack and was not run in this environment.

## Checklist
- [x] Tool names remain unique and `snake_case`
- [x] `tool-manifest.json` updated if tool list changed — N/A (no tools added/removed/renamed)
- [ ] `README.md` updated if behavior/user-facing API changed — tool descriptions updated in-code; additive field only, no API signature change
- [x] Backward compatibility impact described (if any)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document search and listing tools now return and display each document’s trash status.
  * Workspace tree and related listing results include an `inTrash` indicator so it’s clear whether items are marked as removed.
  * Tool responses and descriptions were updated to reflect the new `inTrash` field across supported document listing and search operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->