### PR TITLE
chore: improve Glama MCP quality metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you want to expose the server remotely over HTTP instead of stdio, start with
 
 ## Tool Surface
 
-`tool-manifest.json` is the source of truth for canonical tool names. The MCP server exposes those tools through `tools/list` and `tools/call`, with MCP annotations that mark read-only, destructive, idempotent, and external-world behavior for client-side tool selection.
+`tool-manifest.json` is the source of truth for canonical tool names. The MCP server exposes those tools through `tools/list` and `tools/call`; tool definitions returned by `tools/list` include MCP annotations that mark read-only, destructive, idempotent, and external-world behavior for client-side tool selection.
 
 Domains:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
 [![Version](https://img.shields.io/badge/version-2.4.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
-[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.17.2-green)](https://github.com/modelcontextprotocol/typescript-sdk)
+[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
 
@@ -164,7 +164,7 @@ If you want to expose the server remotely over HTTP instead of stdio, start with
 
 ## Tool Surface
 
-`tool-manifest.json` is the source of truth for canonical tool names. The MCP server exposes those tools through `tools/list` and `tools/call`.
+`tool-manifest.json` is the source of truth for canonical tool names. The MCP server exposes those tools through `tools/list` and `tools/call`, with MCP annotations that mark read-only, destructive, idempotent, and external-world behavior for client-side tool selection.
 
 Domains:
 
@@ -178,7 +178,7 @@ Domains:
 - Notifications: list and mark notifications as read
 - Blob storage: upload, delete, and cleanup blobs
 
-Use `AFFINE_TOOL_PROFILE=read_only`, `core`, or `authoring` when a deployment should expose a smaller surface than the complete `full` default. You can also combine profiles with `AFFINE_DISABLED_GROUPS` such as `docs.database`, `destructive`, or `admin` for finer control.
+Use `AFFINE_TOOL_PROFILE=read_only`, `core`, or `authoring` when a deployment should expose a smaller surface than the complete `full` default. This is the recommended path for hosted, browser-connected, or least-privilege deployments because it reduces agent choice overload while keeping the full tool catalog available as an opt-in surface. You can also combine profiles with `AFFINE_DISABLED_GROUPS` such as `docs.database`, `destructive`, or `admin` for finer control.
 
 For the grouped catalog, notes, and operational caveats, see [docs/tool-reference.md](docs/tool-reference.md).
 

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -77,7 +77,7 @@ Important note for AFFiNE Cloud:
 Prebuilt images are published to GHCR:
 
 - `ghcr.io/dawncr0w/affine-mcp-server:latest`
-- `ghcr.io/dawncr0w/affine-mcp-server:1.12.0`
+- `ghcr.io/dawncr0w/affine-mcp-server:2.4.0`
 
 Example:
 
@@ -101,11 +101,11 @@ Health endpoints:
 
 HTTP mode exposes:
 
-- `/mcp` - Streamable HTTP MCP endpoint
-- `/sse` - SSE endpoint for older-compatible clients
-- `/messages` - message endpoint for older-compatible clients
-- `/healthz` - liveness probe
-- `/readyz` - readiness probe
+- `/mcp` - Streamable HTTP MCP endpoint protected by the configured MCP auth mode
+- `/sse` - SSE endpoint for older-compatible clients protected by the configured MCP auth mode
+- `/messages` - message endpoint for older-compatible clients protected by the configured MCP auth mode
+- `/healthz` - unauthenticated liveness probe for trusted platform checks
+- `/readyz` - unauthenticated readiness probe for trusted platform checks
 
 ### Bearer mode
 
@@ -252,7 +252,10 @@ Before exposing the server remotely, confirm:
 - `MCP_TRANSPORT=http` is set
 - `AFFINE_MCP_AUTH_MODE` is correct for your client model
 - `AFFINE_MCP_HTTP_HOST=0.0.0.0` is set in containerized deployments
+- HTTPS or TLS termination is in front of any non-local HTTP deployment
+- bearer mode uses a long random `AFFINE_MCP_HTTP_TOKEN`, or OAuth is configured for multi-user access
 - `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` is set for browser-based clients
+- `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS` is not enabled outside local testing
 - `/healthz` and `/readyz` are wired into your platform checks
 - destructive tools are filtered if your deployment should be read-only or constrained
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "DAWNCR0W"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "dist",
     "docs",
     "README.md",
+    "SECURITY.md",
+    "glama.json",
     "tool-manifest.json",
     "LICENSE"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { runCli } from "./cli.js";
 import { startHttpMcpServer } from "./sse.js";
 import { existsSync } from "fs";
 import { CONFIG_FILE } from "./config.js";
-import { createToolFilter, toolFilterRequiresRegisterTool } from "./toolSurface.js";
+import { createToolFilter, toolAnnotationsFor, toolFilterRequiresRegisterTool } from "./toolSurface.js";
 
 // CLI commands: affine-mcp login|status|logout|version
 const rawArgs = process.argv.slice(2);
@@ -170,7 +170,13 @@ async function buildServer() {
   } else {
     (server as any).registerTool = (name: string, options: any, handler: any) => {
       if (!toolFilter.isEnabled(name)) return;
-      return originalRegisterTool(name, options, handler);
+      return originalRegisterTool(name, {
+        ...options,
+        annotations: {
+          ...toolAnnotationsFor(name),
+          ...(options?.annotations || {}),
+        },
+      }, handler);
     };
   }
   console.error(`[affine-mcp] Tool profile: ${toolFilter.profile}`);

--- a/src/toolSurface.ts
+++ b/src/toolSurface.ts
@@ -98,6 +98,12 @@ const ALL_TOOLS = [
 
 type ToolName = typeof ALL_TOOLS[number];
 type ToolProfile = "full" | "read_only" | "core" | "authoring";
+type ToolAnnotations = {
+  readOnlyHint: boolean;
+  destructiveHint: boolean;
+  idempotentHint: boolean;
+  openWorldHint: boolean;
+};
 
 const TOOL_GROUPS: Record<ToolName, readonly string[]> = {
   add_database_column: ["docs", "docs.database", "docs.write", "write"],
@@ -367,6 +373,29 @@ export function toolFilterRequiresRegisterTool(filter: {
   disabledTools: ReadonlySet<string>;
 }): boolean {
   return filter.profile !== "full" || filter.disabledGroups.size > 0 || filter.disabledTools.size > 0;
+}
+
+export function toolAnnotationsFor(name: string): ToolAnnotations {
+  const toolName = name as ToolName;
+  if (!KNOWN_TOOLS.has(toolName)) {
+    return {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    };
+  }
+
+  const groups = TOOL_GROUPS[toolName];
+  const isReadOnly = groups.includes("read") && !groups.includes("write") && !groups.includes("destructive");
+  const isDestructive = groups.includes("destructive");
+
+  return {
+    readOnlyHint: isReadOnly,
+    destructiveHint: isDestructive,
+    idempotentHint: isReadOnly,
+    openWorldHint: true,
+  };
 }
 
 export function knownToolSurfaceGroups(): string[] {

--- a/src/tools/accessTokens.ts
+++ b/src/tools/accessTokens.ts
@@ -18,7 +18,7 @@ export function registerAccessTokenTools(server: McpServer, gql: GraphQLClient) 
     "list_access_tokens",
     {
       title: "List Access Tokens",
-      description: "List personal access tokens (metadata).",
+      description: "List metadata for the current user's personal access tokens. Token secrets are not returned; use generate_access_token only when a new secret is needed.",
       inputSchema: {}
     },
     listAccessTokensHandler as any
@@ -33,10 +33,10 @@ export function registerAccessTokenTools(server: McpServer, gql: GraphQLClient) 
     "generate_access_token",
     {
       title: "Generate Access Token",
-      description: "Generate a personal access token (returns token).",
+      description: "Generate a new personal access token and return its one-time secret. This creates a credential; store the returned token securely because it may not be shown again.",
       inputSchema: {
-        name: z.string(),
-        expiresAt: z.string().optional()
+        name: z.string().describe("Human-readable token name shown in AFFiNE token settings."),
+        expiresAt: z.string().optional().describe("Optional expiration timestamp accepted by AFFiNE, typically an ISO 8601 string.")
       }
     },
     generateAccessTokenHandler as any
@@ -51,9 +51,9 @@ export function registerAccessTokenTools(server: McpServer, gql: GraphQLClient) 
     "revoke_access_token",
     {
       title: "Revoke Access Token",
-      description: "Revoke a personal access token by id.",
+      description: "Revoke an existing personal access token by id. This is destructive for API clients using that token; list tokens first if the id is unknown.",
       inputSchema: {
-        id: z.string()
+        id: z.string().describe("Access token id returned by list_access_tokens or generate_access_token.")
       }
     },
     revokeAccessTokenHandler as any

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -16,8 +16,8 @@ export function registerAuthTools(server: McpServer, gql: GraphQLClient, baseUrl
       title: "Sign In",
       description: "Sign in to AFFiNE using email and password; sets session cookies for subsequent calls.",
       inputSchema: {
-        email: z.string().email(),
-        password: z.string().min(1)
+        email: z.string().email().describe("AFFiNE account email address."),
+        password: z.string().min(1).describe("AFFiNE account password. Prefer API tokens for production deployments.")
       }
     },
     signInHandler as any

--- a/src/tools/blobStorage.ts
+++ b/src/tools/blobStorage.ts
@@ -80,12 +80,12 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
     "upload_blob",
     {
       title: "Upload Blob",
-      description: "Upload a file or blob to workspace storage.",
+      description: "Upload a file or blob into AFFiNE workspace storage and return its blob key. This creates stored content but does not attach it to a document by itself.",
       inputSchema: {
-        workspaceId: z.string().describe("Workspace ID"),
-        content: z.string().describe("Base64 encoded content or text"),
-        filename: z.string().optional().describe("Filename"),
-        contentType: z.string().optional().describe("MIME type")
+        workspaceId: z.string().describe("AFFiNE workspace id that owns the blob."),
+        content: z.string().describe("Base64-encoded file content or plain UTF-8 text to upload."),
+        filename: z.string().optional().describe("Optional filename stored with the upload. Defaults to a generated .bin name."),
+        contentType: z.string().optional().describe("Optional MIME type. Defaults to application/octet-stream.")
       }
     },
     uploadBlobHandler as any
@@ -115,11 +115,11 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
     "delete_blob",
     {
       title: "Delete Blob",
-      description: "Delete a blob/file from workspace storage.",
+      description: "Delete a blob from AFFiNE workspace storage. Set permanently only when the blob should bypass recoverable deletion.",
       inputSchema: {
-        workspaceId: z.string().describe("Workspace ID"),
-        key: z.string().describe("Blob key/ID to delete"),
-        permanently: z.boolean().optional().describe("Delete permanently")
+        workspaceId: z.string().describe("AFFiNE workspace id that owns the blob."),
+        key: z.string().describe("Blob key returned by upload_blob or AFFiNE document metadata."),
+        permanently: z.boolean().optional().describe("If true, permanently delete the blob instead of marking it deleted.")
       }
     },
     deleteBlobHandler as any
@@ -147,9 +147,9 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
     "cleanup_blobs",
     {
       title: "Cleanup Deleted Blobs",
-      description: "Permanently remove deleted blobs to free up storage.",
+      description: "Permanently release blobs that were already marked deleted in a workspace. This is destructive cleanup and should be used only after confirming deleted blobs are no longer needed.",
       inputSchema: {
-        workspaceId: z.string().describe("Workspace ID")
+        workspaceId: z.string().describe("AFFiNE workspace id whose deleted blobs should be released.")
       }
     },
     cleanupBlobsHandler as any

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -3,6 +3,14 @@ import { z } from "zod";
 import { GraphQLClient } from "../graphqlClient.js";
 import { receipt, text } from "../util/mcp.js";
 
+const CommentContent = z.union([
+  z.string(),
+  z.record(z.unknown()),
+  z.array(z.unknown()),
+]).describe("Comment content accepted by AFFiNE. Plain strings are normalized to { text }, and rich AFFiNE payload objects are passed through.");
+const CommentPageSize = z.number().int().positive().describe("Maximum number of comments to return from the AFFiNE pagination connection.");
+const CommentOffset = z.number().int().nonnegative().describe("Zero-based offset used by AFFiNE pagination. Do not combine with after unless the AFFiNE API requires it.");
+
 export function registerCommentTools(server: McpServer, gql: GraphQLClient, defaults: { workspaceId?: string }) {
   const listCommentsHandler = async (parsed: { workspaceId?: string; docId: string; first?: number; offset?: number; after?: string }) => {
     const workspaceId = parsed.workspaceId || defaults.workspaceId || parsed.workspaceId;
@@ -15,13 +23,13 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
     "list_comments",
     {
       title: "List Comments",
-      description: "List comments of a doc (with replies).",
+      description: "List paginated comments for a document, including nested replies and resolution state. Use this before update_comment, delete_comment, or resolve_comment when you need the existing comment ids.",
       inputSchema: {
-        workspaceId: z.string().optional(),
-        docId: z.string(),
-        first: z.number().optional(),
-        offset: z.number().optional(),
-        after: z.string().optional()
+        workspaceId: z.string().optional().describe("AFFiNE workspace id. Omit only when AFFINE_WORKSPACE_ID is configured."),
+        docId: z.string().describe("Document id whose comments should be listed."),
+        first: CommentPageSize.optional(),
+        offset: CommentOffset.optional(),
+        after: z.string().optional().describe("Cursor from pageInfo.endCursor for fetching the next page.")
       }
     },
     listCommentsHandler as any
@@ -48,14 +56,14 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
     "create_comment",
     {
       title: "Create Comment",
-      description: "Create a comment on a doc.",
+      description: "Create a new comment on an existing document. This writes collaboration state; use update_comment when editing an existing comment instead.",
       inputSchema: {
-        workspaceId: z.string().optional(),
-        docId: z.string(),
-        docTitle: z.string().optional(),
-        docMode: z.enum(["Page","Edgeless","page","edgeless"]).optional(),
-        content: z.any(),
-        mentions: z.array(z.string()).optional()
+        workspaceId: z.string().optional().describe("AFFiNE workspace id. Omit only when AFFINE_WORKSPACE_ID is configured."),
+        docId: z.string().describe("Document id that will receive the new comment."),
+        docTitle: z.string().optional().describe("Optional document title stored with the comment metadata."),
+        docMode: z.enum(["Page","Edgeless","page","edgeless"]).optional().describe("Document surface for the comment. Defaults to page."),
+        content: CommentContent,
+        mentions: z.array(z.string()).optional().describe("Optional AFFiNE user ids to mention in the comment.")
       }
     },
     createCommentHandler as any
@@ -74,10 +82,10 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
     "update_comment",
     {
       title: "Update Comment",
-      description: "Update a comment content.",
+      description: "Replace the content of an existing comment. This preserves the comment thread; use create_comment for a new thread.",
       inputSchema: {
-        id: z.string(),
-        content: z.any()
+        id: z.string().describe("Comment id returned by list_comments or create_comment."),
+        content: CommentContent.describe("Replacement comment content accepted by AFFiNE.")
       }
     },
     updateCommentHandler as any
@@ -96,9 +104,9 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
     "delete_comment",
     {
       title: "Delete Comment",
-      description: "Delete a comment by id.",
+      description: "Delete an existing comment by id. This is destructive for that comment; use resolve_comment when you only want to mark a thread resolved.",
       inputSchema: {
-        id: z.string()
+        id: z.string().describe("Comment id returned by list_comments or create_comment.")
       }
     },
     deleteCommentHandler as any
@@ -118,10 +126,10 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
     "resolve_comment",
     {
       title: "Resolve Comment",
-      description: "Resolve or unresolve a comment.",
+      description: "Set a comment thread's resolved state without changing its content. Use delete_comment only when the comment should be removed.",
       inputSchema: {
-        id: z.string(),
-        resolved: z.boolean()
+        id: z.string().describe("Comment id returned by list_comments or create_comment."),
+        resolved: z.boolean().describe("true marks the comment resolved; false reopens it.")
       }
     },
     resolveCommentHandler as any

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -71,7 +71,8 @@ export function registerCommentTools(server: McpServer, gql: GraphQLClient, defa
 
   const updateCommentHandler = async (parsed: { id: string; content: any }) => {
     const mutation = `mutation UpdateComment($input: CommentUpdateInput!){ updateComment(input:$input) }`;
-    const data = await gql.request<{ updateComment: boolean }>(mutation, { input: { id: parsed.id, content: parsed.content } });
+    const normalizedContent = typeof parsed.content === 'string' ? { text: parsed.content } : parsed.content;
+    const data = await gql.request<{ updateComment: boolean }>(mutation, { input: { id: parsed.id, content: normalizedContent } });
     return receipt("comment.update", {
       commentId: parsed.id,
       id: parsed.id,

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -67,9 +67,13 @@ function collectLinkedChildIds(blocks: Y.Map<any>): string[] {
   return ids;
 }
 
-const WorkspaceId = z.string().min(1, "workspaceId required");
-const DocId = z.string().min(1, "docId required");
-const MarkdownContent = z.string().min(1, "markdown required");
+const WorkspaceId = z.string().min(1, "workspaceId required").describe("AFFiNE workspace id. Omit only when AFFINE_WORKSPACE_ID is configured.");
+const DocId = z.string().min(1, "docId required").describe("AFFiNE document id.");
+const MarkdownContent = z.string().min(1, "markdown required").describe("Markdown content to import, append, replace, or export-roundtrip.");
+const TagName = z.string().trim().min(1, "tag required").describe("Workspace tag name.");
+const TagIdOrName = z.string().trim().min(1, "tag required").describe("Workspace tag id or tag name.");
+const PageSize = z.number().int().positive().describe("Maximum number of items to return from the AFFiNE pagination connection.");
+const PageOffset = z.number().int().nonnegative().describe("Zero-based offset used by AFFiNE pagination. Do not combine with after unless the AFFiNE API requires it.");
 const APPEND_BLOCK_CANONICAL_TYPE_VALUES = [
   "paragraph",
   "heading",
@@ -3930,10 +3934,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       title: "List Documents",
       description: "List documents in a workspace (GraphQL). Each doc includes an inTrash flag.",
       inputSchema: {
-        workspaceId: z.string().describe("Workspace ID (optional if default set).").optional(),
-        first: z.number().optional(),
-        offset: z.number().optional(),
-        after: z.string().optional()
+        workspaceId: WorkspaceId.optional(),
+        first: PageSize.optional(),
+        offset: PageOffset.optional(),
+        after: z.string().optional().describe("Cursor from pageInfo.endCursor for fetching the next page.")
       }
     },
     listDocsHandler as any
@@ -4240,7 +4244,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "list_tags",
     {
       title: "List Tags",
-      description: "List all tags in a workspace and the number of docs attached to each tag.",
+      description: "List all workspace-level tags and the number of documents attached to each tag. Use this before tag mutation when the exact tag name or id is unknown.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
       },
@@ -4303,10 +4307,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "list_docs_by_tag",
     {
       title: "List Documents By Tag",
-      description: "List documents that contain the requested tag. Each doc includes an inTrash flag.",
+      description: "List documents that contain the requested tag. This is read-only and each result includes title metadata and an inTrash flag.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
-        tag: z.string().min(1).describe("Tag name"),
+        tag: TagName.describe("Tag name to match against workspace tag labels."),
         ignoreCase: z.boolean().optional().describe("Case-insensitive tag matching (default: true)."),
       },
     },
@@ -4350,10 +4354,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "create_tag",
     {
       title: "Create Tag",
-      description: "Create a workspace-level tag entry for future reuse.",
+      description: "Create a workspace-level tag entry for future reuse. This does not attach the tag to a document; use add_tag_to_doc for that.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
-        tag: z.string().min(1).describe("Tag name"),
+        tag: TagName.describe("Tag name to create in the workspace tag registry."),
       },
     },
     createTagHandler as any
@@ -4433,11 +4437,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "add_tag_to_doc",
     {
       title: "Add Tag To Document",
-      description: "Add a tag to a document.",
+      description: "Attach a workspace tag to a document, creating the workspace tag option if needed. This updates workspace metadata and attempts to sync the document's own metadata.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         docId: DocId,
-        tag: z.string().min(1).describe("Tag name"),
+        tag: TagName.describe("Tag name to attach to the document."),
       },
     },
     addTagToDocHandler as any
@@ -4517,11 +4521,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "remove_tag_from_doc",
     {
       title: "Remove Tag From Document",
-      description: "Remove a tag from a document.",
+      description: "Detach a tag from one document without deleting the workspace-level tag. Use delete_tag only when the tag should be removed from every document.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         docId: DocId,
-        tag: z.string().min(1).describe("Tag name"),
+        tag: TagName.describe("Tag name to detach from the document."),
       },
     },
     removeTagFromDocHandler as any
@@ -4651,7 +4655,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         "Delete a workspace-level tag and remove it from every document that references it. Accepts a tag id or name; an ambiguous name is rejected with the candidate ids.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
-        tag: z.string().min(1).describe("Tag id or name to delete"),
+        tag: TagIdOrName.describe("Tag id or name to delete. Ambiguous tag names are rejected with candidate ids."),
       },
     },
     deleteTagHandler as any
@@ -4670,9 +4674,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "get_doc",
     {
       title: "Get Document",
-      description: "Get a document by ID (GraphQL metadata).",
+      description: "Read GraphQL metadata for one document, such as title, summary, public state, roles, and timestamps. Use read_doc when you need block content.",
       inputSchema: {
-        workspaceId: z.string().optional(),
+        workspaceId: WorkspaceId.optional(),
         docId: DocId
       }
     },
@@ -5075,11 +5079,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "publish_doc",
     {
       title: "Publish Document",
-      description: "Publish a doc (make public).",
+      description: "Make a document publicly accessible through AFFiNE public sharing. This changes sharing state; use revoke_doc to disable public access later.",
       inputSchema: {
-        workspaceId: z.string().optional(),
-        docId: z.string(),
-        mode: z.enum(["Page","Edgeless"]).optional()
+        workspaceId: WorkspaceId.optional(),
+        docId: DocId,
+        mode: z.enum(["Page","Edgeless"]).optional().describe("Public document mode to publish. Omit to let AFFiNE use its default.")
       }
     },
     publishDocHandler as any
@@ -5102,10 +5106,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "revoke_doc",
     {
       title: "Revoke Document",
-      description: "Revoke a doc's public access.",
+      description: "Disable public sharing for a document without deleting the document. Use delete_doc only when the document itself should be removed.",
       inputSchema: {
-        workspaceId: z.string().optional(),
-        docId: z.string()
+        workspaceId: WorkspaceId.optional(),
+        docId: DocId
       }
     },
     revokeDocHandler as any
@@ -5160,9 +5164,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       title: 'Create Document',
       description: 'Create a new AFFiNE document with optional content. If parentDocId is provided, the new doc is linked into the sidebar tree immediately. If folderId is provided, the doc is placed inside that folder in the sidebar.',
       inputSchema: {
-        workspaceId: z.string().optional(),
-        title: z.string().optional(),
-        content: z.string().optional(),
+        workspaceId: WorkspaceId.optional(),
+        title: z.string().optional().describe("Optional initial document title."),
+        content: z.string().optional().describe("Optional initial plain text or markdown-like content."),
         parentDocId: z.string().optional().describe("Optional parent doc to link the new doc under in the sidebar."),
         folderId: z.string().optional().describe("Optional folder ID to place the doc in. Use list_organize_nodes to find folder IDs."),
       },
@@ -5885,8 +5889,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     'delete_doc',
     {
       title: 'Delete Document',
-      description: 'Delete a document and remove from workspace list',
-      inputSchema: { workspaceId: z.string().optional(), docId: z.string() },
+      description: 'Delete a document by removing its workspace metadata entry and sending the AFFiNE WebSocket delete request for its content. This is destructive; use revoke_doc when you only need to remove public access.',
+      inputSchema: {
+        workspaceId: WorkspaceId.optional(),
+        docId: DocId,
+      },
     },
     deleteDocHandler as any
   );

--- a/src/tools/notifications.ts
+++ b/src/tools/notifications.ts
@@ -55,7 +55,7 @@ export function registerNotificationTools(server: McpServer, gql: GraphQLClient)
     "list_notifications",
     {
       title: "List Notifications",
-      description: "Get user notifications.",
+      description: "List the current user's AFFiNE notifications with optional unread filtering. This is read-only and returns notification ids, read state, level, and timestamps.",
       inputSchema: {
         first: z.number().optional().describe("Number of notifications to fetch"),
         offset: z.number().optional().describe("Offset for pagination"),
@@ -86,7 +86,7 @@ export function registerNotificationTools(server: McpServer, gql: GraphQLClient)
     "read_all_notifications",
     {
       title: "Mark All Notifications Read",
-      description: "Mark all notifications as read.",
+      description: "Mark every current-user notification as read. This mutates notification state; use list_notifications first when you need to inspect unread items.",
       inputSchema: {}
     },
     readAllNotificationsHandler as any

--- a/src/tools/organize.ts
+++ b/src/tools/organize.ts
@@ -15,23 +15,23 @@ import {
   wsUrlFromGraphQLEndpoint,
 } from "../ws.js";
 
-const WorkspaceId = z.string().min(1, "workspaceId required");
-const DocId = z.string().min(1, "docId required");
-const CollectionId = z.string().min(1, "collectionId required");
-const FolderId = z.string().min(1, "folderId required");
-const OrganizeNodeId = z.string().min(1, "nodeId required");
-const FolderName = z.string().trim().min(1, "name required");
-const CollectionRuleFieldSchema = z.enum(["title", "tag", "docId"]);
-const CollectionRuleOperatorSchema = z.enum(["contains", "equals", "startsWith", "in"]);
+const WorkspaceId = z.string().min(1, "workspaceId required").describe("AFFiNE workspace id. Omit only when AFFINE_WORKSPACE_ID is configured.");
+const DocId = z.string().min(1, "docId required").describe("AFFiNE document id.");
+const CollectionId = z.string().min(1, "collectionId required").describe("AFFiNE collection id from list_collections or create_collection.");
+const FolderId = z.string().min(1, "folderId required").describe("AFFiNE organize folder node id.");
+const OrganizeNodeId = z.string().min(1, "nodeId required").describe("AFFiNE organize node id from list_organize_nodes.");
+const FolderName = z.string().trim().min(1, "name required").describe("Non-empty sidebar folder or collection name.");
+const CollectionRuleFieldSchema = z.enum(["title", "tag", "docId"]).describe("Document field evaluated by the collection rule.");
+const CollectionRuleOperatorSchema = z.enum(["contains", "equals", "startsWith", "in"]).describe("Comparison operator for the collection rule.");
 const CollectionRuleSchema = z.object({
   field: CollectionRuleFieldSchema,
   operator: CollectionRuleOperatorSchema,
-  value: z.union([z.string(), z.array(z.string())]),
-});
+  value: z.union([z.string(), z.array(z.string())]).describe("String value or list of values used by the selected operator."),
+}).describe("Single AFFiNE collection filter rule.");
 const CollectionRulesSchema = z.object({
-  match: z.enum(["all", "any"]).optional(),
-  filters: z.array(CollectionRuleSchema),
-});
+  match: z.enum(["all", "any"]).optional().describe("Whether all filters or any filter must match. Defaults to all."),
+  filters: z.array(CollectionRuleSchema).describe("Collection filter rules used to build the allow-list."),
+}).describe("AFFiNE collection rule set.");
 
 type CollectionInfo = {
   id: string;
@@ -833,7 +833,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "list_collections",
     {
       title: "List Collections",
-      description: "List AFFiNE collections stored in the workspace sidebar.",
+      description: "List AFFiNE sidebar collections and their rules. Use this read-only tool before updating, deleting, or adding documents to a collection.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
       },
@@ -864,7 +864,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "get_collection",
     {
       title: "Get Collection",
-      description: "Get an AFFiNE collection by id.",
+      description: "Read one AFFiNE sidebar collection by id, including rules and allow-list. Use list_collections first when the id is unknown.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -913,7 +913,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "create_collection",
     {
       title: "Create Collection",
-      description: "Create a new AFFiNE collection in the workspace sidebar.",
+      description: "Create a new AFFiNE sidebar collection with optional rules. This writes workspace sidebar metadata but does not create documents.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         name: FolderName.describe("Collection name"),
@@ -953,7 +953,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "update_collection_rules",
     {
       title: "Update Collection Rules",
-      description: "Replace a collection's rules and rebuild its allow-list from workspace docs.",
+      description: "Replace an AFFiNE collection's rules and rebuild its allow-list from current workspace documents. This can change which docs appear in the collection.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -1012,7 +1012,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "update_collection",
     {
       title: "Update Collection",
-      description: "Rename an AFFiNE collection.",
+      description: "Rename an existing AFFiNE sidebar collection without changing its rules or allow-list.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -1055,7 +1055,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "delete_collection",
     {
       title: "Delete Collection",
-      description: "Delete an AFFiNE collection from the workspace sidebar.",
+      description: "Delete an AFFiNE sidebar collection. This removes the collection metadata but does not delete the documents it referenced.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -1110,7 +1110,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "add_doc_to_collection",
     {
       title: "Add Doc To Collection",
-      description: "Add a document id to an AFFiNE collection allow-list.",
+      description: "Add an existing document id to an AFFiNE collection allow-list. Use update_collection_rules instead when membership should be rule-driven.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -1166,7 +1166,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "remove_doc_from_collection",
     {
       title: "Remove Doc From Collection",
-      description: "Remove a document id from an AFFiNE collection allow-list.",
+      description: "Remove a document id from an AFFiNE collection allow-list. This does not delete the document or change collection rules.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         collectionId: CollectionId,
@@ -1197,7 +1197,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "list_organize_nodes",
     {
       title: "List Organize Nodes",
-      description: "Experimental: list AFFiNE sidebar organize nodes from the folders workspace DB.",
+      description: "Experimental: list AFFiNE sidebar organize folder and link nodes from the folders workspace DB. Use this before moving or deleting organize nodes.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
       },
@@ -1229,7 +1229,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "create_folder",
     {
       title: "Create Folder",
-      description: "Experimental: create an AFFiNE organize folder node.",
+      description: "Experimental: create an AFFiNE organize folder node in the sidebar tree. This only changes sidebar organization, not document content.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         name: FolderName.describe("Folder name"),
@@ -1282,7 +1282,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "create_workspace_blueprint",
     {
       title: "Create Workspace Blueprint",
-      description: "Create a simple workspace folder blueprint under the organize tree.",
+      description: "Create a simple AFFiNE organize folder blueprint with one root folder and optional child folders. This is a convenience wrapper around create_folder.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         rootFolderName: FolderName.describe("Root folder name"),
@@ -1321,7 +1321,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "rename_folder",
     {
       title: "Rename Folder",
-      description: "Experimental: rename an AFFiNE organize folder node.",
+      description: "Experimental: rename an AFFiNE organize folder node. This changes sidebar metadata only and does not rename documents inside the folder.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         folderId: FolderId,
@@ -1376,7 +1376,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "delete_folder",
     {
       title: "Delete Folder",
-      description: "Experimental: delete an AFFiNE organize folder and all nested nodes.",
+      description: "Experimental: delete an AFFiNE organize folder and every nested folder or link node. This is destructive for sidebar organization but does not delete target documents, tags, or collections.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         folderId: FolderId,
@@ -1430,7 +1430,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "move_organize_node",
     {
       title: "Move Organize Node",
-      description: "Experimental: move an AFFiNE organize folder or link node.",
+      description: "Experimental: move an AFFiNE organize folder or link node to another folder or root. This preserves the target document, tag, or collection and changes only sidebar placement.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         nodeId: OrganizeNodeId,
@@ -1474,11 +1474,11 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "add_organize_link",
     {
       title: "Add Organize Link",
-      description: "Experimental: add a doc/tag/collection link under an AFFiNE organize folder.",
+      description: "Experimental: add a doc, tag, or collection link under an AFFiNE organize folder. Use move_organize_node for an existing link node instead of creating a duplicate link.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         folderId: FolderId,
-        type: z.enum(["doc", "tag", "collection"]),
+        type: z.enum(["doc", "tag", "collection"]).describe("Type of target represented by the organize link."),
         targetId: z.string().min(1).describe("Target doc/tag/collection id"),
         index: z.string().optional().describe("Optional fractional index. Defaults to append-after-last."),
       },
@@ -1515,7 +1515,7 @@ async function listWorkspaceDocsForCollectionRules(socket: any, workspaceId: str
     "delete_organize_link",
     {
       title: "Delete Organize Link",
-      description: "Experimental: delete an AFFiNE organize doc/tag/collection link.",
+      description: "Experimental: delete an AFFiNE organize doc, tag, or collection link node. This removes only the sidebar link, not the target resource.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         nodeId: OrganizeNodeId,

--- a/src/tools/user.ts
+++ b/src/tools/user.ts
@@ -13,7 +13,7 @@ export function registerUserTools(server: McpServer, gql: GraphQLClient) {
     "current_user",
     {
       title: "Current User",
-      description: "Get current signed-in user.",
+      description: "Return the currently authenticated AFFiNE user profile. Use this read-only check to verify credentials before workspace or document operations.",
       inputSchema: {}
     },
     currentUserHandler as any

--- a/tests/test-tool-filtering.mjs
+++ b/tests/test-tool-filtering.mjs
@@ -11,7 +11,7 @@ const SRC_PATH = path.resolve(__dirname, "..", "src", "index.ts");
 const REPO_ROOT = path.resolve(__dirname, "..");
 const execFileAsync = promisify(execFile);
 
-async function testFiltering(env = {}) {
+async function listToolEntries(env = {}) {
   const client = new Client(
     { name: "test-client", version: "1.0.0" },
     { capabilities: {} }
@@ -32,9 +32,13 @@ async function testFiltering(env = {}) {
 
   await client.connect(transport);
   const result = await client.listTools();
-  const toolNames = result.tools.map((t) => t.name);
   await transport.close();
-  return toolNames;
+  return result.tools;
+}
+
+async function testFiltering(env = {}) {
+  const tools = await listToolEntries(env);
+  return tools.map((t) => t.name);
 }
 
 async function inspectToolSurfacePolicy() {
@@ -68,7 +72,8 @@ async function run() {
   try {
     // 0. Removed convenience wrappers are not registered on the default surface.
     console.log("Case 0: Removed convenience wrappers stay absent");
-    const allTools = await testFiltering();
+    const defaultToolEntries = await listToolEntries();
+    const allTools = defaultToolEntries.map((t) => t.name);
     const removedTools = [
       "append_paragraph",
       "batch_create_docs",
@@ -87,6 +92,29 @@ async function run() {
       console.log("✅ Success: Default tool surface exposes 95 tools.");
     } else {
       console.error(`❌ Failed: Default tool surface mismatch. count=${allTools.length} stillRegistered=${stillRegistered.join(", ")}`);
+      hasFailures = true;
+    }
+
+    // 0a. Tool annotations are present for client-side selection safety.
+    console.log("\nCase 0a: Default tools expose MCP annotations");
+    const missingAnnotations = defaultToolEntries.filter(tool =>
+      !tool.annotations ||
+      typeof tool.annotations.readOnlyHint !== "boolean" ||
+      typeof tool.annotations.destructiveHint !== "boolean" ||
+      typeof tool.annotations.idempotentHint !== "boolean" ||
+      typeof tool.annotations.openWorldHint !== "boolean"
+    );
+    const toolsByName = Object.fromEntries(defaultToolEntries.map(tool => [tool.name, tool]));
+    const annotationExpectations =
+      toolsByName.list_docs?.annotations?.readOnlyHint === true &&
+      toolsByName.list_docs?.annotations?.idempotentHint === true &&
+      toolsByName.delete_doc?.annotations?.destructiveHint === true &&
+      toolsByName.create_doc?.annotations?.readOnlyHint === false &&
+      toolsByName.create_doc?.annotations?.destructiveHint === false;
+    if (missingAnnotations.length === 0 && annotationExpectations) {
+      console.log("✅ Success: Tool annotations are populated and match representative read/write/destructive tools.");
+    } else {
+      console.error(`❌ Failed: Tool annotations missing or mismatched. missing=${missingAnnotations.map(t => t.name).join(", ")}`);
       hasFailures = true;
     }
 


### PR DESCRIPTION
## Summary

Improve the MCP tool metadata that Glama and MCP clients use for safer tool selection.

## Changes

- Add Glama server metadata and include it in the npm package.
- Include SECURITY.md in the published package.
- Add MCP tool annotations for read-only, destructive, idempotent, and external-world behavior.
- Improve descriptions and parameter schemas for comments, tags, document sharing/deletion, organize tools, access tokens, blobs, notifications, and auth.
- Add a tool filtering test that verifies annotations are exposed through tools/list.
- Refresh the README MCP SDK badge and HTTP deployment hardening guidance.

## Validation

- npm run build
- npm run test:tool-manifest
- npm run test:tool-filtering
- npm run ci
- Hangul scan passed with no matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the MCP SDK badge, tool-surface guidance, and deployment/security documentation (including auth-protected vs unauthenticated probes, CORS, TLS, and stricter production settings).
* **New Features**
  * Added per-tool behavior annotations (read-only, destructive, idempotent, external-world) to improve client-side tool filtering and least-privilege deployment guidance.
  * Published/packaged configuration assets for Glama server setup.
* **Chores**
  * Updated package contents to include security and configuration files.
* **Tests**
  * Strengthened tool listing/annotation assertions, including new coverage for expected annotation hint values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->