### PR TITLE
chore: reject protected pull request heads

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-> Base branch must be `develop`. Pull requests targeting other branches are closed automatically.
+> Normal pull requests must use a dedicated, non-protected head branch and target `develop`.
+> Only `release/*` branches may target `main`. The protected branches `main`, `develop`, `dev`, and `master` may never be used as pull request heads.
 
 ## Summary
 
@@ -15,6 +16,7 @@ Commands executed:
 ```bash
 npm run build
 npm run test:tool-manifest
+npm run test:pr-route-policy
 ```
 
 If applicable, also include:
@@ -25,6 +27,8 @@ npm run test:comprehensive
 
 ## Checklist
 
+- [ ] Head branch is a dedicated branch, not `main`, `develop`, `dev`, or `master`
+- [ ] Base branch is `develop`, unless this is a `release/*` pull request targeting `main`
 - [ ] Tool names remain unique and `snake_case`
 - [ ] `tool-manifest.json` updated if tool list changed
 - [ ] `README.md` updated if behavior/user-facing API changed

--- a/.github/scripts/pr-route-policy.cjs
+++ b/.github/scripts/pr-route-policy.cjs
@@ -1,0 +1,67 @@
+"use strict";
+
+const PROTECTED_HEADS = new Set(["main", "develop", "dev", "master"]);
+
+function evaluatePrRoute({ baseRef, headRef }) {
+  if (typeof baseRef !== "string" || baseRef.length === 0) {
+    return {
+      allowed: false,
+      code: "invalid-base",
+      reason: "The pull request base branch is missing or invalid.",
+    };
+  }
+  if (typeof headRef !== "string" || headRef.length === 0) {
+    return {
+      allowed: false,
+      code: "invalid-head",
+      reason: "The pull request head branch is missing or invalid.",
+    };
+  }
+
+  const normalizedHead = headRef.toLowerCase();
+  if (PROTECTED_HEADS.has(normalizedHead)) {
+    return {
+      allowed: false,
+      code: "protected-head",
+      reason:
+        `Protected branch \`${headRef}\` cannot be used as a pull request head. ` +
+        "Create a dedicated working or synchronization branch instead.",
+    };
+  }
+
+  if (baseRef === "develop") {
+    return {
+      allowed: true,
+      code: "develop-target",
+      reason: "A non-protected branch may target develop.",
+    };
+  }
+
+  if (baseRef === "main" && headRef.startsWith("release/")) {
+    return {
+      allowed: true,
+      code: "release-target",
+      reason: "A release branch may target main.",
+    };
+  }
+
+  return {
+    allowed: false,
+    code: "invalid-route",
+    reason:
+      "Pull requests must target develop from a non-protected branch, " +
+      "or target main from a release/* branch.",
+  };
+}
+
+module.exports = {
+  PROTECTED_HEADS,
+  evaluatePrRoute,
+};
+
+if (require.main === module) {
+  const [baseRef, headRef] = process.argv.slice(2);
+  const result = evaluatePrRoute({ baseRef, headRef });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.allowed ? 0 : 1);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Verify tool manifest
         run: npm run test:tool-manifest
 
+      - name: Verify pull request branch route policy
+        run: npm run test:pr-route-policy
+
       - name: Check package contents
         run: npm run pack:check

--- a/.github/workflows/enforce-pr-base.yml
+++ b/.github/workflows/enforce-pr-base.yml
@@ -18,29 +18,61 @@ jobs:
   enforce-branch-route:
     runs-on: ubuntu-latest
     steps:
-      # pull_request_target has a write-capable token. Check out only the trusted
-      # base revision, never the pull request head, and do not persist credentials.
-      - name: Checkout trusted base revision
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-
-      - name: Verify branch route policy
-        run: node tests/test-pr-route-policy.mjs
-
       - name: Enforce branch route
         uses: actions/github-script@v9
         with:
           script: |
