### PR TITLE
fix: fail closed for remote HTTP security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Verify OAuth service-account policy
         run: npm run test:oauth-service-policy
 
+      - name: Verify HTTP security policy
+        run: npm run test:http-security
+
       - name: Check package contents
         run: npm run pack:check

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ For common failures, see:
 - Prefer API tokens over cookies or passwords in production
 - Email/password HTTP sessions share one login and never fall back to anonymous backend requests after authentication failure
 - Use HTTPS for non-local deployments
+- Keep remote HTTP MCP listeners authenticated; bearer mode refuses a non-loopback bind without `AFFINE_MCP_HTTP_TOKEN`
+- Send MCP bearer tokens in the `Authorization` header, never in the URL
 - Rotate access tokens regularly
 - Restrict exposed tools with `AFFINE_DISABLED_GROUPS` and `AFFINE_DISABLED_TOOLS` for least-privilege setups
 - Treat OAuth mode as a shared AFFiNE service-account deployment: it defaults to `read_only`, and write-capable profiles require `AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,15 @@ Please include:
 - Fix timeline: depends on severity and complexity
 
 We will coordinate disclosure and credit reporters unless they prefer anonymity.
+
+## Deployment Hardening
+
+- Remote AFFiNE destinations must use HTTPS. Plain HTTP requires the explicit
+  `AFFINE_ALLOW_INSECURE_HTTP=true` opt-in and should only be used on a trusted
+  private network.
+- Bearer-mode HTTP MCP listeners on non-loopback interfaces require
+  `AFFINE_MCP_HTTP_TOKEN` unless the unsafe
+  `AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED=true` escape hatch is explicitly set.
+- Send MCP bearer tokens in the `Authorization` header. Query-string token
+  authentication is disabled by default because URLs can leak through logs,
+  browser history, and monitoring systems.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -165,6 +165,10 @@ Typical bearer-mode client config:
 }
 ```
 
+Always send the MCP bearer token in the `Authorization` header. The server
+rejects `?token=` by default because URL credentials can leak through logs and
+browser history.
+
 ## Setup tips
 
 - Prefer `affine-mcp login` for local development

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -34,7 +34,8 @@ cookie, while setting a bearer credential removes any cookie header.
 
 | Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `AFFINE_BASE_URL` | No | `http://localhost:3010` | Base URL for AFFiNE Cloud or self-hosted AFFiNE |
+| `AFFINE_BASE_URL` | No | `http://localhost:3010` | Base URL for AFFiNE Cloud or self-hosted AFFiNE; remote destinations must use HTTPS |
+| `AFFINE_ALLOW_INSECURE_HTTP` | No | `false` | Explicitly allow a remote plain-HTTP AFFiNE URL on a trusted private network only |
 | `AFFINE_GRAPHQL_PATH` | No | `/graphql` | Override only if your AFFiNE deployment uses a custom GraphQL path |
 | `AFFINE_HEADERS_JSON` | No | none | JSON object of additional string headers sent to AFFiNE; built-in token/cookie auth takes priority |
 | `AFFINE_WORKSPACE_ID` | No | Auto-detected when possible | Pins the active workspace |
@@ -64,10 +65,12 @@ cookie, while setting a bearer credential removes any cookie header.
 | `MCP_TRANSPORT` | No | `stdio` | Set to `http`; `streamable` and legacy `sse` are accepted aliases |
 | `PORT` | No | `3000` | Commonly injected by container platforms |
 | `AFFINE_MCP_AUTH_MODE` | No | `bearer` | `bearer` or `oauth` |
-| `AFFINE_MCP_HTTP_HOST` | No | `127.0.0.1` | Use `0.0.0.0` in containers |
-| `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` | No | loopback origins only | Comma-separated http(s) origins for browser clients |
+| `AFFINE_MCP_HTTP_HOST` | No | `127.0.0.1` | Use `0.0.0.0` in containers; non-loopback bearer listeners require authentication |
+| `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` | No | none | Comma-separated list for browser clients |
 | `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS` | No | `false` | Testing only; rejected in OAuth mode |
-| `AFFINE_MCP_HTTP_TOKEN` | Required for remote bearer mode | none | Shared bearer token for `/mcp`, `/sse`, and `/messages` |
+| `AFFINE_MCP_HTTP_TOKEN` | Required for non-loopback bearer mode | none | Shared bearer token for `/mcp`, `/sse`, and `/messages` |
+| `AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED` | No | `false` | Unsafe opt-in for an unauthenticated non-loopback bearer-mode listener |
+| `AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN` | No | `false` | Deprecated compatibility mode for `?token=` clients; prefer the `Authorization` header |
 | `AFFINE_MCP_PUBLIC_BASE_URL` | Required in OAuth mode | none | Public base URL for this MCP server |
 | `AFFINE_OAUTH_ISSUER_URL` | Required in OAuth mode | none | OAuth issuer discovery URL |
 | `AFFINE_OAUTH_SCOPES` | No | `mcp` | Scopes advertised for OAuth-protected access |
