### PR TITLE
fix: bound HTTP sessions and guarantee shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,5 +64,8 @@ jobs:
       - name: Verify HTTP security policy
         run: npm run test:http-security
 
+      - name: Verify HTTP runtime safety
+        run: npm run test:http-runtime
+
       - name: Check package contents
         run: npm run pack:check

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ For common failures, see:
 - Restrict exposed tools with `AFFINE_DISABLED_GROUPS` and `AFFINE_DISABLED_TOOLS` for least-privilege setups
 - Treat OAuth mode as a shared AFFiNE service-account deployment: it defaults to `read_only`, and write-capable profiles require `AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true`
 - Use `/healthz` and `/readyz` when running the HTTP server behind a container platform or load balancer
+- Set HTTP body, session, idle, and shutdown limits explicitly for high-volume deployments
 
 ## Development
 

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -71,6 +71,10 @@ cookie, while setting a bearer credential removes any cookie header.
 | `AFFINE_MCP_HTTP_TOKEN` | Required for non-loopback bearer mode | none | Shared bearer token for `/mcp`, `/sse`, and `/messages` |
 | `AFFINE_MCP_HTTP_ALLOW_UNAUTHENTICATED` | No | `false` | Unsafe opt-in for an unauthenticated non-loopback bearer-mode listener |
 | `AFFINE_MCP_HTTP_ALLOW_QUERY_TOKEN` | No | `false` | Deprecated compatibility mode for `?token=` clients; prefer the `Authorization` header |
+| `AFFINE_MCP_HTTP_BODY_LIMIT` | No | `4mb` | Maximum JSON request body size; accepts bytes, `kb`, or `mb` from `1kb` through `64mb` |
+| `AFFINE_MCP_HTTP_MAX_SESSIONS` | No | `32` | Maximum combined Streamable HTTP and legacy SSE sessions |
+| `AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS` | No | `1800000` | Close sessions that receive no MCP activity for this duration |
+| `AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS` | No | `10000` | Deadline before remaining HTTP connections are forcibly closed |
 | `AFFINE_MCP_PUBLIC_BASE_URL` | Required in OAuth mode | none | Public base URL for this MCP server |
 | `AFFINE_OAUTH_ISSUER_URL` | Required in OAuth mode | none | OAuth issuer discovery URL |
 | `AFFINE_OAUTH_SCOPES` | No | `mcp` | Scopes advertised for OAuth-protected access |
@@ -126,6 +130,21 @@ HTTP mode exposes:
 - `/readyz` - unauthenticated readiness probe that checks OAuth discovery when enabled and the exact configured AFFiNE GraphQL endpoint
 
 `/readyz` returns `503` with the failing component when the configured AFFiNE GraphQL endpoint is unavailable. Keep both diagnostic routes private to your load balancer or trusted monitoring network.
+
+### Runtime limits and shutdown
+
+The HTTP transport limits JSON request bodies and the number of active sessions
+to prevent accidental resource exhaustion. Both Streamable HTTP and legacy SSE
+sessions count toward `AFFINE_MCP_HTTP_MAX_SESSIONS`. New sessions receive a
+`503` response with `Retry-After` when the limit is reached. Existing session
+traffic refreshes its idle deadline, and inactive sessions are closed after
+`AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS`.
+
+On `SIGINT` or `SIGTERM`, the server stops accepting connections and closes MCP
+transports concurrently. If a connection prevents graceful shutdown beyond
+`AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS`, the remaining HTTP connections are
+forcibly closed. Invalid runtime limit values and listen errors fail startup
+instead of leaving a partially running process.
 
 ### Bearer mode
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:auth-session": "tsx tests/test-auth-session.mjs",
     "test:http-bearer": "node tests/test-http-bearer.mjs",
     "test:http-security": "tsx tests/test-http-security.mjs",
+    "test:http-runtime": "tsx tests/test-http-runtime-safety.mjs",
     "test:oauth-http": "node tests/test-oauth-http.mjs",
     "test:organize": "node tests/test-organize-tools.mjs",
     "test:create-doc-folder-placement": "node tests/test-create-doc-folder-placement.mjs",
