### PR TITLE
fix: share authentication state across sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,8 @@ jobs:
       - name: Test configuration consistency
         run: npm run test:config-consistency
 
+      - name: Verify authentication session state
+        run: npm run test:auth-session
+
       - name: Check package contents
         run: npm run pack:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed CLI requests that always used `/graphql`, custom GraphQL paths becoming unintended Socket.IO namespaces, environment-only credentials that `status` ignored, and missing config-file values for custom headers and HTTP runtime settings.
 - Corrected documented defaults for the AFFiNE base URL, HTTP bind host, transport aliases, and browser origin policy.
 - Quoted Codex snippet environment arguments safely for POSIX shells and removed saved `Authorization`/`Cookie` headers during logout without deleting unrelated headers or runtime settings.
+- Email/password authentication is now process-scoped and single-flight across concurrent HTTP MCP sessions, and backend requests wait for the shared result instead of falling back to anonymous access.
+- Bearer, cookie, custom-header, and email/password credentials now follow one exclusive priority order across GraphQL, multipart, and WebSocket consumers.
+- Failed asynchronous login state is shared by every consumer while an explicit later `sign_in` can safely establish a new cookie session.
 
 ### Tests
 - Added a source-wide regression guard that rejects `Math.random` in runtime TypeScript and validates identifier alphabets, lengths, uniqueness, seed ranges, and invalid generator inputs.
 - Added self-contained CI coverage for destructive-target validation, remote confirmation, URL normalization, and unique test resource naming.
 - Added self-contained regression coverage for config precedence, custom GraphQL paths, environment-only diagnostics, HTTP runtime flags, CORS, and upstream-aware readiness.
+- Added a self-contained mock AFFiNE regression suite for concurrent authentication, async request gating, credential exclusivity, failure propagation, and explicit recovery.
 
 ## [2.5.0] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ For common failures, see:
 
 - Never commit secrets or long-lived tokens
 - Prefer API tokens over cookies or passwords in production
+- Email/password HTTP sessions share one login and never fall back to anonymous backend requests after authentication failure
 - Use HTTPS for non-local deployments
 - Rotate access tokens regularly
 - Restrict exposed tools with `AFFINE_DISABLED_GROUPS` and `AFFINE_DISABLED_TOOLS` for least-privilege setups

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -18,6 +18,16 @@ Auth priority within the active configuration:
 2. `AFFINE_COOKIE`
 3. `AFFINE_EMAIL` and `AFFINE_PASSWORD`
 
+Email/password authentication is process-scoped. Concurrent HTTP MCP sessions
+share one sign-in attempt and the resulting cookie. In the default `async`
+mode, transport startup is not blocked, but the first backend operation waits
+for authentication to finish. A failed login is returned to every waiting
+operation and is never retried as an unauthenticated request.
+
+Bearer and cookie credentials are mutually exclusive on outbound requests.
+Explicit `sign_in` replaces the current client credential with its session
+cookie, while setting a bearer credential removes any cookie header.
+
 ## Environment variables
 
 ### Core configuration
@@ -28,7 +38,7 @@ Auth priority within the active configuration:
 | `AFFINE_GRAPHQL_PATH` | No | `/graphql` | Override only if your AFFiNE deployment uses a custom GraphQL path |
 | `AFFINE_HEADERS_JSON` | No | none | JSON object of additional string headers sent to AFFiNE; built-in token/cookie auth takes priority |
 | `AFFINE_WORKSPACE_ID` | No | Auto-detected when possible | Pins the active workspace |
-| `AFFINE_LOGIN_AT_START` | No | `async` | Set to `sync` only when you must block startup on email/password login |
+| `AFFINE_LOGIN_AT_START` | No | `async` | `async` starts one shared login without blocking transport startup; `sync` requires login before startup |
 
 ### Authentication
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:data-view-ui": "npx playwright test tests/playwright/verify-data-view.pw.ts --config tests/playwright/playwright.config.ts",
     "test:bearer": "node tests/test-bearer-auth.mjs",
     "test:http-email-password": "node tests/test-http-email-password.mjs",
+    "test:auth-session": "tsx tests/test-auth-session.mjs",
     "test:http-bearer": "node tests/test-http-bearer.mjs",
     "test:oauth-http": "node tests/test-oauth-http.mjs",
     "test:organize": "node tests/test-organize-tools.mjs",