-            const path = require("node:path");
-            const policyPath = path.join(
-              process.env.GITHUB_WORKSPACE,
-              ".github",
-              "scripts",
-              "pr-route-policy.cjs",
-            );
-            const { evaluatePrRoute } = require(policyPath);
+            // pull_request_target has a write-capable token. Keep the policy in
+            // this trusted workflow and never execute code from an event ref.
+            const protectedHeads = new Set(["main", "develop", "dev", "master"]);
+            const evaluatePrRoute = ({ baseRef, headRef }) => {
+              if (typeof baseRef !== "string" || baseRef.length === 0) {
+                return {
+                  allowed: false,
+                  code: "invalid-base",
+                  reason: "The pull request base branch is missing or invalid.",
+                };
+              }
+              if (typeof headRef !== "string" || headRef.length === 0) {
+                return {
+                  allowed: false,
+                  code: "invalid-head",
+                  reason: "The pull request head branch is missing or invalid.",
+                };
+              }
+
+              if (protectedHeads.has(headRef.toLowerCase())) {
+                return {
+                  allowed: false,
+                  code: "protected-head",
+                  reason:
+                    `Protected branch \`${headRef}\` cannot be used as a pull request head. ` +
+                    "Create a dedicated working or synchronization branch instead.",
+                };
+              }
+              if (baseRef === "develop") {
+                return {
+                  allowed: true,
+                  code: "develop-target",
+                  reason: "A non-protected branch may target develop.",
+                };
+              }
+              if (baseRef === "main" && headRef.startsWith("release/")) {
+                return {
+                  allowed: true,
+                  code: "release-target",
+                  reason: "A release branch may target main.",
+                };
+              }
+              return {
+                allowed: false,
+                code: "invalid-route",
+                reason:
+                  "Pull requests must target develop from a non-protected branch, " +
+                  "or target main from a release/* branch.",
+              };
+            };
+
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
             const baseRef = context.payload.pull_request.base.ref;

--- a/.github/workflows/enforce-pr-base.yml
+++ b/.github/workflows/enforce-pr-base.yml
@@ -1,4 +1,4 @@
-name: Enforce PR Base Branch
+name: Enforce PR Branch Route
 
 on:
   pull_request_target:
@@ -15,33 +15,57 @@ permissions:
   pull-requests: write
 
 jobs:
-  enforce-base-branch:
+  enforce-branch-route:
     runs-on: ubuntu-latest
     steps:
-      - name: Allow PRs targeting develop
-        if: ${{ github.event.pull_request.base.ref == 'develop' }}
-        run: echo "PR base branch is develop."
+      # pull_request_target has a write-capable token. Check out only the trusted
+      # base revision, never the pull request head, and do not persist credentials.
+      - name: Checkout trusted base revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
-      - name: Allow release PRs targeting main
-        if: ${{ github.event.pull_request.base.ref == 'main' && startsWith(github.event.pull_request.head.ref, 'release/') }}
-        run: echo "Release PR targeting main is allowed."
+      - name: Verify branch route policy
+        run: node tests/test-pr-route-policy.mjs
 
-      - name: Close PRs targeting non-develop branches
-        if: ${{ github.event.pull_request.base.ref != 'develop' && !(github.event.pull_request.base.ref == 'main' && startsWith(github.event.pull_request.head.ref, 'release/')) }}
+      - name: Enforce branch route
         uses: actions/github-script@v9
         with:
           script: |
+            const path = require("node:path");
+            const policyPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".github",
+              "scripts",
+              "pr-route-policy.cjs",
+            );
+            const { evaluatePrRoute } = require(policyPath);
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
             const baseRef = context.payload.pull_request.base.ref;
             const headRef = context.payload.pull_request.head.ref;