@@ -80,7 +81,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run test:oauth-service-policy && npm run test:http-security && npm run pack:check",
+    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run test:oauth-service-policy && npm run test:http-security && npm run test:http-runtime && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/src/httpRuntimeConfig.ts
+++ b/src/httpRuntimeConfig.ts
@@ -1,0 +1,95 @@
+const KIBIBYTE = 1024;
+const MEBIBYTE = 1024 * KIBIBYTE;
+
+const DEFAULT_BODY_LIMIT_BYTES = 4 * MEBIBYTE;
+const DEFAULT_MAX_SESSIONS = 32;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10 * 1000;
+
+export type HttpRuntimeConfig = {
+  bodyLimitBytes: number;
+  maxSessions: number;
+  sessionIdleTimeoutMs: number;
+  sessionSweepIntervalMs: number;
+  shutdownTimeoutMs: number;
+};
+
+function parseIntegerInRange(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  if (!/^\d+$/.test(raw.trim())) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}. Received: ${raw}`);
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}. Received: ${raw}`);
+  }
+  return parsed;
+}
+
+export function parseBodyLimit(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return DEFAULT_BODY_LIMIT_BYTES;
+
+  const match = /^(\d+(?:\.\d+)?)\s*(b|kb|mb)?$/i.exec(raw.trim());
+  if (!match) {
+    throw new Error(
+      `AFFINE_MCP_HTTP_BODY_LIMIT must be a byte size such as "4096", "512kb", or "4mb". Received: ${raw}`,
+    );
+  }
+
+  const value = Number(match[1]);
+  const unit = (match[2] || "b").toLowerCase();
+  const multiplier = unit === "mb" ? MEBIBYTE : unit === "kb" ? KIBIBYTE : 1;
+  const bytes = Math.floor(value * multiplier);
+
+  if (!Number.isSafeInteger(bytes) || bytes < KIBIBYTE || bytes > 64 * MEBIBYTE) {
+    throw new Error(
+      `AFFINE_MCP_HTTP_BODY_LIMIT must resolve to a value between 1kb and 64mb. Received: ${raw}`,
+    );
+  }
+  return bytes;
+}
+
+export function loadHttpRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): HttpRuntimeConfig {
+  const bodyLimitBytes = parseBodyLimit(env.AFFINE_MCP_HTTP_BODY_LIMIT);
+  const maxSessions = parseIntegerInRange(
+    "AFFINE_MCP_HTTP_MAX_SESSIONS",
+    env.AFFINE_MCP_HTTP_MAX_SESSIONS,
+    DEFAULT_MAX_SESSIONS,
+    1,
+    10_000,
+  );
+  const sessionIdleTimeoutMs = parseIntegerInRange(
+    "AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS",
+    env.AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS,
+    DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+    100,
+    24 * 60 * 60 * 1000,
+  );
+  const shutdownTimeoutMs = parseIntegerInRange(
+    "AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS",
+    env.AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS,
+    DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    100,
+    2 * 60 * 1000,
+  );
+
+  return {
+    bodyLimitBytes,
+    maxSessions,
+    sessionIdleTimeoutMs,
+    sessionSweepIntervalMs: Math.max(
+      25,
+      Math.min(Math.floor(sessionIdleTimeoutMs / 4), 30_000),
+    ),
+    shutdownTimeoutMs,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,10 +144,6 @@ console.error(`[affine-mcp] HTTP auth mode: ${config.authMode}`);
 
 console.error(`[affine-mcp] Workspace: ${config.defaultWorkspaceId ? 'set' : '(none)'}`);
 
-for (const warning of toolFilter.warnings) {
-  console.error(`[affine-mcp] WARNING: ${warning}`);
-}
-
 if (config.authMode === "oauth" && !useHttpTransport) {
   throw new Error("AFFINE_MCP_AUTH_MODE=oauth requires MCP_TRANSPORT=http (or streamable/sse).");
 }
@@ -155,7 +151,6 @@ assertOAuthServiceWritePolicy({
   authMode: config.authMode,
   allowServiceWrites: config.oauthAllowServiceWrites,
   enabledWriteTools: toolFilter.enabledWriteTools,
-  toolFilterWarnings: toolFilter.warnings,
 });
 if (
   config.authMode === "oauth"

--- a/src/oauthServicePolicy.ts
+++ b/src/oauthServicePolicy.ts
@@ -13,14 +13,7 @@ export function assertOAuthServiceWritePolicy(input: {
   authMode: "bearer" | "oauth";
   allowServiceWrites: boolean;
   enabledWriteTools: readonly string[];
-  toolFilterWarnings?: readonly string[];
 }): void {
-  if (
-    input.authMode === "oauth"
-    && input.toolFilterWarnings?.some(warning => warning.startsWith("Unknown AFFINE_TOOL_PROFILE"))
-  ) {
-    throw new Error("OAuth mode refuses an unknown AFFINE_TOOL_PROFILE instead of falling back to full.");
-  }
   if (
     input.authMode === "oauth"
     && input.enabledWriteTools.length > 0

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -372,6 +372,7 @@ export async function startHttpMcpServer(
               `[affine-mcp] StreamableHTTP session initialized: ${sid}`,
             );
             registerSession(sid, transport, "streamable");
+            endSessionRequest = beginSessionRequest(sid, req.method);
           },
         });
         newTransport = transport;

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import type { Server as HttpServer } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -13,11 +15,79 @@ import {
   isLoopbackHostname,
   parseBooleanFlag,
 } from "./networkSecurity.js";
+import {
+  loadHttpRuntimeConfig,
+  type HttpRuntimeConfig,
+} from "./httpRuntimeConfig.js";
+
+type HttpTransport = StreamableHTTPServerTransport | SSEServerTransport;
+
+type TrackedSession = {
+  activeRequests: number;
+  kind: "streamable" | "legacy-sse";
+  lastActivityAt: number;
+  transport: HttpTransport;
+};
+
+export type HttpMcpServerHandle = {
+  close: (reason?: string) => Promise<void>;
+  host: string;
+  port: number;
+  sessionCount: () => number;
+};
+
+type BodyParserError = Error & {
+  status?: number;
+  type?: string;
+};
+
+function sendJsonRpcError(
+  res: Response,
+  status: number,
+  code: number,
+  message: string,
+) {
+  res.status(status).json({
+    jsonrpc: "2.0",
+    error: { code, message },
+    id: null,
+  });
+}
+
+async function listen(app: express.Express, port: number, host: string): Promise<HttpServer> {
+  return await new Promise<HttpServer>((resolve, reject) => {
+    const server = app.listen(port, host);
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve(server);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+  });
+}
+
+function closeHttpServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error && (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING") {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+    server.closeIdleConnections?.();
+  });
+}
 
 export async function startHttpMcpServer(
   createMcpServer: () => Promise<McpServer>,
   config: ServerConfig,
-) {
+): Promise<HttpMcpServerHandle> {
+  const runtimeConfig: HttpRuntimeConfig = loadHttpRuntimeConfig();
   const { host, port, authToken: httpAuthToken, allowedOrigins, allowAllOrigins } = config.http;
 
   // --- Bearer Token guard (AFFINE_MCP_HTTP_TOKEN) ---
@@ -71,10 +141,33 @@ export async function startHttpMcpServer(
   }
 
   // Use a plain Express app here so it can fully control JSON parser ordering/limits.
-  // `createMcpExpressApp()` installs its own JSON parser first, which can enforce
-  // a smaller default limit before the intended 50mb parser runs on /mcp.
+  // `createMcpExpressApp()` installs its own JSON parser before route-specific policy.
   const app = express();
-  const jsonBody = express.json({ limit: "50mb" });
+  const jsonBody = express.json({ limit: runtimeConfig.bodyLimitBytes });
+
+  const parseJsonBody = async (req: Request, res: Response): Promise<boolean> => {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        jsonBody(req, res, (error) => (error ? reject(error) : resolve()));
+      });
+      return true;
+    } catch (error) {
+      const parserError = error as BodyParserError;
+      if (parserError.status === 413 || parserError.type === "entity.too.large") {
+        sendJsonRpcError(res, 413, -32001, "Request body exceeds the configured HTTP body limit");
+        return false;
+      }
+      if (
+        parserError.status === 400 ||
+        parserError.type === "entity.parse.failed" ||
+        error instanceof SyntaxError
+      ) {
+        sendJsonRpcError(res, 400, -32700, "Parse error: Invalid JSON request body");
+        return false;
+      }
+      throw error;
+    }
+  };
 
   // --- CORS origin allowlist ---
   // AFFINE_MCP_HTTP_ALLOWED_ORIGINS: comma-separated list, e.g. "https://app.example.com,http://localhost:3000".
