### PR TITLE
fix: image blocks on edgeless canvas + SHA-256 blob keys

### DIFF
--- a/src/tools/blobStorage.ts
+++ b/src/tools/blobStorage.ts
@@ -4,10 +4,30 @@ import { GraphQLClient } from "../graphqlClient.js";
 import { text } from "../util/mcp.js";
 import FormData from "form-data";
 import fetch from "node-fetch";
+import { createHash } from "crypto";
+import { readFileSync, existsSync } from "fs";
+import { basename, extname } from "path";
+
+const MIME_MAP: Record<string, string> = {
+  ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png",
+  ".gif": "image/gif", ".webp": "image/webp", ".svg": "image/svg+xml",
+  ".pdf": "application/pdf", ".mp4": "video/mp4", ".mp3": "audio/mpeg",
+};
+
+/**
+ * Compute the blob key the same way AFFiNE's native UI does:
+ * SHA-256 of the file content, base64url-encoded (no padding issues).
+ * GraphQL setBlob returns the filename instead — causing "Failed to download image"
+ * in the browser. REST PUT with this hash matches native behaviour exactly.
+ */
+function computeBlobKey(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("base64")
+    .replace(/\+/g, "-").replace(/\//g, "_");
+}
 
 function decodeBlobContent(content: string): Buffer {
   const normalized = content.trim().replace(/\s+/g, "");
-  const base64Like = normalized.length > 0 && normalized.length % 4 === 0 && /^[A-Za-z0-9+/=]+$/.test(normalized);
+  const base64Like = normalized.length >= 8 && normalized.length % 4 !== 1 && /^[A-Za-z0-9+/=]+$/.test(normalized);
   if (base64Like) {
     try {
       const decoded = Buffer.from(normalized, "base64");
@@ -23,44 +43,86 @@ function decodeBlobContent(content: string): Buffer {
 
 export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
   // UPLOAD BLOB/FILE
-  const uploadBlobHandler = async ({ workspaceId, content, filename, contentType }: { workspaceId: string; content: string; filename?: string; contentType?: string }) => {
+  const uploadBlobHandler = async ({ workspaceId, filePath, content, filename, contentType }: {
+    workspaceId: string;
+    filePath?: string;
+    content?: string;
+    filename?: string;
+    contentType?: string;
+  }) => {
     try {
       const endpoint = gql.endpoint;
       const headers = gql.headers;
       const cookie = gql.cookie;
-      const payload = decodeBlobContent(content);
-      const safeFilename = filename || `blob-${Date.now()}.bin`;
-      const mime = contentType || "application/octet-stream";
 
-      const form = new FormData();
-      form.append("operations", JSON.stringify({
-        query: `mutation SetBlob($workspaceId: String!, $blob: Upload!) {
-          setBlob(workspaceId: $workspaceId, blob: $blob)
-        }`,
-        variables: {
-          workspaceId,
-          blob: null
+      let payload: Buffer;
+      let safeFilename: string;
+      let mime: string;
+
+      // Resolve file path: explicit filePath param OR file:// URI in content
+      const resolvedPath = filePath || (content?.startsWith("file://") ? content.slice(7) : null);
+      if (resolvedPath) {
+        if (!existsSync(resolvedPath)) {
+          throw new Error(`File not found: ${resolvedPath}`);
         }
-      }));
-      form.append("map", JSON.stringify({ "0": ["variables.blob"] }));
-      form.append("0", payload, { filename: safeFilename, contentType: mime });
-
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          ...headers,
-          Cookie: cookie,
-          ...form.getHeaders(),
-        },
-        body: form as any,
-      });
-      const result = await response.json() as any;
-      if (result.errors?.length) {
-        throw new Error(result.errors[0].message);
+        payload = readFileSync(resolvedPath);
+        safeFilename = filename || basename(resolvedPath);
+        const ext = extname(resolvedPath).toLowerCase();
+        mime = contentType || MIME_MAP[ext] || "application/octet-stream";
+      } else {
+        if (!content) throw new Error("Either filePath, file:// URI in content, or base64 content is required.");
+        payload = decodeBlobContent(content);
+        safeFilename = filename || `blob-${Date.now()}.bin`;
+        mime = contentType || "application/octet-stream";
       }
-      const blobKey = result.data?.setBlob;
-      if (!blobKey) {
-        throw new Error("Upload succeeded but no blob key was returned.");
+
+      // Compute SHA-256 hash — AFFiNE native UI uses this as the blob key.
+      // GraphQL setBlob returns the filename instead, causing broken images in browser.
+      const blobKey = computeBlobKey(payload);
+
+      // Upload via REST PUT (mirrors AFFiNE browser native upload mechanism)
+      const baseUrl = endpoint.replace(/\/graphql$/, "");
+      const blobUrl = `${baseUrl}/api/workspaces/${workspaceId}/blobs/${blobKey}`;
+      const putResponse = await fetch(blobUrl, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": mime },
+        body: payload,
+      });
+
+      if (!putResponse.ok) {
+        // Fallback: try GraphQL setBlob
+        const form = new FormData();
+        form.append("operations", JSON.stringify({
+          query: `mutation SetBlob($workspaceId: String!, $blob: Upload!) {
+            setBlob(workspaceId: $workspaceId, blob: $blob)
+          }`,
+          variables: { workspaceId, blob: null }
+        }));
+        form.append("map", JSON.stringify({ "0": ["variables.blob"] }));
+        form.append("0", payload, { filename: safeFilename, contentType: mime });
+        const gqlResponse = await fetch(endpoint, {
+          method: "POST",
+          headers: { ...headers, Cookie: cookie, ...form.getHeaders() },
+          body: form as any,
+        });
+        const result = await gqlResponse.json() as any;
+        if (result.errors?.length) {
+          throw new Error(`REST PUT failed (${putResponse.status}) and GraphQL fallback also failed: ${result.errors[0].message}`);
+        }
+        if (!result.data?.setBlob) {
+          throw new Error(`REST PUT failed (${putResponse.status}) and GraphQL returned no key.`);
+        }
+        // GraphQL succeeded but returns filename-based key — warn so callers know
+        return text({
+          id: blobKey,
+          key: blobKey,
+          workspaceId,
+          filename: safeFilename,
+          contentType: mime,
+          size: payload.length,
+          uploadedAt: new Date().toISOString(),
+          warning: "REST PUT failed; uploaded via GraphQL fallback. Browser may fail to load this blob."
+        });
       }
 
       return text({
@@ -76,16 +138,18 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
       return text({ error: error.message });
     }
   };
+
   server.registerTool(
     "upload_blob",
     {
       title: "Upload Blob",
-      description: "Upload a file or blob into AFFiNE workspace storage and return its blob key. This creates stored content but does not attach it to a document by itself.",
+      description: "Upload a file or blob to workspace storage. Prefer filePath for local files (avoids base64 size limits). Use content only for small inline data. Returns a SHA-256-based blob key compatible with AFFiNE's native image rendering.",
       inputSchema: {
-        workspaceId: z.string().describe("AFFiNE workspace id that owns the blob."),
-        content: z.string().describe("Base64-encoded file content or plain UTF-8 text to upload."),
-        filename: z.string().optional().describe("Optional filename stored with the upload. Defaults to a generated .bin name."),
-        contentType: z.string().optional().describe("Optional MIME type. Defaults to application/octet-stream.")
+        workspaceId: z.string().describe("Workspace ID"),
+        filePath: z.string().optional().describe("Absolute path to a local file. Preferred over content for large files — server reads binary directly, no base64 size limits."),
+        content: z.string().optional().describe("Base64-encoded file content or plain UTF-8 text. Use only when filePath is not available."),
+        filename: z.string().optional().describe("Filename override (default: basename of filePath or blob-<ts>.bin)"),
+        contentType: z.string().optional().describe("MIME type override")
       }
     },
     uploadBlobHandler as any
@@ -99,13 +163,7 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
           deleteBlob(workspaceId: $workspaceId, key: $key, permanently: $permanently)
         }
       `;
-      
-      const data = await gql.request<{ deleteBlob: boolean }>(mutation, {
-        workspaceId,
-        key,
-        permanently
-      });
-      
+      const data = await gql.request<{ deleteBlob: boolean }>(mutation, { workspaceId, key, permanently });
       return text({ success: data.deleteBlob, key, workspaceId, permanently });
     } catch (error: any) {
       return text({ error: error.message });
@@ -133,11 +191,7 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
           releaseDeletedBlobs(workspaceId: $workspaceId)
         }
       `;
-      
-      const data = await gql.request<{ releaseDeletedBlobs: boolean }>(mutation, {
-        workspaceId
-      });
-      
+      const data = await gql.request<{ releaseDeletedBlobs: boolean }>(mutation, { workspaceId });
       return text({ success: true, workspaceId, blobsReleased: data.releaseDeletedBlobs });
     } catch (error: any) {
       return text({ error: error.message });

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1202,8 +1202,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       if (!Number.isInteger(normalized.height) || normalized.height < 1 || normalized.height > 10000) {
         throw new Error(`${normalized.type} height must be an integer between 1 and 10000.`);
       }
+    } else if (normalized.type === "image") {
+      // image blocks support width/height for canvas placement (prop:xywh)
     } else if ((raw.width !== undefined || raw.height !== undefined) && normalized.strict) {
-      throw new Error("The 'width'/'height' fields are only valid for frame/edgeless_text/note.");
+      throw new Error("The 'width'/'height' fields are only valid for frame/edgeless_text/note/image.");
     }
 
     if (normalized.type !== "frame" && normalized.type !== "note" && raw.background !== undefined && normalized.strict) {
@@ -1453,7 +1455,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       if (
         parentFlavour === "affine:surface" &&
         normalized.type !== "frame" &&
-        normalized.type !== "edgeless_text"
+        normalized.type !== "edgeless_text" &&
+        normalized.type !== "image"
       ) {
         throw new Error(`Cannot append '${normalized.type}' directly under 'affine:surface'.`);
       }
@@ -1856,10 +1859,16 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         block.set("sys:children", new Y.Array<string>());
         block.set("prop:caption", normalized.caption ?? "");
         block.set("prop:sourceId", normalized.sourceId);
-        block.set("prop:width", 0);
-        block.set("prop:height", 0);
+        block.set("prop:width", normalized.width || 0);
+        block.set("prop:height", normalized.height || 0);
         block.set("prop:size", normalized.size || -1);
-        block.set("prop:xywh", "[0,0,0,0]");
+        // When placed on the edgeless canvas (under affine:surface), x/y/width/height
+        // define the canvas bounding box via prop:xywh. Without this, images land at [0,0,0,0].
+        const imgX = normalized.x ?? 0;
+        const imgY = normalized.y ?? 0;
+        const imgW = normalized.width || 0;
+        const imgH = normalized.height || 0;
+        block.set("prop:xywh", `[${imgX},${imgY},${imgW},${imgH}]`);
         block.set("prop:index", "a0");
         block.set("prop:lockedBySelf", false);
         block.set("prop:rotate", 0);
@@ -8667,6 +8676,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         "affine:frame",
         "affine:edgeless-text",
         "affine:note",
+        "affine:image",
       ]);
 
       const collectNoteText = (rootId: string): string[] => {
@@ -8764,6 +8774,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           entry.displayMode = raw.get("prop:displayMode") ?? null;
           const bg = raw.get("prop:background");
           entry.background = bg instanceof Y.Map ? bg.toJSON() : bg ?? null;
+        } else if (flavour === "affine:image") {
+          const sid = raw.get("prop:sourceId");
+          if (typeof sid === "string") entry.sourceId = sid;
+          const pw = raw.get("prop:width");
+          const ph = raw.get("prop:height");
+          if (typeof pw === "number") entry.imgWidth = pw;
+          if (typeof ph === "number") entry.imgHeight = ph;
         }
         edgelessBlocks.push(entry);
       }


### PR DESCRIPTION
## Problem

Two related bugs make it impossible to place images directly on the AFFiNE edgeless canvas via MCP:

**Bug 1 — Wrong blob key breaks image rendering**
`upload_blob` uses GraphQL `setBlob`, which returns the filename as the blob key (e.g. `photo.jpg`). AFFiNE's browser client validates blobs by their SHA-256 hash, so any blob referenced by filename fails with **"Failed to download image!"** in the UI. Native browser upload uses `PUT /api/workspaces/{id}/blobs/{sha256-base64url}` — this PR does the same.

**Bug 2 — Validation blocks `affine:image` under `affine:surface`**
`append_block` with `type=image` and `parentId=<surfaceId>` throws:
> Cannot append 'image' directly under 'affine:surface'

`affine:image` is a valid canvas-level block per AFFiNE's own CRDT schema (it has `prop:xywh`, `prop:index`, `prop:lockedBySelf` — identical to `affine:frame`). The restriction in the MCP is overly strict.

**Bug 3 — Images land at [0,0,0,0] on the canvas**
Even if placement succeeds, the image block is created with `prop:xywh = "[0,0,0,0]"` regardless of the `x/y/width/height` parameters the caller provides — so images are invisible (zero-size) until manually dragged.

**Missing — `get_edgeless_canvas` omits image blocks**
`affine:image` was not in `edgelessFlavours`, so canvas images were invisible to any agent reading the canvas state.

## Changes

### `src/tools/blobStorage.ts`
- Add `computeBlobKey()`: SHA-256 of file content → base64url (matches native UI)
- Replace GraphQL `setBlob` with `PUT /api/workspaces/{id}/blobs/{hash}` as primary path; GraphQL is kept as fallback with a warning in the response
- Add `filePath` parameter: read binary directly from disk, avoiding base64 size limits
- Keep `content` (base64/text) for backwards compatibility

### `src/tools/docs.ts`
- Allow `type=image` under `affine:surface` in placement validation
- Allow `width`/`height` for `type=image` (used for `prop:xywh`)
- Set `prop:xywh` from caller-provided `x/y/width/height` in the image block builder
- Add `"affine:image"` to `edgelessFlavours`; expose `sourceId`, `imgWidth`, `imgHeight` in `get_edgeless_canvas` output

## Testing

Verified end-to-end on a self-hosted AFFiNE instance (v0.21+):
- `upload_blob(filePath=...)` → returns SHA-256 hash key; image loads in browser without errors
- `append_block(type=image, sourceId=<hash>, placement={parentId: surfaceId}, width=W, height=H, x=X, y=Y)` → image appears at correct position and size on the canvas
- `get_edgeless_canvas` → returns image blocks with `sourceId`, `imgWidth`, `imgHeight`, `xywh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images are now handled as editable canvas content, with proper sizing and placement support.
  * Blob uploads now support local files and `file://` content, with more reliable blob keys for consistent rendering.

* **Bug Fixes**
  * Improved blob upload compatibility by using a fallback upload path when needed.
  * Fixed image block data so canvases now display image dimensions and layout correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->