@@ -143,6 +146,18 @@ Use bearer mode when:
 - the client can inject a shared secret header
 - you want the simplest remote deployment
 - you do not need OAuth discovery and token validation
+
+Bearer tokens must be sent with `Authorization: Bearer <token>`. Query-string
+tokens are rejected by default because URLs can be retained in access logs,
+browser history, and monitoring systems. Legacy clients can temporarily opt in
+with `AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN=true`, but this mode is deprecated.
+
+In bearer mode, a non-loopback listener such as `0.0.0.0`, `::`, a LAN address,
+or a hostname requires `AFFINE_MCP_HTTP_TOKEN`. Startup fails when the token is
+missing. `AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED=true` is an explicit unsafe
+escape hatch for isolated private networks and must not be used on an
+internet-reachable listener. Loopback listeners remain available without MCP
+authentication for local development.
 
 ### OAuth mode
 
@@ -287,6 +302,8 @@ Before exposing the server remotely, confirm:
 - `AFFINE_MCP_HTTP_HOST=0.0.0.0` is set in containerized deployments
 - HTTPS or TLS termination is in front of any non-local HTTP deployment
 - bearer mode uses a long random `AFFINE_MCP_HTTP_TOKEN`, or OAuth is configured for multi-user access
+- clients send bearer credentials in the `Authorization` header rather than the URL
+- `AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED` and `AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN` are not enabled
 - `AFFINE_MCP_HTTP_ALLOWED_ORIGINS` is set for browser-based clients
 - `AFFINE_MCP_HTTP_ALLOW_ALL_ORIGINS` is not enabled outside local testing
 - `/healthz` and `/readyz` are wired into your platform checks
@@ -302,3 +319,5 @@ Before exposing the server remotely, confirm:
 - Custom GraphQL deployments: run `affine-mcp show-config --json` and confirm `graphqlEndpoint`, then run `affine-mcp doctor --json`
 - `doctor` also rejects an unprotected non-loopback HTTP bind and validates OAuth transport, discovery metadata, and JWKS reachability
 - Invalid transport, port, origin, or boolean values now fail at startup instead of silently falling back