@@ -147,10 +240,86 @@ export async function startHttpMcpServer(
   app.options("/sse", corsMiddleware);
   app.options("/messages", corsMiddleware);
 
-  const transports: Record<
-    string,
-    StreamableHTTPServerTransport | SSEServerTransport
-  > = {};
+  const sessions = new Map<string, TrackedSession>();
+  let pendingSessionCount = 0;
+  let shutdownPromise: Promise<void> | null = null;
+  let idleSweepTimer: NodeJS.Timeout | undefined;
+
+  const hasSessionCapacity = () =>
+    sessions.size + pendingSessionCount < runtimeConfig.maxSessions;
+
+  const rejectUnavailable = (res: Response, message: string) => {
+    res.set("Retry-After", "1");
+    sendJsonRpcError(res, 503, -32002, message);
+  };
+
+  const reserveSessionSlot = (): (() => void) | null => {
+    if (!hasSessionCapacity()) return null;
+    pendingSessionCount += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      pendingSessionCount = Math.max(0, pendingSessionCount - 1);
+    };
+  };
+
+  const registerSession = (
+    sessionId: string,
+    transport: HttpTransport,
+    kind: TrackedSession["kind"],
+  ) => {
+    sessions.set(sessionId, {
+      activeRequests: 0,
+      kind,
+      lastActivityAt: Date.now(),
+      transport,
+    });
+  };
+
+  const removeSession = (sessionId: string, transport: HttpTransport) => {
+    const current = sessions.get(sessionId);
+    if (current?.transport === transport) sessions.delete(sessionId);
+  };
+
+  const beginSessionRequest = (sessionId: string, method: string) => {
+    const session = sessions.get(sessionId);
+    if (!session) return () => {};
+    session.lastActivityAt = Date.now();
+    const tracksInFlightWork = method !== "GET";
+    if (tracksInFlightWork) session.activeRequests += 1;
+
+    return () => {
+      const current = sessions.get(sessionId);
+      if (!current || current.transport !== session.transport) return;
+      if (tracksInFlightWork) {
+        current.activeRequests = Math.max(0, current.activeRequests - 1);
+      }
+      current.lastActivityAt = Date.now();
+    };
+  };
+
+  const closeSession = async (sessionId: string, reason: string) => {
+    const session = sessions.get(sessionId);
+    if (!session) return;
+    sessions.delete(sessionId);
+    console.error(`[affine-mcp] Closing ${session.kind} session ${sessionId}: ${reason}`);
+    try {
+      await session.transport.close();
+    } catch (error) {
+      console.error(`[affine-mcp] Failed to close session ${sessionId}:`, error);
+    }
+  };
+
+  const sweepIdleSessions = async () => {
+    const cutoff = Date.now() - runtimeConfig.sessionIdleTimeoutMs;
+    const expired = [...sessions.entries()]
+      .filter(([, session]) =>
+        session.activeRequests === 0 && session.lastActivityAt <= cutoff
+      )
+      .map(([sessionId]) => sessionId);
+    await Promise.all(expired.map((sessionId) => closeSession(sessionId, "idle timeout")));
+  };
 
   // ===========================================================================
   // STREAMABLE HTTP TRANSPORT — MCP protocol 2025-03-26
@@ -159,84 +328,98 @@ export async function startHttpMcpServer(
   // ===========================================================================
   app.all("/mcp", corsMiddleware, authMiddleware, async (req, res) => {
     console.error(`[affine-mcp] Received ${req.method} request to /mcp`);
+    let newTransport: StreamableHTTPServerTransport | undefined;
+    let releaseReservation: (() => void) | undefined;
+    let initializedSessionId: string | undefined;
+    let endSessionRequest: (() => void) | undefined;
     try {
+      if (shutdownPromise) {
+        rejectUnavailable(res, "Server is shutting down");
+        return;
+      }
+
       // mcp-session-id header can technically be string | string[]; normalise.
       const sidHeader = req.headers["mcp-session-id"];
       const sessionId = Array.isArray(sidHeader) ? sidHeader[0] : sidHeader;
 
       let transport: StreamableHTTPServerTransport;
-      const existing = sessionId ? transports[sessionId] : undefined;
+      const existing = sessionId ? sessions.get(sessionId) : undefined;
 
-      if (existing instanceof StreamableHTTPServerTransport) {
-        transport = existing;
+      if (existing?.transport instanceof StreamableHTTPServerTransport) {
+        transport = existing.transport;
+        endSessionRequest = beginSessionRequest(sessionId!, req.method);
       } else if (!sessionId && req.method === "POST") {
         // Parse body only for the initialize POST (lazy — avoids consuming the stream early).
-        await new Promise<void>((resolve, reject) => {
-          jsonBody(req, res, (err) => (err ? reject(err) : resolve()));
-        });
+        if (!(await parseJsonBody(req, res))) return;
 
         if (!isInitializeRequest(req.body)) {
-          res.status(400).json({
-            jsonrpc: "2.0",
-            error: {
-              code: -32000,
-              message: "Bad Request: Not an initialize request",
-            },
-            id: null,
-          });
+          sendJsonRpcError(res, 400, -32000, "Bad Request: Not an initialize request");
+          return;
+        }
+
+        releaseReservation = reserveSessionSlot() || undefined;
+        if (!releaseReservation) {
+          rejectUnavailable(res, "Server busy: maximum HTTP MCP session capacity reached");
           return;
         }
 
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           onsessioninitialized: (sid) => {
+            initializedSessionId = sid;
+            releaseReservation?.();
             console.error(
               `[affine-mcp] StreamableHTTP session initialized: ${sid}`,
             );
-            transports[sid] = transport;
+            registerSession(sid, transport, "streamable");
           },
         });
+        newTransport = transport;
 
         transport.onclose = () => {
           const sid = transport.sessionId;
-          if (sid && transports[sid]) {
+          if (sid && sessions.has(sid)) {
             console.error(`[affine-mcp] StreamableHTTP session closed: ${sid}`);
-            delete transports[sid];
+            removeSession(sid, transport);
           }
         };
 
-        const server = await createMcpServer();
-        await server.connect(transport);
+        const mcpServer = await createMcpServer();
+        await mcpServer.connect(transport);
       } else {
-        res.status(400).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message:
-              "Bad Request: No valid session ID or not an initialize request",
-          },
-          id: null,
-        });
+        sendJsonRpcError(
+          res,
+          400,
+          -32000,
+          "Bad Request: No valid session ID or not an initialize request",
+        );
         return;
       }
 
       // Ensure JSON body is available for subsequent POST requests within the session.
       if (req.method === "POST" && req.body === undefined) {
-        await new Promise<void>((resolve, reject) => {
-          jsonBody(req, res, (err) => (err ? reject(err) : resolve()));
-        });
+        if (!(await parseJsonBody(req, res))) return;
       }
 
       await transport.handleRequest(req, res, req.body);
+      if (newTransport && !initializedSessionId) {
+        releaseReservation?.();
+        await newTransport.close();
+      }
     } catch (e) {
+      releaseReservation?.();
+      if (newTransport && !initializedSessionId) {
+        try {
+          await newTransport.close();
+        } catch {}
+      }
       console.error("[affine-mcp] Error handling /mcp request:", e);
       if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: { code: -32603, message: "Internal server error" },
-          id: null,
-        });
+        sendJsonRpcError(res, 500, -32603, "Internal server error");
       }