@@ -77,7 +78,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run pack:check",
+    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/src/authSession.ts
+++ b/src/authSession.ts
@@ -1,0 +1,108 @@
+import { loginWithPassword } from "./auth.js";
+
+export type AuthSnapshot =
+  | { kind: "none" }
+  | { kind: "bearer"; token: string }
+  | { kind: "cookie"; cookie: string };
+
+export type LoginMode = "async" | "sync";
+
+type LoginFunction = typeof loginWithPassword;
+
+type AuthSessionOptions = {
+  baseUrl: string;
+  bearer?: string;
+  cookie?: string;
+  email?: string;
+  password?: string;
+  login?: LoginFunction;
+};
+
+export function parseLoginMode(raw: string | undefined): LoginMode {
+  if (raw === undefined || raw.trim() === "") return "async";
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "async" || normalized === "sync") return normalized;
+  throw new Error(`AFFINE_LOGIN_AT_START must be "async" or "sync". Received: ${raw}`);
+}
+
+/** Process-scoped authentication state shared by every MCP transport session. */
+export class AuthSession {
+  private readonly baseUrl: string;
+  private readonly login: LoginFunction;
+  private email?: string;
+  private password?: string;
+  private immediate: AuthSnapshot;
+  private pending?: Promise<AuthSnapshot>;
+
+  constructor(options: AuthSessionOptions) {
+    const hasImmediateAuth = Boolean(options.bearer || options.cookie);
+    if (!hasImmediateAuth && Boolean(options.email) !== Boolean(options.password)) {
+      throw new Error("AFFINE_EMAIL and AFFINE_PASSWORD must be configured together.");
+    }
+
+    this.baseUrl = options.baseUrl;
+    this.login = options.login || loginWithPassword;
+    this.email = hasImmediateAuth ? undefined : options.email;
+    this.password = hasImmediateAuth ? undefined : options.password;
+
+    if (options.bearer) {
+      this.immediate = { kind: "bearer", token: options.bearer };
+    } else if (options.cookie) {
+      this.immediate = { kind: "cookie", cookie: options.cookie };
+    } else {
+      this.immediate = { kind: "none" };
+    }
+  }
+
+  get hasConfiguredAuth(): boolean {
+    return this.immediate.kind !== "none" || this.requiresLogin;
+  }
+
+  get requiresLogin(): boolean {
+    return this.immediate.kind === "none" && Boolean(this.pending || (this.email && this.password));
+  }
+
+  get source(): "bearer" | "cookie" | "email-password" | "none" {
+    if (this.immediate.kind === "bearer") return "bearer";
+    if (this.immediate.kind === "cookie") return "cookie";
+    return this.requiresLogin ? "email-password" : "none";
+  }
+
+  /** Begin authentication without delaying transport startup. */
+  start(): void {
+    void this.ready().catch(() => {
+      // The shared promise remains rejected so every backend consumer receives the failure.
+    });
+  }
+
+  /** Resolve the single shared authentication attempt. Rejections are never downgraded to anonymous access. */
+  ready(): Promise<AuthSnapshot> {
+    if (this.pending) return this.pending;
+    if (this.immediate.kind !== "none" || !this.requiresLogin) {
+      return Promise.resolve(this.immediate);
+    }
+
+    const email = this.email!;
+    const password = this.password!;
+    this.email = undefined;
+    this.password = undefined;
+    console.error("[affine-mcp] Authenticating with email/password...");
+
+    this.pending = Promise.resolve()
+      .then(() => this.login(this.baseUrl, email, password))
+      .then(({ cookieHeader }) => {
+        this.immediate = { kind: "cookie", cookie: cookieHeader };
+        console.error("[affine-mcp] Email/password authentication succeeded");
+        return this.immediate;
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[affine-mcp] Email/password authentication failed: ${message}`);
+        throw new Error(`Email/password authentication failed: ${message}`, { cause: error });
+      });
+
+    // Attach a handler immediately so an asynchronously started login cannot emit an unhandled rejection.
+    void this.pending.catch(() => {});
+    return this.pending;
+  }
+}

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -1,7 +1,76 @@
 import { fetch } from "undici";
+
+import type { AuthSnapshot } from "./authSession.js";
 import { VERSION } from "./config.js";
 
 const GQL_FETCH_TIMEOUT_MS = 30_000;
+
+export type ConnectionAuth = {
+  bearer: string;
+  cookie: string;
+  endpoint: string;
+  headers: Record<string, string>;
+};
+
+type GraphQLClientOptions = {
+  authProvider?: () => Promise<AuthSnapshot>;
+  bearer?: string;
+  endpoint: string;
+  headers?: Record<string, string>;
+};
+
+function isAuthenticationHeader(name: string): boolean {
+  return /^(authorization|cookie)$/i.test(name);
+}
+
+function findHeader(headers: Record<string, string>, name: string): string | undefined {
+  let found: string | undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === name.toLowerCase()) found = value;
+  }
+  return found;
+}
+
+function withoutAuthenticationHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !isAuthenticationHeader(name)),
+  );
+}
+
+function bearerFromHeader(value: string): string {
+  if (/[\r\n]/.test(value)) {
+    throw new Error("Authorization header contains illegal CR/LF characters");
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(value);
+  if (!match) throw new Error("Authorization header must use the Bearer scheme");
+  return match[1];
+}
+
+function validateAuthSnapshot(snapshot: AuthSnapshot): AuthSnapshot {
+  if (snapshot.kind === "bearer") {
+    if (/[\r\n]/.test(snapshot.token)) {
+      throw new Error("Bearer token contains illegal CR/LF characters");
+    }
+    if (!snapshot.token.trim()) throw new Error("Bearer token must not be empty");
+  }
+  if (snapshot.kind === "cookie") {
+    if (/[\r\n]/.test(snapshot.cookie)) {
+      throw new Error("Cookie header contains illegal CR/LF characters");
+    }
+    if (!snapshot.cookie.trim()) throw new Error("Cookie header must not be empty");
+  }
+  return snapshot;
+}
+
+function authHeaders(snapshot: AuthSnapshot): Record<string, string> {
+  if (snapshot.kind === "bearer") {
+    return { Authorization: `Bearer ${snapshot.token}` };
+  }
+  if (snapshot.kind === "cookie") {
+    return { Cookie: snapshot.cookie };
+  }
+  return {};
+}
 
 /** Strip HTML tags and truncate to a safe length for error messages. */
 function sanitizeErrorBody(s: string, max = 200): string {
@@ -10,66 +79,111 @@ function sanitizeErrorBody(s: string, max = 200): string {
 }
 
 export class GraphQLClient {
-  private _headers: Record<string, string>;
-  private authenticated: boolean = false;
+  private readonly baseHeaders: Record<string, string>;
+  private readonly authProvider?: () => Promise<AuthSnapshot>;
+  private authResolution?: Promise<AuthSnapshot>;
+  private resolvedAuth: AuthSnapshot = { kind: "none" };
+  private authOverride?: AuthSnapshot;
 
-  constructor(private opts: { endpoint: string; headers?: Record<string, string>; bearer?: string }) {
-    this._headers = { ...(opts.headers || {}) };
+  constructor(private readonly opts: GraphQLClientOptions) {
+    const sourceHeaders = { ...(opts.headers || {}) };
+    this.baseHeaders = withoutAuthenticationHeaders(sourceHeaders);
+    this.authProvider = opts.authProvider;
 
-    // Set authentication in priority order
+    const authorization = findHeader(sourceHeaders, "authorization");
+    const cookie = findHeader(sourceHeaders, "cookie");
     if (opts.bearer) {
-      this._headers["Authorization"] = `Bearer ${opts.bearer}`;
-      this.authenticated = true;
-      console.error("Using Bearer token authentication");
-    } else if (this._headers.Cookie) {
-      this.authenticated = true;
-      console.error("Using Cookie authentication");
+      this.resolvedAuth = validateAuthSnapshot({ kind: "bearer", token: opts.bearer });
+    } else if (authorization !== undefined) {
+      this.resolvedAuth = validateAuthSnapshot({
+        kind: "bearer",
+        token: bearerFromHeader(authorization),
+      });
+    } else if (cookie !== undefined) {
+      this.resolvedAuth = validateAuthSnapshot({ kind: "cookie", cookie });
     }
   }
 
-  /** The GraphQL endpoint URL */
+  /** The GraphQL endpoint URL. */
   get endpoint(): string {
     return this.opts.endpoint;
   }
 
-  /** Current request headers (including auth) */
+  /** Synchronous snapshot for compatibility. Async consumers must use getConnectionAuth(). */
   get headers(): Record<string, string> {
-    return { ...this._headers };
+    const snapshot = this.authOverride || this.resolvedAuth;
+    return { ...this.baseHeaders, ...authHeaders(snapshot) };
   }
 
-  /** Cookie header value, if set */
   get cookie(): string {
-    return this._headers["Cookie"] || "";
+    const snapshot = this.authOverride || this.resolvedAuth;
+    return snapshot.kind === "cookie" ? snapshot.cookie : "";
   }
 
-  /** Bearer token, if set */
   get bearer(): string {
-    const auth = this._headers["Authorization"] || "";
-    return auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    const snapshot = this.authOverride || this.resolvedAuth;
+    return snapshot.kind === "bearer" ? snapshot.token : "";
   }
 
   setHeaders(next: Record<string, string>) {
-    this._headers = { ...this._headers, ...next };
+    const authorization = findHeader(next, "authorization");
+    const cookie = findHeader(next, "cookie");
+    Object.assign(this.baseHeaders, withoutAuthenticationHeaders(next));
+
+    if (authorization !== undefined) {
+      this.setBearer(bearerFromHeader(authorization));
+    } else if (cookie !== undefined) {
+      this.setCookie(cookie);
+    }
   }
 
   setCookie(cookieHeader: string) {
-    if (/[\r\n]/.test(cookieHeader)) {
-      throw new Error("Cookie header contains illegal CR/LF characters");
-    }
-    this._headers["Cookie"] = cookieHeader;
-    this.authenticated = true;
+    this.authOverride = validateAuthSnapshot({ kind: "cookie", cookie: cookieHeader });
     console.error("Session cookies set from email/password login");
   }
 
+  setBearer(token: string) {
+    this.authOverride = validateAuthSnapshot({ kind: "bearer", token });
+    console.error("Using Bearer token authentication");
+  }
+
   isAuthenticated(): boolean {
-    return this.authenticated;
+    return (this.authOverride || this.resolvedAuth).kind !== "none";
+  }
+
+  private resolveAuth(): Promise<AuthSnapshot> {
+    if (this.authOverride) return Promise.resolve(this.authOverride);
+    if (!this.authProvider) return Promise.resolve(this.resolvedAuth);
+    if (!this.authResolution) {
+      this.authResolution = this.authProvider().then((snapshot) => {
+        const provided = validateAuthSnapshot(snapshot);
+        if (provided.kind !== "none" || this.resolvedAuth.kind === "none") {
+          this.resolvedAuth = provided;
+        }
+        return this.resolvedAuth;
+      });
+    }
+    return this.authResolution;
+  }
+
+  /** Await authentication and return one normalized credential set for HTTP or WebSocket consumers. */
+  async getConnectionAuth(): Promise<ConnectionAuth> {
+    const snapshot = this.authOverride || await this.resolveAuth();
+    const headers = { ...this.baseHeaders, ...authHeaders(snapshot) };
+    return {
+      bearer: snapshot.kind === "bearer" ? snapshot.token : "",
+      cookie: snapshot.kind === "cookie" ? snapshot.cookie : "",
+      endpoint: this.opts.endpoint,
+      headers,
+    };
   }
 
   async request<T>(query: string, variables?: Record<string, any>): Promise<T> {
+    const connection = await this.getConnectionAuth();
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "User-Agent": `affine-mcp-server/${VERSION}`,
-      ...this._headers,
+      ...connection.headers,
     };
 
     const controller = new AbortController();
@@ -83,35 +197,33 @@ export class GraphQLClient {
         signal: controller.signal,
       });
     } catch (err: any) {
-      if (err.name === "AbortError") throw new Error(`GraphQL request timed out after ${GQL_FETCH_TIMEOUT_MS / 1000}s`);
+      if (err.name === "AbortError") {
+        throw new Error(`GraphQL request timed out after ${GQL_FETCH_TIMEOUT_MS / 1000}s`);
+      }
       throw err;
     } finally {
       clearTimeout(timer);
     }
 
-    // Handle redirects (undici may follow them but strip auth headers)
     if (res.status >= 300 && res.status < 400) {
       const location = res.headers.get("location");
       throw new Error(
         `GraphQL endpoint returned redirect ${res.status} -> ${location || "(no location)"}. ` +
-        `Check AFFINE_BASE_URL.`
+        "Check AFFINE_BASE_URL.",
       );
     }
 
     const contentType = res.headers.get("content-type") || "";
-
-    // Guard against non-JSON responses (Cloudflare challenges, HTML error pages)
     if (!contentType.includes("application/json") && !contentType.includes("application/graphql")) {
       const body = await res.text();
       const snippet = sanitizeErrorBody(body);
       throw new Error(
         `GraphQL endpoint returned non-JSON response (${res.status} ${res.statusText}, ` +
-        `Content-Type: ${contentType || "(none)"}). Body: ${snippet}`
+        `Content-Type: ${contentType || "(none)"}). Body: ${snippet}`,
       );
     }
 
     if (!res.ok) {
-      // Try to parse error body as JSON
       let body: string;
       try {
         const json = await res.json() as any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { registerUserCRUDTools } from "./tools/userCRUD.js";
 import { registerAccessTokenTools } from "./tools/accessTokens.js";
 import { registerBlobTools } from "./tools/blobStorage.js";
 import { registerNotificationTools } from "./tools/notifications.js";
-import { loginWithPassword } from "./auth.js";
+import { AuthSession, parseLoginMode } from "./authSession.js";
 import { registerAuthTools } from "./tools/auth.js";
 import { registerOrganizeTools } from "./tools/organize.js";
 import { registerPropertyTools } from "./tools/properties.js";
@@ -60,100 +60,97 @@ const useHttpTransport = config.transportMode === "http";
 // Tool filtering is parsed once at module load (not per-session in HTTP mode).
 const toolFilter = createToolFilter(process.env);
 
+if (config.authMode === "oauth" && !useHttpTransport) {
+  throw new Error("AFFINE_MCP_AUTH_MODE=oauth requires MCP_TRANSPORT=http (or streamable/sse).");
+}
+if (config.authMode === "oauth" && !config.apiToken) {
+  throw new Error("AFFINE_API_TOKEN is required when AFFINE_MCP_AUTH_MODE=oauth.");
+}
+if (config.authMode === "oauth" && (config.cookie || config.email || config.password)) {
+  console.error(
+    "[affine-mcp] OAuth mode uses the configured AFFINE_API_TOKEN service credential. " +
+    "Ignoring AFFINE_COOKIE / AFFINE_EMAIL / AFFINE_PASSWORD.",
+  );
+}
+if (config.authMode === "oauth" && process.env.AFFINE_LOGIN_AT_START) {
+  console.error("[affine-mcp] AFFINE_LOGIN_AT_START is ignored when AFFINE_MCP_AUTH_MODE=oauth.");
+}
+
+const loginMode = config.authMode === "oauth"
+  ? "async"
+  : parseLoginMode(process.env.AFFINE_LOGIN_AT_START);
+
+function findConfiguredHeader(name: string): string | undefined {
+  let value: string | undefined;
+  for (const [headerName, headerValue] of Object.entries(config.headers || {})) {
+    if (headerName.toLowerCase() === name) value = headerValue;
+  }
+  return value;
+}
+
+const configuredAuthorization = findConfiguredHeader("authorization");
+const configuredCookie = findConfiguredHeader("cookie");
+let headerBearer: string | undefined;
+if (!config.apiToken && configuredAuthorization !== undefined) {
+  if (/[\r\n]/.test(configuredAuthorization)) {
+    throw new Error("Configured Authorization header contains illegal CR/LF characters.");
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(configuredAuthorization);
+  if (!match) {
+    throw new Error("Configured Authorization header must use the Bearer scheme.");
+  }
+  headerBearer = match[1];
+}
+
+const sessionBearer = config.apiToken || headerBearer;
+const sessionCookie = config.authMode === "oauth" || sessionBearer
+  ? undefined
+  : config.cookie || configuredCookie;
+const authSession = new AuthSession({
+  baseUrl: config.baseUrl,
+  bearer: sessionBearer,
+  cookie: sessionCookie,
+  email: config.authMode === "oauth" || sessionBearer || sessionCookie ? undefined : config.email,
+  password: config.authMode === "oauth" || sessionBearer || sessionCookie ? undefined : config.password,
+});
+
+// The process-scoped AuthSession owns credentials after configuration is loaded.
+config.email = undefined;
+config.password = undefined;
+
+if (loginMode === "async" && authSession.requiresLogin) {
+  authSession.start();
+}
+
 // Startup diagnostics (visible in Claude Code MCP server logs via stderr)
 console.error(`[affine-mcp] Config: ${CONFIG_FILE} (${existsSync(CONFIG_FILE) ? 'found' : 'missing'})`);
 console.error(`[affine-mcp] Endpoint: ${config.graphqlEndpoint}`);
-const hasAuth = !!(config.apiToken || config.cookie || (config.email && config.password));
-console.error(`[affine-mcp] Auth: ${hasAuth ? 'configured' : 'not configured'}`);
+const authSource = authSession.hasConfiguredAuth ? authSession.source : "not configured";
+console.error(`[affine-mcp] Auth: ${authSource}`);
+if (authSource === "not configured") {
+  console.error("[affine-mcp] WARNING: No authentication configured. Some operations may fail.");
+  console.error("[affine-mcp] Set AFFINE_API_TOKEN or run: affine-mcp login");
+}
 console.error(`[affine-mcp] HTTP auth mode: ${config.authMode}`);
-if (hasAuth && config.baseUrl.startsWith("http://")
+if (authSource !== "not configured" && config.baseUrl.startsWith("http://")
     && !config.baseUrl.includes("localhost")
     && !config.baseUrl.includes("127.0.0.1")) {
   console.error("WARNING: Credentials configured over plain HTTP. Use HTTPS for remote servers.");
 }
 console.error(`[affine-mcp] Workspace: ${config.defaultWorkspaceId ? 'set' : '(none)'}`);
 
-if (config.authMode === "oauth" && !useHttpTransport) {
-  throw new Error("AFFINE_MCP_AUTH_MODE=oauth requires MCP_TRANSPORT=http (or streamable/sse).");
-}
 
 async function buildServer() {
   const server = new McpServer({ name: "affine-mcp", version: VERSION });
   const gqlHeaders = { ...(config.headers || {}) };
-  const gqlBearer = config.apiToken;
-
-  if (config.authMode === "oauth") {
-    if (!gqlBearer) {
-      throw new Error("AFFINE_API_TOKEN is required when AFFINE_MCP_AUTH_MODE=oauth.");
-    }
-    if (config.cookie || config.email || config.password) {
-      console.error(
-        "[affine-mcp] OAuth mode uses the configured AFFINE_API_TOKEN service credential. " +
-        "Ignoring AFFINE_COOKIE / AFFINE_EMAIL / AFFINE_PASSWORD.",
-      );
-    }
-    delete gqlHeaders.Cookie;
-    if (config.loginAtStart !== "async") {
-      console.error("[affine-mcp] AFFINE_LOGIN_AT_START is ignored when AFFINE_MCP_AUTH_MODE=oauth.");
-    }
-  }
 
   // Initialize GraphQL client with authentication
   const gql = new GraphQLClient({
     endpoint: config.graphqlEndpoint,
     headers: gqlHeaders,
-    bearer: gqlBearer
+    authProvider: () => authSession.ready(),
   });
 
-  // Try email/password authentication if no other auth method is configured.
-  // To avoid startup timeouts in MCP clients, default to async login after the stdio handshake.
-  if (config.authMode !== "oauth" && !gql.isAuthenticated() && config.email && config.password) {
-    const mode = config.loginAtStart;
-    // In HTTP transport mode, buildServer() is called per session, so credentials
-    // must be retained for subsequent sessions. Only clear in stdio mode (single session).
-    const isHttpTransport = config.transportMode === "http";
-    if (mode === "sync") {
-      console.error("No token/cookie; performing synchronous email/password authentication at startup...");
-      try {
-        const { cookieHeader } = await loginWithPassword(config.baseUrl, config.email, config.password);
-        gql.setCookie(cookieHeader);
-        console.error("Successfully authenticated with email/password");
-      } catch (e) {
-        console.error("Failed to authenticate with email/password:", e);
-        console.error("WARNING: Continuing without authentication - some operations may fail");
-      } finally {
-        if (!isHttpTransport) {
-          config.password = undefined;
-          config.email = undefined;
-        }
-      }
-    } else {
-      console.error("No token/cookie; deferring email/password authentication (async after connect)...");
-      // Capture credentials before clearing — async login needs them.
-      const loginEmail = config.email!;
-      const loginPassword = config.password!;
-      if (!isHttpTransport) {
-        config.password = undefined;
-        config.email = undefined;
-      }
-      // Fire-and-forget async login so stdio handshake is not delayed.
-      (async () => {
-        try {
-          const { cookieHeader } = await loginWithPassword(config.baseUrl, loginEmail, loginPassword);
-          gql.setCookie(cookieHeader);
-          console.error("Successfully authenticated with email/password (async)");
-        } catch (e) {
-          console.error("Failed to authenticate with email/password (async):", e);
-        }
-      })();
-    }
-  }
-
-  // Log authentication status
-  if (!gql.isAuthenticated()) {
-    console.error("WARNING: No authentication configured. Some operations may fail.");
-    console.error("Set AFFINE_API_TOKEN or run: affine-mcp login");
-  }
 
   const originalRegisterTool = (server as any).registerTool?.bind(server);
   if (typeof originalRegisterTool !== "function") {
@@ -197,6 +194,10 @@ async function buildServer() {
 }
 
 async function start() {
+  if (loginMode === "sync" && authSession.requiresLogin) {
+    await authSession.ready();
+  }
+
   if (useHttpTransport) {
     await startHttpMcpServer(buildServer, config);
   } else {

--- a/src/tools/blobStorage.ts
+++ b/src/tools/blobStorage.ts
@@ -25,9 +25,7 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
   // UPLOAD BLOB/FILE
   const uploadBlobHandler = async ({ workspaceId, content, filename, contentType }: { workspaceId: string; content: string; filename?: string; contentType?: string }) => {
     try {
-      const endpoint = gql.endpoint;
-      const headers = gql.headers;
-      const cookie = gql.cookie;
+      const { endpoint, headers } = await gql.getConnectionAuth();
       const payload = decodeBlobContent(content);
       const safeFilename = filename || `blob-${Date.now()}.bin`;
       const mime = contentType || "application/octet-stream";
@@ -49,7 +47,6 @@ export function registerBlobTools(server: McpServer, gql: GraphQLClient) {
         method: "POST",
         headers: {
           ...headers,
-          Cookie: cookie,
           ...form.getHeaders(),
         },
         body: form as any,

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -370,10 +370,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   }
 
   async function getCookieAndEndpoint() {
-    const endpoint = gql.endpoint;
-    const cookie = gql.cookie;
-    const bearer = gql.bearer;
-    return { endpoint, cookie, bearer };
+    return await gql.getConnectionAuth();
   }
 
   const SELECT_COLORS = [

--- a/src/tools/icons.ts
+++ b/src/tools/icons.ts
@@ -59,8 +59,9 @@ export function registerIconTools(
     workspaceId: string,
     fn: (socket: WorkspaceSocket) => Promise<T>,
   ): Promise<T> {
-    const wsUrl = wsUrlFromGraphQLEndpoint(gql.endpoint);
-    const socket = await connectWorkspaceSocket(wsUrl, gql.cookie, gql.bearer);
+    const { endpoint, cookie, bearer } = await gql.getConnectionAuth();
+    const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
+    const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
       return await fn(socket);

--- a/src/tools/organize.ts
+++ b/src/tools/organize.ts
@@ -630,9 +630,7 @@ export function registerOrganizeTools(
   defaults: { workspaceId?: string }
 ) {
   async function getSocketContext() {
-    const endpoint = gql.endpoint;
-    const cookie = gql.cookie;
-    const bearer = gql.bearer;
+    const { endpoint, cookie, bearer } = await gql.getConnectionAuth();
     const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
     const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
     return { socket };

--- a/src/tools/properties.ts
+++ b/src/tools/properties.ts
@@ -183,8 +183,8 @@ export function registerPropertyTools(
   defaults: { workspaceId?: string }
 ) {
   /** Snapshot the current GraphQL endpoint and auth material for WebSocket use. */
-  function getCookieAndEndpoint() {
-    return { endpoint: gql.endpoint, cookie: gql.cookie, bearer: gql.bearer };
+  async function getCookieAndEndpoint() {
+    return await gql.getConnectionAuth();
   }
 
   /** Resolve the workspace id from the argument or the configured default; throws if absent. */
@@ -249,7 +249,7 @@ export function registerPropertyTools(
   /** Handle `list_doc_properties`: definitions, decoded per-doc values, and orphan values. */
   const listDocPropertiesHandler = async (parsed: { workspaceId?: string; docId: string }) => {
     const workspaceId = requireWorkspaceId(parsed.workspaceId);
-    const { endpoint, cookie, bearer } = getCookieAndEndpoint();
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(endpoint), cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
@@ -320,7 +320,7 @@ export function registerPropertyTools(
     const name = parsed.name.trim();
     if (!name) throw new Error("name is required");
 
-    const { endpoint, cookie, bearer } = getCookieAndEndpoint();
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(endpoint), cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
@@ -376,7 +376,7 @@ export function registerPropertyTools(
     property: string;
   }) => {
     const workspaceId = requireWorkspaceId(parsed.workspaceId);
-    const { endpoint, cookie, bearer } = getCookieAndEndpoint();
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(endpoint), cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
@@ -422,7 +422,7 @@ export function registerPropertyTools(
     value: string | number | boolean;
   }) => {
     const workspaceId = requireWorkspaceId(parsed.workspaceId);
-    const { endpoint, cookie, bearer } = getCookieAndEndpoint();
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(endpoint), cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
@@ -492,7 +492,7 @@ export function registerPropertyTools(
     property: string;
   }) => {
     const workspaceId = requireWorkspaceId(parsed.workspaceId);
-    const { endpoint, cookie, bearer } = getCookieAndEndpoint();
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
     const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(endpoint), cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -186,11 +186,8 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
   // CREATE WORKSPACE
   const createWorkspaceHandler = async ({ name, avatar }: { name: string; avatar?: string }) => {
       try {
-        // Get endpoint and headers from GraphQL client
-        const endpoint = gql.endpoint;
-        const headers = gql.headers;
-        const cookie = gql.cookie;
-        const bearer = gql.bearer;
+        // Wait for the shared auth session before multipart or WebSocket operations.
+        const { endpoint, headers, cookie, bearer } = await gql.getConnectionAuth();
         
         // Create initial workspace data
         const { workspaceUpdate, firstDocId, docUpdate } = createInitialWorkspaceData(name, avatar || '');
@@ -229,7 +226,6 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
           method: 'POST',
           headers: {
             ...headers,
-            'Cookie': cookie,
             ...form.getHeaders()
           },
           body: form as any

--- a/tests/test-auth-session.mjs
+++ b/tests/test-auth-session.mjs
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { AuthSession, parseLoginMode } from "../src/authSession.ts";
+import { GraphQLClient } from "../src/graphqlClient.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = path.resolve(__dirname, "..");
+const MCP_SERVER_PATH = path.resolve(PROJECT_DIR, "dist", "index.js");
+const EMAIL = "auth-session@example.test";
+const PASSWORD = "mock-password";
+const COOKIE = "affine_session=shared-session";
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+async function assertRejects(promise, expectedMessage, message) {
+  try {
+    await promise;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    assert(detail.includes(expectedMessage), `${message}: unexpected error: ${detail}`);
+    return;
+  }
+  throw new Error(`${message}: expected a rejection`);
+}
+
+function assertThrows(fn, expectedMessage, message) {
+  try {
+    fn();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    assert(detail.includes(expectedMessage), `${message}: unexpected error: ${detail}`);
+    return;
+  }
+  throw new Error(`${message}: expected an error`);
+}
+
+async function findFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function readRequestBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+function jsonResponse(res, status, body, headers = {}) {
+  res.writeHead(status, { "Content-Type": "application/json", ...headers });
+  res.end(JSON.stringify(body));
+}
+
+async function startMockAffine(options = {}) {
+  let releaseLogin;
+  const loginGate = options.blockLogin
+    ? new Promise((resolve) => { releaseLogin = resolve; })
+    : Promise.resolve();
+  const state = {
+    graphqlCalls: 0,
+    graphqlHeaders: [],
+    loginCompletedAt: 0,
+    signInCalls: 0,
+    unauthenticatedGraphqlCalls: 0,
+  };
+
+  const server = createServer((req, res) => {
+    void (async () => {
+      if (req.url === "/api/auth/sign-in" && req.method === "POST") {
+        state.signInCalls += 1;
+        await readRequestBody(req);
+        await loginGate;
+        if (options.failLogin) {
+          jsonResponse(res, 401, { error: "invalid credentials" });
+          return;
+        }
+        state.loginCompletedAt = Date.now();
+        jsonResponse(res, 200, { ok: true }, { "Set-Cookie": `${COOKIE}; Path=/; HttpOnly` });
+        return;
+      }
+
+      if (req.url === "/graphql" && req.method === "POST") {
+        state.graphqlCalls += 1;
+        state.graphqlHeaders.push({
+          authorization: req.headers.authorization || "",
+          cookie: req.headers.cookie || "",
+          receivedAt: Date.now(),
+        });
+        await readRequestBody(req);
+        if (req.headers.cookie !== COOKIE || req.headers.authorization) {
+          state.unauthenticatedGraphqlCalls += 1;
+          jsonResponse(res, 401, { errors: [{ message: "unauthorized" }] });
+          return;
+        }
+
+        const contentType = req.headers["content-type"] || "";
+        if (contentType.startsWith("multipart/form-data")) {
+          jsonResponse(res, 200, { data: { setBlob: "mock-blob-key" } });
+          return;
+        }
+        jsonResponse(res, 200, {
+          data: {
+            currentUser: {
+              id: "mock-user-id",
+              name: "Auth Session Test",
+              email: EMAIL,
+              emailVerified: true,
+              avatarUrl: null,
+              disabled: false,
+            },
+          },
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    })().catch((error) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    releaseLogin: () => releaseLogin?.(),
+    state,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+function cleanServerEnvironment(port, baseUrl) {
+  const env = { ...process.env };
+  for (const key of [
+    "AFFINE_API_TOKEN",
+    "AFFINE_COOKIE",
+    "AFFINE_DISABLED_GROUPS",
+    "AFFINE_DISABLED_TOOLS",
+    "AFFINE_HEADERS_JSON",
+    "AFFINE_MCP_HTTP_TOKEN",
+    "AFFINE_TOOL_PROFILE",
+  ]) {
+    delete env[key];
+  }
+  return {
+    ...env,
+    MCP_TRANSPORT: "http",
+    PORT: String(port),
+    AFFINE_BASE_URL: baseUrl,
+    AFFINE_EMAIL: EMAIL,
+    AFFINE_PASSWORD: PASSWORD,
+    AFFINE_LOGIN_AT_START: "async",
+    AFFINE_MCP_AUTH_MODE: "bearer",
+    AFFINE_MCP_HTTP_HOST: "127.0.0.1",
+    XDG_CONFIG_HOME: `/tmp/affine-mcp-auth-session-${process.pid}-${port}`,
+  };
+}
+
+async function waitForHealth(child, url, logs, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`MCP server exited before health check: ${JSON.stringify(logs())}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      await response.body?.cancel();
+    } catch {
+      // Retry until startup completes.
+    }
+    await delay(100);
+  }
+  throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(logs())}`);
+}
+
+async function startMcpServer(baseUrl) {
+  const port = await findFreePort();
+  const child = spawn("node", [MCP_SERVER_PATH], {
+    cwd: PROJECT_DIR,
+    env: cleanServerEnvironment(port, baseUrl),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+  const logs = () => ({ stdout, stderr });
+  const publicBaseUrl = `http://127.0.0.1:${port}`;
+  await waitForHealth(child, `${publicBaseUrl}/healthz`, logs);
+  return {
+    child,
+    logs,
+    mcpUrl: `${publicBaseUrl}/mcp`,
+    async close() {
+      if (child.exitCode !== null) return;
+      child.kill("SIGTERM");
+      const exited = await Promise.race([
+        new Promise((resolve) => child.once("exit", () => resolve(true))),
+        delay(4_000).then(() => false),
+      ]);
+      if (!exited && child.exitCode === null) {
+        child.kill("SIGKILL");
+        await new Promise((resolve) => child.once("exit", resolve));
+      }
+    },
+  };
+}
+
+async function createMcpClient(mcpUrl, name) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl));
+  await client.connect(transport);
+  return { client, transport };
+}
+
+function parseToolContent(result) {
+  const text = result?.content?.[0]?.text;
+  if (!text) return null;
+  return JSON.parse(text);
+}
+
+async function waitFor(predicate, message, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+async function testSingleFlightPrimitive() {
+  let loginCalls = 0;
+  const session = new AuthSession({
+    baseUrl: "http://127.0.0.1:1",
+    email: EMAIL,
+    password: PASSWORD,
+    login: async () => {
+      loginCalls += 1;
+      await delay(50);
+      return { cookieHeader: COOKIE };
+    },
+  });
+
+  const snapshots = await Promise.all(Array.from({ length: 20 }, () => session.ready()));
+  assertEqual(loginCalls, 1, "concurrent ready calls share one login");
+  assert(snapshots.every((snapshot) => snapshot.kind === "cookie" && snapshot.cookie === COOKIE), "shared login result");
+  assertEqual(session.source, "cookie", "resolved auth source");
+  assertEqual(parseLoginMode(undefined), "async", "default login mode");
+  assertEqual(parseLoginMode("SYNC"), "sync", "sync login mode");
+  assertThrows(() => parseLoginMode("background"), "must be", "invalid login mode");
+
+  const bearerPriority = new AuthSession({
+    baseUrl: "http://127.0.0.1:1",
+    bearer: "preferred-token",
+    email: EMAIL,
+  });
+  assertEqual((await bearerPriority.ready()).kind, "bearer", "bearer ignores incomplete lower-priority credentials");
+}
+
+async function testExclusiveAuthState() {
+  const client = new GraphQLClient({
+    endpoint: "http://127.0.0.1:1/graphql",
+    headers: {
+      authorization: "Bearer old-lowercase-token",
+      Authorization: "Bearer old-uppercase-token",
+      cookie: "old-lowercase-cookie=1",
+      Cookie: "old-uppercase-cookie=1",
+      "X-Test": "kept",
+    },
+  });
+
+  client.setCookie("new-cookie=1");
+  let connection = await client.getConnectionAuth();
+  assertEqual(connection.cookie, "new-cookie=1", "setCookie cookie value");
+  assertEqual(connection.bearer, "", "setCookie clears bearer");
+  assertEqual(Object.keys(connection.headers).filter((key) => key.toLowerCase() === "cookie").length, 1, "one cookie header");
+  assertEqual(Object.keys(connection.headers).filter((key) => key.toLowerCase() === "authorization").length, 0, "no authorization header after setCookie");
+
+  client.setBearer("new-bearer-token");
+  connection = await client.getConnectionAuth();
+  assertEqual(connection.bearer, "new-bearer-token", "setBearer token value");
+  assertEqual(connection.cookie, "", "setBearer clears cookie");
+  assertEqual(Object.keys(connection.headers).filter((key) => key.toLowerCase() === "authorization").length, 1, "one authorization header");
+  assertEqual(Object.keys(connection.headers).filter((key) => key.toLowerCase() === "cookie").length, 0, "no cookie header after setBearer");
+  assertEqual(connection.headers["X-Test"], "kept", "non-auth header retained");
+
+  client.setHeaders({ COOKIE: "header-cookie=1" });
+  connection = await client.getConnectionAuth();
+  assertEqual(connection.cookie, "header-cookie=1", "setHeaders cookie override");
+  assertEqual(connection.bearer, "", "setHeaders cookie clears bearer");
+  assertThrows(() => client.setCookie("bad\r\ncookie"), "CR/LF", "cookie header injection");
+  assertThrows(() => client.setBearer("bad\ntoken"), "CR/LF", "bearer header injection");
+  assertThrows(() => client.setBearer(" "), "must not be empty", "empty bearer token");
+
+  const rejectedProviderClient = new GraphQLClient({
+    endpoint: "http://127.0.0.1:1/graphql",
+    authProvider: async () => { throw new Error("provider failed"); },
+  });
+  await assertRejects(rejectedProviderClient.getConnectionAuth(), "provider failed", "provider failure");
+  rejectedProviderClient.setCookie("recovered-cookie=1");
+  assertEqual((await rejectedProviderClient.getConnectionAuth()).cookie, "recovered-cookie=1", "explicit sign-in overrides failed provider");
+}
+
+async function testFailureNeverFallsBack() {
+  const mock = await startMockAffine({ failLogin: true });
+  try {
+    const session = new AuthSession({ baseUrl: mock.baseUrl, email: EMAIL, password: PASSWORD });
+    session.start();
+    const first = new GraphQLClient({
+      endpoint: `${mock.baseUrl}/graphql`,
+      authProvider: () => session.ready(),
+    });
+    const second = new GraphQLClient({
+      endpoint: `${mock.baseUrl}/graphql`,
+      authProvider: () => session.ready(),
+    });
+
+    const results = await Promise.allSettled([
+      first.request("query { currentUser { email } }"),
+      second.request("query { currentUser { email } }"),
+      first.getConnectionAuth(),
+    ]);
+    assert(results.every((result) => result.status === "rejected"), "all consumers should receive login failure");
+    assertEqual(mock.state.signInCalls, 1, "failed login remains single-flight");
+    assertEqual(mock.state.graphqlCalls, 0, "failed login sends no anonymous GraphQL request");
+  } finally {
+    await mock.close();
+  }
+}
+
+async function testConcurrentHttpSessionsAndDirectMultipart() {
+  const mock = await startMockAffine({ blockLogin: true });
+  const mcp = await startMcpServer(mock.baseUrl);
+  const clients = [];
+  try {
+    const [first, second] = await Promise.all([
+      createMcpClient(mcp.mcpUrl, "auth-session-first"),
+      createMcpClient(mcp.mcpUrl, "auth-session-second"),
+    ]);
+    clients.push(first, second);
+
+    const userResultsPromise = Promise.all([
+      first.client.callTool({ name: "current_user", arguments: {} }),
+      second.client.callTool({ name: "current_user", arguments: {} }),
+    ]);
+
+    await waitFor(() => mock.state.signInCalls === 1, "shared sign-in request did not start");
+    await delay(100);
+    assertEqual(mock.state.graphqlCalls, 0, "backend requests wait for auth readiness");
+    mock.releaseLogin();
+
+    const userResults = await userResultsPromise;
+    for (const result of userResults) {
+      assertEqual(parseToolContent(result)?.email, EMAIL, "current_user email");
+    }
+
+    const uploadResult = await first.client.callTool({
+      name: "upload_blob",
+      arguments: {
+        workspaceId: "mock-workspace",
+        content: "plain mock upload",
+        filename: "mock.txt",
+        contentType: "text/plain",
+      },
+    });
+    assertEqual(parseToolContent(uploadResult)?.key, "mock-blob-key", "multipart upload result");
+
+    assertEqual(mock.state.signInCalls, 1, "two HTTP sessions share one login");
+    assertEqual(mock.state.graphqlCalls, 3, "two GraphQL calls and one multipart call");
+    assertEqual(mock.state.unauthenticatedGraphqlCalls, 0, "no unauthenticated backend request");
+    assert(
+      mock.state.graphqlHeaders.every((headers) =>
+        headers.cookie === COOKIE && headers.authorization === ""
+      ),
+      "all backend consumers use exactly the shared cookie credential",
+    );
+    assert(
+      mock.state.graphqlHeaders.every((headers) => headers.receivedAt >= mock.state.loginCompletedAt),
+      "backend requests occur only after login completes",
+    );
+  } finally {
+    mock.releaseLogin();
+    for (const { client, transport } of clients) {
+      try { await client.close(); } catch {}
+      try { await transport.close(); } catch {}
+    }
+    await mcp.close();
+    await mock.close();
+  }
+}
+
+async function main() {
+  assert(existsSync(MCP_SERVER_PATH), "dist/index.js is missing; run npm run build first");
+  await testSingleFlightPrimitive();
+  await testExclusiveAuthState();
+  await testFailureNeverFallsBack();
+  await testConcurrentHttpSessionsAndDirectMultipart();
+  console.log("Authentication session regression tests passed.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
# TL;DR
- Share one fail-closed authentication session across all MCP transports and backend consumers.

# Context
- Concurrent HTTP sessions could repeat email/password login and requests could race ahead without the resolved credential.
- Rebase after configuration consistency, then integrate HTTP runtime/security changes.

# Changes
- Added process-scoped single-flight login with sync/async startup semantics and shared failures.
- Enforced exclusive bearer/cookie priority and normalized GraphQL, multipart, and WebSocket auth consumption.
- Preserved explicit sign-in recovery without anonymous fallback.
- Added mock AFFiNE concurrency and failure regressions; local CI passed.