+- Remote plain-HTTP AFFiNE URL rejected: use HTTPS, or set `AFFINE_ALLOW_INSECURE_HTTP=true` only for a trusted private network
+- Non-loopback bearer listener rejected: set `AFFINE_MCP_HTTP_TOKEN` or configure OAuth

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,10 @@ Client-side MCP config:
 }
 ```
 
+Remote bearer-mode listeners fail to start without
+`AFFINE_MCP_HTTP_TOKEN`. Send this token only in the `Authorization` header;
+query-string tokens are rejected by default.
+
 For OAuth mode, origin controls, and deployment hardening, continue with [configuration and deployment](configuration-and-deployment.md#docker).
 
 ## Path D: Run from a local clone

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:http-email-password": "node tests/test-http-email-password.mjs",
     "test:auth-session": "tsx tests/test-auth-session.mjs",
     "test:http-bearer": "node tests/test-http-bearer.mjs",
+    "test:http-security": "tsx tests/test-http-security.mjs",
     "test:oauth-http": "node tests/test-oauth-http.mjs",
     "test:organize": "node tests/test-organize-tools.mjs",
     "test:create-doc-folder-placement": "node tests/test-create-doc-folder-placement.mjs",
@@ -79,7 +80,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run test:oauth-service-policy && npm run pack:check",
+    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run test:oauth-service-policy && npm run test:http-security && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
 } from "./config.js";
 import { loginWithPassword } from "./auth.js";
 import { probeOAuthReadiness, validateOAuthConfig } from "./oauth.js";
+import { parseBooleanFlag } from "./networkSecurity.js";
 
 const CLI_FETCH_TIMEOUT_MS = 30_000;
 
@@ -479,7 +480,14 @@ async function login(args: string[]) {
 
   const defaultUrl = "https://app.affine.pro";
   const rawUrl = providedUrl ?? ((await ask(`Affine URL [${defaultUrl}]: `)) || defaultUrl);
-  const baseUrl = validateBaseUrl(rawUrl);
+  const baseUrl = validateBaseUrl(rawUrl, {
+    allowInsecureHttp: parseBooleanFlag(
+      "AFFINE_ALLOW_INSECURE_HTTP",
+      process.env.AFFINE_ALLOW_INSECURE_HTTP,
+    ),
+    insecureHttpOptInName: "AFFINE_ALLOW_INSECURE_HTTP",
+    label: "AFFINE URL",
+  });
   const graphqlPath = validateGraphqlPath(
     providedGraphqlPath || process.env.AFFINE_GRAPHQL_PATH || existing.AFFINE_GRAPHQL_PATH || "/graphql",
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,11 @@ import * as os from "os";
 import * as path from "path";
 import { createRequire } from "module";
 
+import {
+  isRemotePlainHttpUrl,
+  parseBooleanFlag,
+} from "./networkSecurity.js";
+
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 export const VERSION: string = pkg.version;
@@ -85,8 +90,17 @@ export function writeConfigFile(vars: Record<string, string>) {
   }
 }
 
+type BaseUrlValidationOptions = {
+  allowInsecureHttp?: boolean;
+  insecureHttpOptInName?: string;
+  label?: string;
+};
+
 /** Validate and sanitize a base URL. Throws on invalid or dangerous URLs. */
-export function validateBaseUrl(input: string): string {
+export function validateBaseUrl(
+  input: string,
+  options: BaseUrlValidationOptions = {},
+): string {
   let parsed: URL;
   try {
     parsed = new URL(input);
@@ -101,11 +115,18 @@ export function validateBaseUrl(input: string): string {
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(`Unsupported URL scheme: ${parsed.protocol} (only http/https allowed)`);
   }
-  // Warn (but allow) plain HTTP for non-local targets
-  const host = parsed.hostname;
-  const isLocal = host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "0.0.0.0";
-  if (parsed.protocol === "http:" && !isLocal) {
-    console.error("WARNING: Using plain HTTP for a non-localhost URL. Consider HTTPS for security.");
+  if (isRemotePlainHttpUrl(parsed)) {
+    const label = options.label || "URL";
+    if (!options.allowInsecureHttp) {
+      const optIn = options.insecureHttpOptInName
+        ? ` Set ${options.insecureHttpOptInName}=true only for a trusted private network.`
+        : "";
+      throw new Error(`${label} must use HTTPS for non-loopback destinations.${optIn}`);
+    }
+    console.warn(
+      `[affine-mcp] WARNING: ${label} uses plain HTTP for a non-loopback destination. ` +
+        "Credentials and content are not protected in transit.",
+    );
   }
   // Return normalized URL without trailing slash
   return parsed.origin + parsed.pathname.replace(/\/+$/, "");
@@ -278,7 +299,18 @@ function parseAllowedOrigins(raw: string | undefined): string[] {
 
 export function loadConfig(): ServerConfig {
   const file = loadConfigFile();
-  const baseUrl = validateBaseUrl(env("AFFINE_BASE_URL", file, "http://localhost:3010")!);
+  const allowInsecureHttp = parseBooleanFlag(
+    "AFFINE_ALLOW_INSECURE_HTTP",
+    env("AFFINE_ALLOW_INSECURE_HTTP", file),
+  );
+  const baseUrl = validateBaseUrl(
+    env("AFFINE_BASE_URL", file, "http://localhost:3010")!,
+    {
+      allowInsecureHttp,
+      insecureHttpOptInName: "AFFINE_ALLOW_INSECURE_HTTP",
+      label: "AFFINE_BASE_URL",
+    },
+  );
   const authMode = parseAuthMode(env("AFFINE_MCP_AUTH_MODE", file, "bearer"));
   const apiToken = env("AFFINE_API_TOKEN", file);
   const cookie = env("AFFINE_COOKIE", file);
@@ -298,8 +330,12 @@ export function loadConfig(): ServerConfig {
   const defaultWorkspaceId = env("AFFINE_WORKSPACE_ID", file);
   const publicBaseUrlRaw = env("AFFINE_MCP_PUBLIC_BASE_URL", file);
   const oauthIssuerUrlRaw = env("AFFINE_OAUTH_ISSUER_URL", file);
-  const publicBaseUrl = publicBaseUrlRaw ? validateBaseUrl(publicBaseUrlRaw) : undefined;
-  const oauthIssuerUrl = oauthIssuerUrlRaw ? validateBaseUrl(oauthIssuerUrlRaw) : undefined;
+  const publicBaseUrl = publicBaseUrlRaw
+    ? validateBaseUrl(publicBaseUrlRaw, { label: "AFFINE_MCP_PUBLIC_BASE_URL" })
+    : undefined;
+  const oauthIssuerUrl = oauthIssuerUrlRaw
+    ? validateBaseUrl(oauthIssuerUrlRaw, { label: "AFFINE_OAUTH_ISSUER_URL" })
+    : undefined;
   const oauthScopes = parseOAuthScopes(env("AFFINE_OAUTH_SCOPES", file, "mcp"));
   const oauthClockSkewSeconds = parsePositiveIntegerEnv(
     "AFFINE_OAUTH_CLOCK_SKEW_SECONDS",

--- a/src/httpAuth.ts
+++ b/src/httpAuth.ts
@@ -97,7 +97,7 @@ export function createHttpAuthState(
         return;
       }
 
-      if (typeof req.query.token === "string") {
+      if (req.query.token !== undefined) {
         res.set("WWW-Authenticate", buildWwwAuthenticateHeader(protectedResourceMetadataUrl, {
           error: "invalid_request",
           errorDescription: "Query parameter token is not allowed in oauth mode.",

--- a/src/httpAuth.ts
+++ b/src/httpAuth.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
 import type express from "express";
 import type { NextFunction, Request, Response } from "express";
 
@@ -26,6 +28,12 @@ function buildOAuthErrorResponse(error: string, description: string) {
   };
 }
 
+function tokenMatches(provided: string, expected: string): boolean {
+  const providedDigest = createHash("sha256").update(provided, "utf8").digest();
+  const expectedDigest = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+}
+
 function buildWwwAuthenticateHeader(
   protectedResourceMetadataUrl: string | null,
   opts?: {
@@ -52,7 +60,11 @@ function buildWwwAuthenticateHeader(
 
 export function createHttpAuthState(
   config: ServerConfig,
-  opts: { allowAnyOrigin: boolean; httpAuthToken?: string },
+  opts: {
+    allowAnyOrigin: boolean;
+    allowQueryToken?: boolean;
+    httpAuthToken?: string;
+  },
 ): HttpAuthState {
   let oauthConfig: OAuthConfig | null = null;
   let protectedResourceMetadataUrl: string | null = null;
@@ -144,6 +156,28 @@ export function createHttpAuthState(
     if (!httpAuthToken) return next();
 
     const authHeader = req.headers.authorization;
+    const hasQueryToken = req.query.token !== undefined;
+    if (hasQueryToken && !opts.allowQueryToken) {
+      res.set("WWW-Authenticate", "Bearer");
+      res.status(400).json(
+        buildOAuthErrorResponse(
+          "invalid_request",
+          "Query parameter token authentication is disabled. Use the Authorization header.",
+        ),
+      );
+      return;
+    }
+
+    if (hasQueryToken && typeof req.query.token !== "string") {
+      res.status(400).json(
+        buildOAuthErrorResponse(
+          "invalid_request",
+          "The token query parameter must contain exactly one string value.",
+        ),
+      );
+      return;
+    }
+
     const queryToken = typeof req.query.token === "string" ? req.query.token : undefined;
     let token: string | undefined;
 
@@ -160,7 +194,7 @@ export function createHttpAuthState(
       token = queryToken;
     }
 
-    if (token !== httpAuthToken) {
+    if (!token || !tokenMatches(token, httpAuthToken)) {
       res.status(401).send("Unauthorized: Invalid or missing token");
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,11 +141,7 @@ if (authSource === "not configured") {
   console.error("[affine-mcp] Set AFFINE_API_TOKEN or run: affine-mcp login");
 }
 console.error(`[affine-mcp] HTTP auth mode: ${config.authMode}`);
-if (authSource !== "not configured" && config.baseUrl.startsWith("http://")
-    && !config.baseUrl.includes("localhost")
-    && !config.baseUrl.includes("127.0.0.1")) {
-  console.error("WARNING: Credentials configured over plain HTTP. Use HTTPS for remote servers.");
-}
+
 console.error(`[affine-mcp] Workspace: ${config.defaultWorkspaceId ? 'set' : '(none)'}`);
 
 for (const warning of toolFilter.warnings) {

--- a/src/networkSecurity.ts
+++ b/src/networkSecurity.ts
@@ -1,0 +1,29 @@
+/** Parse an explicit boolean environment flag and reject ambiguous values. */
+export function parseBooleanFlag(name: string, raw: string | undefined): boolean {
+  if (raw === undefined || raw.trim() === "") return false;
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+
+  throw new Error(`${name} must be either "true" or "false". Received: ${raw}`);
+}
+
+/** Return true only for hostnames that are unambiguously loopback addresses. */
+export function isLoopbackHostname(input: string): boolean {
+  const hostname = input.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (hostname === "localhost" || hostname === "::1") return true;
+
+  const parts = hostname.split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) {
+    return false;
+  }
+
+  const octets = parts.map(Number);
+  return octets.every((octet) => octet >= 0 && octet <= 255) && octets[0] === 127;
+}
+
+/** Return true when a URL uses plain HTTP for a non-loopback destination. */
+export function isRemotePlainHttpUrl(url: URL): boolean {
+  return url.protocol === "http:" && !isLoopbackHostname(url.hostname);
+}

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -9,6 +9,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerConfig } from "./config.js";
 import { registerHttpDiagnosticsRoutes } from "./httpDiagnostics.js";
 import { createHttpAuthState, registerHttpAuthRoutes } from "./httpAuth.js";
+import {
+  isLoopbackHostname,
+  parseBooleanFlag,
+} from "./networkSecurity.js";
 
 export async function startHttpMcpServer(
   createMcpServer: () => Promise<McpServer>,
@@ -18,12 +22,51 @@ export async function startHttpMcpServer(
 
   // --- Bearer Token guard (AFFINE_MCP_HTTP_TOKEN) ---
   // When set, all requests to /mcp, /sse and /messages must include:
-  //   Authorization: Bearer <token>   OR   ?token=<token> (fallback for limited clients)
-  // When the server is bound to 0.0.0.0 without a token, a startup warning is emitted.
-  if (!httpAuthToken && host === "0.0.0.0") {
+  //   Authorization: Bearer <token>
+  // Query-string token authentication is disabled unless explicitly enabled for legacy clients.
+  const allowUnauthenticated = parseBooleanFlag(
+    "AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED",
+    process.env.AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED,
+  );
+  const allowQueryToken = parseBooleanFlag(
+    "AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN",
+    process.env.AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN,
+  );
+
+  if (config.authMode === "oauth" && allowUnauthenticated) {
+    throw new Error(
+      "AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED is not valid when AFFINE_MCP_AUTH_MODE=oauth.",
+    );
+  }
+  if (config.authMode === "oauth" && allowQueryToken) {
+    throw new Error(
+      "AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN is not valid when AFFINE_MCP_AUTH_MODE=oauth.",
+    );
+  }
+
+  const remoteBind = !isLoopbackHostname(host);
+  if (
+    config.authMode === "bearer" &&
+    remoteBind &&
+    !httpAuthToken &&
+    !allowUnauthenticated
+  ) {
+    throw new Error(
+      `Refusing to bind the HTTP MCP server to non-loopback host "${host}" without authentication. ` +
+        "Set AFFINE_MCP_HTTP_TOKEN, use OAuth, or explicitly set " +
+        "AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED=true only for a trusted private network.",
+    );
+  }
+  if (config.authMode === "bearer" && remoteBind && !httpAuthToken) {
     console.warn(
-      "[affine-mcp] WARNING: HTTP MCP server is bound to 0.0.0.0 without AFFINE_MCP_HTTP_TOKEN. " +
-        "The endpoint is unprotected. Set AFFINE_MCP_HTTP_TOKEN for public deployments.",
+      `[affine-mcp] WARNING: HTTP MCP server is bound to non-loopback host "${host}" without authentication ` +
+        "because AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED=true. Do not expose this listener to an untrusted network.",
+    );
+  }
+  if (config.authMode === "bearer" && allowQueryToken) {
+    console.warn(
+      "[affine-mcp] WARNING: Query-string bearer tokens are enabled by " +
+        "AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN=true. This legacy mode can leak credentials through URLs and logs.",
     );
   }
 
@@ -87,7 +130,11 @@ export async function startHttpMcpServer(
     });
   };
 
-  const authState = createHttpAuthState(config, { allowAnyOrigin: allowAllOrigins, httpAuthToken });
+  const authState = createHttpAuthState(config, {
+    allowAnyOrigin: allowAllOrigins,
+    allowQueryToken,
+    httpAuthToken,
+  });
 
   // Validates the Bearer token on all non-preflight requests.
   // The auth scheme match is case-insensitive for client compatibility.

--- a/tests/test-http-bearer.mjs
+++ b/tests/test-http-bearer.mjs
@@ -7,7 +7,7 @@ import { testResourceName, testTempPath } from './require-destructive-test-safet
  * Covers:
  * - /healthz and /readyz
  * - 401 for missing/invalid bearer token
- * - query-string token fallback
+ * - rejection of query-string bearer tokens
  * - valid static bearer auth over Streamable HTTP
  */
 import { createServer } from "node:http";
@@ -223,9 +223,9 @@ async function main() {
         Accept: "text/event-stream",
       },
     });
-    if (queryTokenResponse.status === 401) {
-      throw new Error("query-string token was rejected before reaching the MCP handler");
-    }
+    expectEqual(queryTokenResponse.status, 400, "query-string bearer token status");
+    const queryTokenError = await queryTokenResponse.json();
+    expectEqual(queryTokenError?.error, "invalid_request", "query-string bearer token error");
 
     const client = new Client({ name: "http-bearer-client", version: "1.0.0" });
     const transport = new StreamableHTTPClientTransport(new URL(server.mcpUrl), {

--- a/tests/test-http-security.mjs
+++ b/tests/test-http-security.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { validateBaseUrl } from "../src/config.ts";
+import { createHttpAuthState } from "../src/httpAuth.ts";
 import {
   isLoopbackHostname,
   isRemotePlainHttpUrl,
@@ -178,6 +179,78 @@ async function readJson(response) {
   }
 }
 
+function invokeAuthMiddleware(state, query) {
+  let nextCalled = false;
+  const response = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    set(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+      return this;
+    },
+    status(statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+    send(body) {
+      this.body = body;
+      return this;
+    },
+  };
+
+  state.authMiddleware(
+    { method: "GET", query, headers: {} },
+    response,
+    () => { nextCalled = true; },
+  );
+  return { nextCalled, response };
+}
+
+function testQueryTokenShapeRejection() {
+  const commonConfig = {
+    baseUrl: "http://127.0.0.1:3010",
+    graphqlPath: "/graphql",
+    oauthScopes: ["mcp"],
+    oauthClockSkewSeconds: 60,
+  };
+  const oauth = createHttpAuthState(
+    {
+      ...commonConfig,
+      authMode: "oauth",
+      publicBaseUrl: "http://127.0.0.1:3100",
+      oauthIssuerUrl: "http://127.0.0.1:3200",
+    },
+    { allowAnyOrigin: false },
+  );
+  const bearer = createHttpAuthState(
+    { ...commonConfig, authMode: "bearer" },
+    {
+      allowAnyOrigin: false,
+      allowQueryToken: false,
+      httpAuthToken: "static-test-token",
+    },
+  );
+
+  const queryTokenShapes = [
+    ["string", "one"],
+    ["duplicate/array", ["one", "two"]],
+    ["object", { value: "one" }],
+  ];
+  for (const [label, token] of queryTokenShapes) {
+    for (const [mode, state] of [["oauth", oauth], ["bearer", bearer]]) {
+      const { nextCalled, response } = invokeAuthMiddleware(state, { token });
+      assertEqual(response.statusCode, 400, `${mode} ${label} query token status`);
+      assertEqual(response.body?.error, "invalid_request", `${mode} ${label} query token error`);
+      assertEqual(nextCalled, false, `${mode} ${label} query token must not call next`);
+    }
+  }
+}
+
 async function testNetworkPolicyHelpers() {
   const loopbackHosts = ["localhost", "LOCALHOST", "127.0.0.1", "127.255.255.255", "::1", "[::1]"];
   for (const host of loopbackHosts) {
@@ -305,6 +378,7 @@ async function testBearerTokenPolicy() {
 
 async function main() {
   assert(existsSync(SERVER_PATH), "dist/index.js is missing; run npm run build first");
+  testQueryTokenShapeRejection();
   await testNetworkPolicyHelpers();
   await testRemoteBindPolicy();
   await testBearerTokenPolicy();

--- a/tests/test-http-security.mjs
+++ b/tests/test-http-security.mjs
@@ -148,6 +148,27 @@ async function expectStartupFailure(overrides, expectedMessage) {
   assert(spawned.logs().stderr.includes(expectedMessage), `missing startup error: ${spawned.logs().stderr}`);
 }
 
+async function expectStatusFailure(overrides, expectedMessage) {
+  const child = spawn("node", [SERVER_PATH, "status", "--json"], {
+    cwd: PROJECT_DIR,
+    env: serverEnvironment(0, overrides),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr.on("data", chunk => { stderr += chunk.toString(); });
+  const result = await Promise.race([
+    new Promise(resolve => child.once("exit", code => resolve({ exited: true, code }))),
+    delay(5_000).then(() => ({ exited: false, code: null })),
+  ]);
+  if (!result.exited) {
+    child.kill("SIGKILL");
+    await new Promise(resolve => child.once("exit", resolve));
+    throw new Error(`Expected status failure but command stayed running: ${stderr}`);
+  }
+  assertEqual(result.code, 1, "status failure exit code");
+  assert(stderr.includes(expectedMessage), `missing status error: ${stderr}`);
+}
+
 async function readJson(response) {
   const body = await response.text();
   try {
@@ -187,6 +208,11 @@ async function testNetworkPolicyHelpers() {
   assertEqual(parseBooleanFlag("FLAG", "true"), true, "true boolean flag");
   assertEqual(parseBooleanFlag("FLAG", "FALSE"), false, "false boolean flag");
   assertThrows(() => parseBooleanFlag("FLAG", "yes"), "must be either", "ambiguous boolean flag");
+
+  await expectStatusFailure(
+    { AFFINE_BASE_URL: "http://192.0.2.10" },
+    "must use HTTPS",
+  );
 }
 
 async function testRemoteBindPolicy() {

--- a/tests/test-http-security.mjs
+++ b/tests/test-http-security.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { validateBaseUrl } from "../src/config.ts";
+import {
+  isLoopbackHostname,
+  isRemotePlainHttpUrl,
+  parseBooleanFlag,
+} from "../src/networkSecurity.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = path.resolve(__dirname, "..");
+const SERVER_PATH = path.join(PROJECT_DIR, "dist", "index.js");
+const SECURITY_ENV_KEYS = [
+  "AFFINE_ALLOW_INSECURE_HTTP",
+  "AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN",
+  "AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED",
+  "AFFINE_MCP_HTTP_TOKEN",
+];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertThrows(fn, expectedMessage, message) {
+  try {
+    fn();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    assert(detail.includes(expectedMessage), `${message}: unexpected error: ${detail}`);
+    return;
+  }
+  throw new Error(`${message}: expected an error`);
+}
+
+async function findFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function serverEnvironment(port, overrides = {}) {
+  const env = { ...process.env };
+  for (const key of SECURITY_ENV_KEYS) delete env[key];
+  return {
+    ...env,
+    MCP_TRANSPORT: "http",
+    PORT: String(port),
+    AFFINE_BASE_URL: "http://127.0.0.1:3010",
+    AFFINE_API_TOKEN: "test-affine-api-token",
+    AFFINE_MCP_AUTH_MODE: "bearer",
+    AFFINE_MCP_HTTP_HOST: "127.0.0.1",
+    XDG_CONFIG_HOME: `/tmp/affine-mcp-http-security-${process.pid}-${port}`,
+    ...overrides,
+  };
+}
+
+function spawnServer(port, overrides = {}) {
+  const child = spawn("node", [SERVER_PATH], {
+    cwd: PROJECT_DIR,
+    env: serverEnvironment(port, overrides),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  return { child, logs: () => ({ stdout, stderr }) };
+}
+
+async function waitForHealth(child, url, logs, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Server exited before becoming healthy: ${JSON.stringify(logs())}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      await response.body?.cancel();
+    } catch {
+      // Retry until the startup deadline.
+    }
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(logs())}`);
+}
+
+async function stopServer(child) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const exited = await Promise.race([
+    new Promise((resolve) => child.once("exit", () => resolve(true))),
+    delay(4_000).then(() => false),
+  ]);
+  if (!exited && child.exitCode === null) {
+    child.kill("SIGKILL");
+    await new Promise((resolve) => child.once("exit", resolve));
+    throw new Error("HTTP server did not stop after SIGTERM");
+  }
+}
+
+async function startHealthyServer(overrides = {}) {
+  const port = await findFreePort();
+  const spawned = spawnServer(port, overrides);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForHealth(spawned.child, `${baseUrl}/healthz`, spawned.logs);
+  } catch (error) {
+    if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL");
+    throw error;
+  }
+  return { ...spawned, baseUrl, close: () => stopServer(spawned.child) };
+}
+
+async function expectStartupFailure(overrides, expectedMessage) {
+  const port = await findFreePort();
+  const spawned = spawnServer(port, overrides);
+  const result = await Promise.race([
+    new Promise((resolve) => spawned.child.once("exit", (code) => resolve({ exited: true, code }))),
+    delay(5_000).then(() => ({ exited: false, code: null })),
+  ]);
+  if (!result.exited) {
+    spawned.child.kill("SIGKILL");
+    await new Promise((resolve) => spawned.child.once("exit", resolve));
+    throw new Error(`Expected startup failure but server stayed running: ${JSON.stringify(spawned.logs())}`);
+  }
+  assertEqual(result.code, 1, "startup failure exit code");
+  assert(spawned.logs().stderr.includes(expectedMessage), `missing startup error: ${spawned.logs().stderr}`);
+}
+
+async function readJson(response) {
+  const body = await response.text();
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error(`Expected JSON response, got ${response.status}: ${body}`);
+  }
+}
+
+async function testNetworkPolicyHelpers() {
+  const loopbackHosts = ["localhost", "LOCALHOST", "127.0.0.1", "127.255.255.255", "::1", "[::1]"];
+  for (const host of loopbackHosts) {
+    assert(isLoopbackHostname(host), `${host} should be loopback`);
+  }
+  const remoteHosts = ["0.0.0.0", "::", "192.168.1.10", "10.0.0.4", "example.com", "127.0.0.256"];
+  for (const host of remoteHosts) {
+    assert(!isLoopbackHostname(host), `${host} should not be loopback`);
+  }
+
+  assert(isRemotePlainHttpUrl(new URL("http://192.0.2.10")), "remote HTTP URL should be insecure");
+  assert(!isRemotePlainHttpUrl(new URL("https://192.0.2.10")), "remote HTTPS URL should be secure");
+  assert(!isRemotePlainHttpUrl(new URL("http://127.0.0.1:3010")), "loopback HTTP URL should be allowed");
+
+  assertThrows(
+    () => validateBaseUrl("http://192.0.2.10", { label: "AFFINE_BASE_URL" }),
+    "must use HTTPS",
+    "remote plain HTTP rejection",
+  );
+  assertEqual(
+    validateBaseUrl("http://192.0.2.10/", { allowInsecureHttp: true, label: "AFFINE_BASE_URL" }),
+    "http://192.0.2.10",
+    "explicit remote plain HTTP opt-in",
+  );
+  assertEqual(validateBaseUrl("http://127.0.0.1:3010/"), "http://127.0.0.1:3010", "loopback URL");
+
+  assertEqual(parseBooleanFlag("FLAG", undefined), false, "undefined boolean flag");
+  assertEqual(parseBooleanFlag("FLAG", "true"), true, "true boolean flag");
+  assertEqual(parseBooleanFlag("FLAG", "FALSE"), false, "false boolean flag");
+  assertThrows(() => parseBooleanFlag("FLAG", "yes"), "must be either", "ambiguous boolean flag");
+}
+
+async function testRemoteBindPolicy() {
+  await expectStartupFailure(
+    { AFFINE_MCP_HTTP_HOST: "0.0.0.0" },
+    "Refusing to bind the HTTP MCP server to non-loopback host",
+  );
+
+  const local = await startHealthyServer();
+  try {
+    const health = await fetch(`${local.baseUrl}/healthz`);
+    assertEqual(health.status, 200, "local unauthenticated health status");
+    assertEqual((await readJson(health)).protected, false, "local server protection state");
+
+    const mcp = await fetch(`${local.baseUrl}/mcp`);
+    assertEqual(mcp.status, 400, "local unauthenticated MCP reaches protocol handler");
+    assertEqual((await readJson(mcp)).jsonrpc, "2.0", "local MCP protocol response");
+  } finally {
+    await local.close();
+  }
+
+  const explicitlyUnsafe = await startHealthyServer({
+    AFFINE_MCP_HTTP_HOST: "0.0.0.0",
+    AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED: "true",
+  });
+  try {
+    const health = await fetch(`${explicitlyUnsafe.baseUrl}/healthz`);
+    assertEqual(health.status, 200, "explicit unsafe opt-in health status");
+    assert(
+      explicitlyUnsafe.logs().stderr.includes("Do not expose this listener to an untrusted network"),
+      "explicit unsafe opt-in should emit a warning",
+    );
+  } finally {
+    await explicitlyUnsafe.close();
+  }
+}
+
+async function testBearerTokenPolicy() {
+  const token = "static-test-token";
+  const server = await startHealthyServer({ AFFINE_MCP_HTTP_TOKEN: token });
+  try {
+    const health = await fetch(`${server.baseUrl}/healthz`);
+    assertEqual(health.status, 200, "protected server health remains unauthenticated");
+    assertEqual((await readJson(health)).protected, true, "protected server health metadata");
+    const readiness = await fetch(`${server.baseUrl}/readyz`);
+    assertEqual(readiness.status, 200, "protected server readiness remains unauthenticated");
+
+    const missing = await fetch(`${server.baseUrl}/mcp`);
+    assertEqual(missing.status, 401, "missing bearer token");
+
+    const wrong = await fetch(`${server.baseUrl}/mcp`, {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+    assertEqual(wrong.status, 401, "incorrect bearer token");
+
+    const query = await fetch(`${server.baseUrl}/mcp?token=${encodeURIComponent(token)}`);
+    assertEqual(query.status, 400, "query token disabled status");
+    const queryBody = await readJson(query);
+    assertEqual(queryBody.error, "invalid_request", "query token disabled error");
+    assert(
+      queryBody.error_description.includes("Authorization header"),
+      "query token rejection should explain the supported transport",
+    );
+
+    const authorized = await fetch(`${server.baseUrl}/mcp`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assertEqual(authorized.status, 400, "header token reaches MCP protocol handler");
+    assertEqual((await readJson(authorized)).jsonrpc, "2.0", "authorized MCP protocol response");
+  } finally {
+    await server.close();
+  }
+
+  const legacy = await startHealthyServer({
+    AFFINE_MCP_HTTP_TOKEN: token,
+    AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN: "true",
+  });
+  try {
+    const query = await fetch(`${legacy.baseUrl}/mcp?token=${encodeURIComponent(token)}`);
+    assertEqual(query.status, 400, "legacy query token reaches MCP protocol handler");
+    assertEqual((await readJson(query)).jsonrpc, "2.0", "legacy query token protocol response");
+    assert(
+      legacy.logs().stderr.includes("Query-string bearer tokens are enabled"),
+      "legacy query token mode should emit a warning",
+    );
+  } finally {
+    await legacy.close();
+  }
+}
+
+async function main() {
+  assert(existsSync(SERVER_PATH), "dist/index.js is missing; run npm run build first");
+  await testNetworkPolicyHelpers();
+  await testRemoteBindPolicy();
+  await testBearerTokenPolicy();
+  console.log("HTTP security regression tests passed.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
# TL;DR
- Make remote HTTP transport and remote AFFiNE connections fail closed by default.

# Context
- Non-loopback listeners could start without authentication, query-string tokens could leak, and remote plain HTTP could carry credentials.
- Rebase after the configuration/auth branches when integrating the runtime hardening queue.

# Changes
- Require authentication or an explicit unsafe acknowledgement for non-loopback binds.
- Rejected every query-string token shape and hardened token comparison.
- Require HTTPS for non-loopback AFFiNE URLs unless explicitly acknowledged, including CLI status/login paths.
- Added focused HTTP and CLI regressions; local CI passed.