+    } finally {
+      endSessionRequest?.();
+      releaseReservation?.();
     }
   });
 
@@ -247,23 +430,39 @@ export async function startHttpMcpServer(
   // @deprecated — SSEServerTransport is deprecated by the SDK; use /mcp for new clients.
   // ===========================================================================
   app.get("/sse", corsMiddleware, authMiddleware, async (req, res) => {
+    let transport: SSEServerTransport | undefined;
     try {
+      if (shutdownPromise) {
+        rejectUnavailable(res, "Server is shutting down");
+        return;
+      }
+      if (!hasSessionCapacity()) {
+        rejectUnavailable(res, "Server busy: maximum HTTP MCP session capacity reached");
+        return;
+      }
+
       // @ts-ignore — intentional: SSEServerTransport retained for backward compat only
-      const transport = new SSEServerTransport("/messages", res);
+      transport = new SSEServerTransport("/messages", res);
       const sessionId = transport.sessionId;
-      transports[sessionId] = transport;
+      registerSession(sessionId, transport, "legacy-sse");
 
       res.on("close", () => {
         console.error(`[affine-mcp] Legacy SSE session closed: ${sessionId}`);
-        delete transports[sessionId];
+        removeSession(sessionId, transport!);
       });
 
-      const server = await createMcpServer();
-      await server.connect(transport);
+      const mcpServer = await createMcpServer();
+      await mcpServer.connect(transport);
       console.error(
         `[affine-mcp] Legacy SSE session established: ${sessionId}`,
       );
     } catch (e) {
+      if (transport) {
+        removeSession(transport.sessionId, transport);
+        try {
+          await transport.close();
+        } catch {}
+      }
       console.error("[affine-mcp] Error establishing legacy SSE stream:", e);
       if (!res.headersSent)
         res.status(500).send("Error establishing SSE stream");
@@ -274,8 +473,13 @@ export async function startHttpMcpServer(
     "/messages",
     corsMiddleware,
     authMiddleware,
-    jsonBody,
     async (req, res) => {
+      if (shutdownPromise) {
+        rejectUnavailable(res, "Server is shutting down");
+        return;
+      }
+      if (!(await parseJsonBody(req, res))) return;
+
       const sessionId =
         typeof req.query.sessionId === "string"
           ? req.query.sessionId
@@ -285,65 +489,142 @@ export async function startHttpMcpServer(
         return;
       }
 
-      const transport = transports[sessionId];
-      if (!(transport instanceof SSEServerTransport)) {
-        res.status(400).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Bad Request: Session uses a different transport protocol",
-          },
-          id: null,
-        });
+      const session = sessions.get(sessionId);
+      if (!(session?.transport instanceof SSEServerTransport)) {
+        sendJsonRpcError(
+          res,
+          400,
+          -32000,
+          "Bad Request: Session uses a different transport protocol",
+        );
         return;
       }
+      const endSessionRequest = beginSessionRequest(sessionId, req.method);
 
       try {
         // @ts-ignore — intentional: SSEServerTransport retained for backward compat only
-        await transport.handlePostMessage(req, res, req.body);
+        await session.transport.handlePostMessage(req, res, req.body);
       } catch (e) {
         console.error("[affine-mcp] Error handling legacy SSE message:", e);
         if (!res.headersSent)
           res.status(500).send("Error handling POST message");
+      } finally {
+        endSessionRequest();
       }
     },
   );
 
-  const server = app.listen(port, host, () => {
-    const displayHostValue = host === "0.0.0.0" ? "localhost" : host;
-    const displayHost = displayHostValue.includes(":") ? `[${displayHostValue}]` : displayHostValue;
-    const address = server.address();
-    const listeningPort = typeof address === "object" && address ? address.port : port;
-    console.error(`[affine-mcp] MCP server listening on ${host}:${listeningPort}`);
-    console.error(
-      `[affine-mcp] Streamable HTTP (2025-03-26): http://${displayHost}:${listeningPort}/mcp`,
-    );
-    console.error(
-      `[affine-mcp] Legacy SSE     (2024-11-05): http://${displayHost}:${listeningPort}/sse`,
-    );
-    console.error(`[affine-mcp] Diagnostics: http://${displayHost}:${listeningPort}/healthz`);
-    console.error(`[affine-mcp] Readiness:   http://${displayHost}:${listeningPort}/readyz`);
-    if (authState.protectedResourceMetadataUrl) {
-      console.error(`[affine-mcp] Protected resource metadata: ${authState.protectedResourceMetadataUrl}`);
-    }
-  });
+  const server = await listen(app, port, host);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.closeAllConnections?.();
+    throw new Error("HTTP MCP server did not expose a TCP listening address");
+  }
+  const boundPort = address.port;
+  const displayHost = host === "0.0.0.0"
+    ? "localhost"
+    : host.includes(":") && !host.startsWith("[")
+      ? `[${host}]`
+      : host;
 
-  // Graceful shutdown: stop accepting new connections, then close active transports.
-  const shutdown = async (signal: string) => {
-    console.error(`[affine-mcp] ${signal} received - shutting down gracefully`);
-    server.close(() => {
-      void (async () => {
-        for (const sessionId in transports) {
-          try {
-            await transports[sessionId].close();
-          } catch {}
-          delete transports[sessionId];
-        }
-        process.exit(0);
-      })();
+  console.error(`[affine-mcp] MCP server listening on ${host}:${boundPort}`);
+  console.error(
+    `[affine-mcp] Streamable HTTP (2025-03-26): http://${displayHost}:${boundPort}/mcp`,
+  );
+  console.error(
+    `[affine-mcp] Legacy SSE     (2024-11-05): http://${displayHost}:${boundPort}/sse`,
+  );
+  console.error(`[affine-mcp] Diagnostics: http://${displayHost}:${boundPort}/healthz`);
+  console.error(`[affine-mcp] Readiness:   http://${displayHost}:${boundPort}/readyz`);
+  console.error(
+    `[affine-mcp] HTTP runtime limits: body=${runtimeConfig.bodyLimitBytes} bytes, ` +
+      `sessions=${runtimeConfig.maxSessions}, idle=${runtimeConfig.sessionIdleTimeoutMs}ms, ` +
+      `shutdown=${runtimeConfig.shutdownTimeoutMs}ms`,
+  );
+  if (authState.protectedResourceMetadataUrl) {
+    console.error(`[affine-mcp] Protected resource metadata: ${authState.protectedResourceMetadataUrl}`);
+  }
+
+  idleSweepTimer = setInterval(() => {
+    void sweepIdleSessions().catch((error) => {
+      console.error("[affine-mcp] Idle session cleanup failed:", error);
     });
+  }, runtimeConfig.sessionSweepIntervalMs);
+  idleSweepTimer.unref();
+
+  let sigintHandler: (() => void) | undefined;
+  let sigtermHandler: (() => void) | undefined;
+
+  const removeSignalHandlers = () => {
+    if (sigintHandler) process.off("SIGINT", sigintHandler);
+    if (sigtermHandler) process.off("SIGTERM", sigtermHandler);
   };
 
-  process.on("SIGINT", () => void shutdown("SIGINT"));
-  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  const performShutdown = async (reason: string) => {
+    console.error(`[affine-mcp] ${reason} received - shutting down gracefully`);
+    if (idleSweepTimer) {
+      clearInterval(idleSweepTimer);
+      idleSweepTimer = undefined;
+    }
+    pendingSessionCount = 0;
+
+    const closeSessionsPromise = Promise.all(
+      [...sessions.keys()].map((sessionId) => closeSession(sessionId, "server shutdown")),
+    ).then(() => undefined);
+    const closeServerPromise = closeHttpServer(server);
+    const gracefulClose = Promise.all([closeSessionsPromise, closeServerPromise]).then(() => undefined);
+
+    const outcome = await Promise.race([
+      gracefulClose.then(
+        () => ({ completed: true as const }),
+        (error) => ({ completed: true as const, error }),
+      ),
+      delay(runtimeConfig.shutdownTimeoutMs, undefined, { ref: false }).then(
+        () => ({ completed: false as const }),
+      ),
+    ]);
+
+    if (!outcome.completed) {
+      console.error(
+        `[affine-mcp] Graceful shutdown exceeded ${runtimeConfig.shutdownTimeoutMs}ms; forcing remaining HTTP connections closed`,
+      );
+      server.closeAllConnections?.();
+      void gracefulClose.catch((error) => {
+        console.error("[affine-mcp] Shutdown cleanup failed after the deadline:", error);
+      });
+      await delay(25);
+      return;
+    }
+    if ("error" in outcome) throw outcome.error;
+  };
+
+  const shutdown = (reason = "Manual shutdown"): Promise<void> => {
+    if (!shutdownPromise) {
+      shutdownPromise = performShutdown(reason).finally(removeSignalHandlers);
+    }
+    return shutdownPromise;
+  };
+
+  const handleSignal = (signal: "SIGINT" | "SIGTERM") => {
+    void shutdown(signal)
+      .then(() => {
+        process.exitCode = 0;
+      })
+      .catch((error) => {
+        console.error("[affine-mcp] Graceful shutdown failed:", error);
+        server.closeAllConnections?.();
+        process.exitCode = 1;
+      });
+  };
+  sigintHandler = () => handleSignal("SIGINT");
+  sigtermHandler = () => handleSignal("SIGTERM");
+  process.on("SIGINT", sigintHandler);
+  process.on("SIGTERM", sigtermHandler);
+
+  return {
+    close: shutdown,
+    host,
+    port: boundPort,
+    sessionCount: () => sessions.size,
+  };
 }

--- a/tests/test-http-runtime-safety.mjs
+++ b/tests/test-http-runtime-safety.mjs
@@ -346,13 +346,22 @@ async function testIdempotentProgrammaticClose() {
   try {
     const handle = await startHttpMcpServer(
       async () => new McpServer({ name: "runtime-close-test", version: "1.0.0" }),
-      0,
       {
         baseUrl: "http://127.0.0.1:3010",
+        graphqlEndpoint: "http://127.0.0.1:3010/graphql",
         graphqlPath: "/graphql",
         authMode: "bearer",
         oauthScopes: ["mcp"],
         oauthClockSkewSeconds: 60,
+        transportMode: "http",
+        loginAtStart: "async",
+        http: {
+          host: "127.0.0.1",
+          port: 0,
+          allowedOrigins: [],
+          allowAllOrigins: false,
+        },
+        oauthAllowServiceWrites: false,
       },
     );
     const first = handle.close("Test shutdown");

--- a/tests/test-http-runtime-safety.mjs
+++ b/tests/test-http-runtime-safety.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { connect as connectTcp } from "node:net";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  loadHttpRuntimeConfig,
+  parseBodyLimit,
+} from "../src/httpRuntimeConfig.ts";
+import { startHttpMcpServer } from "../src/sse.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = path.resolve(__dirname, "..");
+const SERVER_PATH = path.join(PROJECT_DIR, "dist", "index.js");
+const RUNTIME_ENV_KEYS = [
+  "AFFINE_MCP_HTTP_BODY_LIMIT",
+  "AFFINE_MCP_HTTP_MAX_SESSIONS",
+  "AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS",
+  "AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS",
+];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertThrows(fn, expectedMessage, message) {
+  try {
+    fn();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    assert(detail.includes(expectedMessage), `${message}: unexpected error: ${detail}`);
+    return;
+  }
+  throw new Error(`${message}: expected an error`);
+}
+
+async function findFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function serverEnvironment(port, overrides = {}) {
+  const env = { ...process.env };
+  for (const key of RUNTIME_ENV_KEYS) delete env[key];
+  delete env.AFFINE_MCP_HTTP_TOKEN;
+  return {
+    ...env,
+    MCP_TRANSPORT: "http",
+    PORT: String(port),
+    AFFINE_BASE_URL: "http://127.0.0.1:3010",
+    AFFINE_API_TOKEN: "test-affine-api-token",
+    AFFINE_MCP_AUTH_MODE: "bearer",
+    AFFINE_MCP_HTTP_HOST: "127.0.0.1",
+    XDG_CONFIG_HOME: `/tmp/affine-mcp-http-runtime-${process.pid}-${port}`,
+    ...overrides,
+  };
+}
+
+function spawnServer(port, overrides = {}) {
+  const child = spawn("node", [SERVER_PATH], {
+    cwd: PROJECT_DIR,
+    env: serverEnvironment(port, overrides),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  return { child, logs: () => ({ stdout, stderr }) };
+}
+
+async function waitForHealth(child, url, logs, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Server exited before becoming healthy: ${JSON.stringify(logs())}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      await response.body?.cancel();
+    } catch {
+      // Retry until the startup deadline.
+    }
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(logs())}`);
+}
+
+async function waitForExit(child, timeoutMs = 4_000) {
+  if (child.exitCode !== null) return { code: child.exitCode, signal: child.signalCode };
+  return await Promise.race([
+    new Promise((resolve) => child.once("exit", (code, signal) => resolve({ code, signal }))),
+    delay(timeoutMs).then(() => null),
+  ]);
+}
+
+async function stopServer(child) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const result = await waitForExit(child);
+  if (!result) {
+    child.kill("SIGKILL");
+    await waitForExit(child);
+    throw new Error("HTTP server did not stop after SIGTERM");
+  }
+  assertEqual(result.code, 0, "HTTP server shutdown exit code");
+}
+
+async function startHealthyServer(overrides = {}) {
+  const port = await findFreePort();
+  const spawned = spawnServer(port, overrides);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  try {
+    await waitForHealth(spawned.child, `${baseUrl}/healthz`, spawned.logs);
+  } catch (error) {
+    if (spawned.child.exitCode === null) spawned.child.kill("SIGKILL");
+    throw error;
+  }
+  return { ...spawned, baseUrl, port, close: () => stopServer(spawned.child) };
+}
+
+async function expectStartupFailure(overrides, expectedMessage, port) {
+  const targetPort = port ?? await findFreePort();
+  const spawned = spawnServer(targetPort, overrides);
+  const result = await waitForExit(spawned.child, 5_000);
+  if (!result) {
+    spawned.child.kill("SIGKILL");
+    await waitForExit(spawned.child);
+    throw new Error(`Expected startup failure but server stayed running: ${JSON.stringify(spawned.logs())}`);
+  }
+  assertEqual(result.code, 1, "startup failure exit code");
+  assert(spawned.logs().stderr.includes(expectedMessage), `missing startup error: ${spawned.logs().stderr}`);
+}
+
+async function readJson(response) {
+  const body = await response.text();
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error(`Expected JSON response, got ${response.status}: ${body}`);
+  }
+}
+
+function initializeBody(id) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "http-runtime-test", version: "1.0.0" },
+    },
+  };
+}
+
+async function postMcp(baseUrl, body, sessionId) {
+  const headers = {
+    Accept: "application/json, text/event-stream",
+    "Content-Type": "application/json",
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return await fetch(`${baseUrl}/mcp`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function initializeSession(baseUrl, id) {
+  const response = await postMcp(baseUrl, initializeBody(id));
+  const responseBody = await response.text();
+  assertEqual(response.status, 200, `initialize session ${id}: ${responseBody}`);
+  const sessionId = response.headers.get("mcp-session-id");
+  assert(sessionId, `initialize session ${id} did not return mcp-session-id`);
+  return sessionId;
+}
+
+async function testRuntimeConfig() {
+  assertEqual(parseBodyLimit(undefined), 4 * 1024 * 1024, "default body limit");
+  assertEqual(parseBodyLimit("1kb"), 1024, "kilobyte body limit");
+  assertEqual(parseBodyLimit("1.5mb"), 1.5 * 1024 * 1024, "fractional megabyte body limit");
+  assertThrows(() => parseBodyLimit("512b"), "between 1kb and 64mb", "too-small body limit");
+  assertThrows(() => parseBodyLimit("1gb"), "must be a byte size", "unsupported body limit unit");
+
+  const parsed = loadHttpRuntimeConfig({
+    AFFINE_MCP_HTTP_BODY_LIMIT: "2kb",
+    AFFINE_MCP_HTTP_MAX_SESSIONS: "1",
+    AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS: "600",
+    AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS: "100",
+  });
+  assertEqual(parsed.bodyLimitBytes, 2048, "configured body limit");
+  assertEqual(parsed.maxSessions, 1, "configured session limit");
+  assertEqual(parsed.sessionIdleTimeoutMs, 600, "configured idle timeout");
+  assertEqual(parsed.shutdownTimeoutMs, 100, "configured shutdown timeout");
+  assertThrows(
+    () => loadHttpRuntimeConfig({ AFFINE_MCP_HTTP_MAX_SESSIONS: "0" }),
+    "must be an integer between 1 and 10000",
+    "invalid max sessions",
+  );
+}
+
+async function testStartupErrors() {
+  await expectStartupFailure(
+    { AFFINE_MCP_HTTP_MAX_SESSIONS: "0" },
+    "AFFINE_MCP_HTTP_MAX_SESSIONS must be an integer",
+  );
+
+  const occupied = createServer();
+  await new Promise((resolve, reject) => {
+    occupied.once("error", reject);
+    occupied.listen(0, "127.0.0.1", resolve);
+  });
+  const address = occupied.address();
+  try {
+    await expectStartupFailure({}, "EADDRINUSE", address.port);
+  } finally {
+    await new Promise((resolve) => occupied.close(resolve));
+  }
+}
+
+async function testBodyLimitErrors() {
+  const server = await startHealthyServer({ AFFINE_MCP_HTTP_BODY_LIMIT: "1kb" });
+  try {
+    const oversized = await fetch(`${server.baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ payload: "x".repeat(2_048) }),
+    });
+    assertEqual(oversized.status, 413, "oversized JSON status");
+    const oversizedBody = await readJson(oversized);
+    assertEqual(oversizedBody.error?.code, -32001, "oversized JSON error code");
+
+    const malformed = await fetch(`${server.baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{\"broken\":",
+    });
+    assertEqual(malformed.status, 400, "malformed JSON status");
+    const malformedBody = await readJson(malformed);
+    assertEqual(malformedBody.error?.code, -32700, "malformed JSON error code");
+  } finally {
+    await server.close();
+  }
+}
+
+async function testSessionCapacityActivityAndIdleCleanup() {
+  const server = await startHealthyServer({
+    AFFINE_MCP_HTTP_MAX_SESSIONS: "1",
+    AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS: "600",
+  });
+  try {
+    const firstSessionId = await initializeSession(server.baseUrl, 1);
+
+    const full = await postMcp(server.baseUrl, initializeBody(2));
+    assertEqual(full.status, 503, "session capacity status");
+    assertEqual((await readJson(full)).error?.code, -32002, "session capacity error code");
+
+    await delay(400);
+    const activity = await postMcp(
+      server.baseUrl,
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      firstSessionId,
+    );
+    assert([200, 202, 204].includes(activity.status), `session activity status: ${activity.status}`);
+    await activity.body?.cancel();
+
+    await delay(400);
+    const stillFull = await postMcp(server.baseUrl, initializeBody(3));
+    assertEqual(stillFull.status, 503, "session activity refreshes idle deadline");
+    await stillFull.body?.cancel();
+
+    await delay(500);
+    await initializeSession(server.baseUrl, 4);
+    assert(server.logs().stderr.includes("idle timeout"), "idle cleanup should be logged");
+  } finally {
+    await server.close();
+  }
+}
+
+async function testShutdownWithActiveSession() {
+  const server = await startHealthyServer({
+    AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS: "60000",
+    AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS: "1000",
+  });
+  await initializeSession(server.baseUrl, 10);
+
+  const startedAt = Date.now();
+  server.child.kill("SIGTERM");
+  const result = await waitForExit(server.child, 2_000);
+  assert(result, `server did not exit: ${JSON.stringify(server.logs())}`);
+  assertEqual(result.code, 0, "active-session shutdown exit code");
+  assert(Date.now() - startedAt < 1_500, "active-session shutdown exceeded deadline");
+  assert(!server.logs().stderr.includes("forcing remaining"), "transport close should unblock HTTP close");
+}
+
+async function testForcedConnectionDeadline() {
+  const server = await startHealthyServer({
+    AFFINE_MCP_HTTP_SHUTDOWN_TIMEOUT_MS: "100",
+  });
+  const socket = connectTcp(server.port, "127.0.0.1");
+  await new Promise((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  socket.write(
+    "POST /mcp HTTP/1.1\r\n" +
+      `Host: 127.0.0.1:${server.port}\r\n` +
+      "Content-Type: application/json\r\n" +
+      "Content-Length: 100000\r\n\r\n{",
+  );
+
+  server.child.kill("SIGTERM");
+  const result = await waitForExit(server.child, 2_000);
+  socket.destroy();
+  assert(result, `server did not force-close incomplete connection: ${JSON.stringify(server.logs())}`);
+  assertEqual(result.code, 0, "forced shutdown exit code");
+  assert(server.logs().stderr.includes("forcing remaining HTTP connections closed"), "forced close should be logged");
+}
+
+async function testIdempotentProgrammaticClose() {
+  const previousHost = process.env.AFFINE_MCP_HTTP_HOST;
+  process.env.AFFINE_MCP_HTTP_HOST = "127.0.0.1";
+  try {
+    const handle = await startHttpMcpServer(
+      async () => new McpServer({ name: "runtime-close-test", version: "1.0.0" }),
+      0,
+      {
+        baseUrl: "http://127.0.0.1:3010",
+        graphqlPath: "/graphql",
+        authMode: "bearer",
+        oauthScopes: ["mcp"],
+        oauthClockSkewSeconds: 60,
+      },
+    );
+    const first = handle.close("Test shutdown");
+    const second = handle.close("Duplicate shutdown");
+    assert(first === second, "programmatic close should return the same promise");
+    await Promise.all([first, second]);
+  } finally {
+    if (previousHost === undefined) delete process.env.AFFINE_MCP_HTTP_HOST;
+    else process.env.AFFINE_MCP_HTTP_HOST = previousHost;
+  }
+}
+
+async function main() {
+  assert(existsSync(SERVER_PATH), "dist/index.js is missing; run npm run build first");
+  await testRuntimeConfig();
+  await testStartupErrors();
+  await testBodyLimitErrors();
+  await testSessionCapacityActivityAndIdleCleanup();
+  await testShutdownWithActiveSession();
+  await testForcedConnectionDeadline();
+  await testIdempotentProgrammaticClose();
+  console.log("HTTP runtime safety regression tests passed.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-http-runtime-safety.mjs
+++ b/tests/test-http-runtime-safety.mjs
@@ -340,6 +340,61 @@ async function testForcedConnectionDeadline() {
   assert(server.logs().stderr.includes("forcing remaining HTTP connections closed"), "forced close should be logged");
 }
 
+async function testInitializeRequestSurvivesIdleSweep() {
+  const previousIdleTimeout = process.env.AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS;
+  process.env.AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS = "100";
+  let releaseRequest;
+  const requestGate = new Promise((resolve) => {
+    releaseRequest = resolve;
+  });
+  let handle;
+  try {
+    handle = await startHttpMcpServer(
+      async () => {
+        const server = new McpServer({ name: "runtime-idle-test", version: "1.0.0" });
+        const connect = server.connect.bind(server);
+        server.connect = async (transport) => {
+          await connect(transport);
+          const handleRequest = transport.handleRequest.bind(transport);
+          transport.handleRequest = async (...args) => {
+            await handleRequest(...args);
+            await requestGate;
+          };
+        };
+        return server;
+      },
+      {
+        baseUrl: "http://127.0.0.1:3010",
+        graphqlEndpoint: "http://127.0.0.1:3010/graphql",
+        graphqlPath: "/graphql",
+        authMode: "bearer",
+        oauthScopes: ["mcp"],
+        oauthClockSkewSeconds: 60,
+        transportMode: "http",
+        loginAtStart: "async",
+        http: {
+          host: "127.0.0.1",
+          port: 0,
+          allowedOrigins: [],
+          allowAllOrigins: false,
+        },
+        oauthAllowServiceWrites: false,
+      },
+    );
+
+    const response = await postMcp(`http://127.0.0.1:${handle.port}`, initializeBody(20));
+    assertEqual(response.status, 200, "delayed initialize response status");
+    await response.body?.cancel();
+    await delay(150);
+    assertEqual(handle.sessionCount(), 1, "initialize request remains active during idle sweep");
+  } finally {
+    releaseRequest?.();
+    await handle?.close("Idle sweep test shutdown");
+    if (previousIdleTimeout === undefined) delete process.env.AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS;
+    else process.env.AFFINE_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS = previousIdleTimeout;
+  }
+}
+
 async function testIdempotentProgrammaticClose() {
   const previousHost = process.env.AFFINE_MCP_HTTP_HOST;
   process.env.AFFINE_MCP_HTTP_HOST = "127.0.0.1";
@@ -382,6 +437,7 @@ async function main() {
   await testSessionCapacityActivityAndIdleCleanup();
   await testShutdownWithActiveSession();
   await testForcedConnectionDeadline();
+  await testInitializeRequestSurvivesIdleSweep();
   await testIdempotentProgrammaticClose();
   console.log("HTTP runtime safety regression tests passed.");
 }

--- a/tests/test-http-security.mjs
+++ b/tests/test-http-security.mjs
@@ -331,7 +331,10 @@ async function testBearerTokenPolicy() {
     assertEqual(health.status, 200, "protected server health remains unauthenticated");
     assertEqual((await readJson(health)).protected, true, "protected server health metadata");
     const readiness = await fetch(`${server.baseUrl}/readyz`);
-    assertEqual(readiness.status, 200, "protected server readiness remains unauthenticated");
+    assertEqual(readiness.status, 503, "protected server readiness bypasses authentication");
+    const readinessBody = await readJson(readiness);
+    assertEqual(readinessBody.status, "not_ready", "unavailable upstream readiness status");
+    assertEqual(readinessBody.component, "affine-graphql", "unavailable readiness component");
 
     const missing = await fetch(`${server.baseUrl}/mcp`);
     assertEqual(missing.status, 401, "missing bearer token");

--- a/tests/test-live-test-safety.mjs
+++ b/tests/test-live-test-safety.mjs
@@ -99,7 +99,7 @@ assert.throws(
 );
 
 const mutationPattern = /\b(create_workspace|delete_workspace|create_doc|delete_doc|generate_access_token|append_block|update_profile|ensureAdminUser)\b/;
-const staticOnlyFiles = new Set(['test-tool-filtering.mjs']);
+const staticOnlyFiles = new Set(['test-tool-filtering.mjs', 'test-oauth-service-policy.mjs']);
 const liveTestFiles = fs.readdirSync(testDirectory)
   .filter(name => name.endsWith('.mjs'))
   .filter(name => !staticOnlyFiles.has(name))

--- a/tests/test-oauth-service-policy.mjs
+++ b/tests/test-oauth-service-policy.mjs
@@ -65,17 +65,11 @@ assert.doesNotThrow(() => assertOAuthServiceWritePolicy({
   enabledWriteTools: explicitlyRestrictedFullFilter.enabledWriteTools,
 }));
 
-const invalidProfileFilter = createToolFilter(
-  createToolFilterEnvironment("oauth", { AFFINE_TOOL_PROFILE: "readonly" }),
-);
 assert.throws(
-  () => assertOAuthServiceWritePolicy({
-    authMode: "oauth",
-    allowServiceWrites: true,
-    enabledWriteTools: invalidProfileFilter.enabledWriteTools,
-    toolFilterWarnings: invalidProfileFilter.warnings,
-  }),
-  /refuses an unknown AFFINE_TOOL_PROFILE/,
+  () => createToolFilter(
+    createToolFilterEnvironment("oauth", { AFFINE_TOOL_PROFILE: "readonly" }),
+  ),
+  /Unknown AFFINE_TOOL_PROFILE "readonly"/,
 );
 
 const inputEnvironment = { AFFINE_DISABLED_TOOLS: "delete_doc" };
@@ -114,6 +108,6 @@ const invalidBooleanProcess = spawnSync(process.execPath, ["dist/index.js"], {
   timeout: 5_000,
 });
 assert.equal(invalidBooleanProcess.status, 1);
-assert.match(invalidBooleanProcess.stderr, /must be "true" or "false"/);
+assert.match(invalidBooleanProcess.stderr, /must be ['"]true['"] or ['"]false['"]/);
 
 console.log("OAuth service-account policy tests passed");


### PR DESCRIPTION
# TL;DR
- Bound HTTP sessions and request bodies and guarantee deterministic server shutdown.

# Context
- Unbounded session growth, oversized bodies, listen races, and incomplete shutdown could exhaust or hang a hosted server.
- Rebase after HTTP security and configuration changes during integration.

# Changes
- Added body, session-count, idle-time, and shutdown-deadline limits.
- Reserved capacity across Streamable HTTP and SSE sessions and returned correct failure statuses.
- Made listen errors, ephemeral ports, and concurrent shutdown deterministic.
- Added self-contained runtime stress/regression coverage; local CI passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable HTTP body-size, session-capacity, idle-timeout, and shutdown-timeout limits.
  - Added improved graceful shutdown with forced connection closure after the configured deadline.
- **Bug Fixes**
  - Oversized or malformed JSON requests now return consistent JSON-RPC errors.
  - Readiness endpoint behavior is better validated under bearer-token authentication.
- **Documentation**
  - Expanded deployment guidance and runtime-limit configuration details.
- **Tests**
  - Added HTTP runtime safety regression coverage and integrated it into CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->