+            const result = evaluatePrRoute({ baseRef, headRef });
+
+            if (result.allowed) {
+              core.info(`Allowed pull request route: ${headRef} -> ${baseRef} (${result.code})`);
+              return;
+            }
+
             const message = [
-              "This repository only accepts pull requests targeting `develop`, plus `release/*` pull requests targeting `main`.",
+              "This pull request uses a branch route that is not allowed.",
               "",
               `Current base branch: \`${baseRef}\``,
               `Current head branch: \`${headRef}\``,
               "",
-              "Please change the base branch to `develop`, or use a `release/*` branch when targeting `main`, and reopen this pull request.",
+              `Reason: ${result.reason}`,
+              "",
+              "Allowed routes:",
+              "- a dedicated non-protected branch targeting `develop`",
+              "- a `release/*` branch targeting `main`",
+              "",
+              "The protected branches `main`, `develop`, `dev`, and `master` may never be used as pull request heads.",
+              "Please create or select an allowed head branch, update the target if needed, and reopen the pull request.",
             ].join("\n");
 
             await github.rest.issues.createComment({
@@ -58,4 +82,4 @@ jobs:
               state: "closed",
             });
 
-            core.setFailed("Pull requests must target develop, or use release/* when targeting main.");
+            core.setFailed(`Blocked pull request route: ${headRef} -> ${baseRef} (${result.code})`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,11 @@ npm run test:comprehensive
 ## Pull Request Guidelines
 
 - Keep each PR focused on one logical change.
-- Target the `develop` branch only. PRs against `main` or any other branch are closed automatically.
+- Use a dedicated, non-protected head branch for every pull request.
+- Target `develop` for normal feature, fix, refactor, documentation, and maintenance pull requests.
+- Only `release/*` branches may target `main`.
+- Never use `main`, `develop`, `dev`, or `master` as a pull request head, regardless of the target branch.
+- To synchronize release metadata from `main` back to `develop`, create a dedicated branch such as `chore/sync-v2.6.0-to-develop` from the confirmed `main` release commit.
 - Include what changed and why.
 - Include validation evidence (commands and result summary).
 - Update docs (`README.md`, `CHANGELOG.md`) when behavior changes.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:tool-manifest && npm run pack:check",
+    "ci": "npm run build && npm run test:tool-manifest && npm run test:pr-route-policy && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:cli-commands": "node tests/test-cli-commands.mjs",
     "test:cli-live": "node tests/test-cli-live.mjs",
     "test:tool-manifest": "node scripts/verify-tool-manifest.mjs",
+    "test:pr-route-policy": "node tests/test-pr-route-policy.mjs",
     "test:tool-filtering": "node tests/test-tool-filtering.mjs",
     "test:comprehensive": "bash tests/run-comprehensive.sh",
     "test:comprehensive:raw": "node test-comprehensive.mjs",

--- a/tests/test-pr-route-policy.mjs
+++ b/tests/test-pr-route-policy.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
@@ -38,6 +39,7 @@ const invalidRoutes = [
   { baseRef: "main", headRef: "release-candidate/2.6.0" },
   { baseRef: "production", headRef: "release/2.6.0" },
   { baseRef: "feature-target", headRef: "fix/http-auth" },
+  { baseRef: "attacker-controlled", headRef: "release/2.6.0" },
 ];
 
 for (const route of invalidRoutes) {
@@ -48,5 +50,25 @@ for (const route of invalidRoutes) {
 
 assert.equal(evaluatePrRoute({ baseRef: "", headRef: "feat/test" }).code, "invalid-base");
 assert.equal(evaluatePrRoute({ baseRef: "develop", headRef: "" }).code, "invalid-head");
+
+const enforcementWorkflow = fs.readFileSync(
+  new URL("../.github/workflows/enforce-pr-base.yml", import.meta.url),
+  "utf8",
+);
+assert.doesNotMatch(
+  enforcementWorkflow,
+  /actions\/checkout|github\.event\.pull_request\.(?:base|head)\.sha/,
+  "pull_request_target enforcement must not check out an event-controlled ref",
+);
+assert.doesNotMatch(
+  enforcementWorkflow,
+  /GITHUB_WORKSPACE|require\s*\(/,
+  "pull_request_target enforcement must not load repository code",
+);
+assert.match(
+  enforcementWorkflow,
+  /Keep the policy in\s+\/\/ this trusted workflow and never execute code from an event ref\./,
+  "the trusted inline policy guard must remain explicit",
+);
 
 console.log("PR route policy tests passed");

--- a/tests/test-pr-route-policy.mjs
+++ b/tests/test-pr-route-policy.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { PROTECTED_HEADS, evaluatePrRoute } = require("../.github/scripts/pr-route-policy.cjs");
+
+const allowedRoutes = [
+  { baseRef: "develop", headRef: "feat/new-tool", code: "develop-target" },
+  { baseRef: "develop", headRef: "fix/http-auth", code: "develop-target" },
+  { baseRef: "develop", headRef: "release/2.6.0", code: "develop-target" },
+  { baseRef: "main", headRef: "release/2.6.0", code: "release-target" },
+];
+
+for (const route of allowedRoutes) {
+  const result = evaluatePrRoute(route);
+  assert.equal(result.allowed, true, `${route.headRef} -> ${route.baseRef} should be allowed`);
+  assert.equal(result.code, route.code);
+}
+
+for (const headRef of PROTECTED_HEADS) {
+  for (const baseRef of ["develop", "main", "feature-target"]) {
+    const result = evaluatePrRoute({ baseRef, headRef });
+    assert.equal(result.allowed, false, `${headRef} -> ${baseRef} should be blocked`);
+    assert.equal(result.code, "protected-head");
+  }
+}
+
+for (const headRef of ["MAIN", "Develop", "DEV", "Master"]) {
+  const result = evaluatePrRoute({ baseRef: "develop", headRef });
+  assert.equal(result.allowed, false, `${headRef} -> develop should be blocked case-insensitively`);
+  assert.equal(result.code, "protected-head");
+}
+
+const invalidRoutes = [
+  { baseRef: "main", headRef: "feat/new-tool" },
+  { baseRef: "main", headRef: "chore/sync-v2.6.0-to-develop" },
+  { baseRef: "main", headRef: "release-candidate/2.6.0" },
+  { baseRef: "production", headRef: "release/2.6.0" },
+  { baseRef: "feature-target", headRef: "fix/http-auth" },
+];
+
+for (const route of invalidRoutes) {
+  const result = evaluatePrRoute(route);
+  assert.equal(result.allowed, false, `${route.headRef} -> ${route.baseRef} should be blocked`);
+  assert.equal(result.code, "invalid-route");
+}
+
+assert.equal(evaluatePrRoute({ baseRef: "", headRef: "feat/test" }).code, "invalid-base");
+assert.equal(evaluatePrRoute({ baseRef: "develop", headRef: "" }).code, "invalid-head");
+
+console.log("PR route policy tests passed");


### PR DESCRIPTION
# TL;DR
- Reject protected pull-request head branches while preserving the intended develop and release routes.

# Context
- A protected branch used as a PR head can create an unsafe or unmergeable release synchronization flow.
- This policy PR is independent of runtime changes.

# Changes
- Added a tested base/head routing policy for pull_request_target events.
- Allowed dedicated branches into develop and release branches into main.
- Rejected main, develop, dev, and master as PR heads using trusted inline workflow code without checking out pull-request content.
- Policy, local CI, YAML, and action checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request routing rules.
  * Standard branches must target `develop`; only `release/*` branches may target `main`.
  * Protected branches cannot be used as pull request source branches.
  * Invalid routes are rejected with an explanation and the pull request is closed.

* **Documentation**
  * Updated contribution guidelines and pull request templates with the new branch requirements.

* **Tests**
  * Added automated validation for allowed, blocked, and invalid routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->