### PR TITLE
fix: guard OAuth service-account writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,8 @@ jobs:
       - name: Verify authentication session state
         run: npm run test:auth-session
 
+      - name: Verify OAuth service-account policy
+        run: npm run test:oauth-service-policy
+
       - name: Check package contents
         run: npm run pack:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a fail-closed guard to destructive live-test entry points. Loopback targets remain available by default, while non-loopback targets require an explicit remote opt-in and an exact `DESTROY <target>` confirmation.
 - Isolated Docker-backed test runs with unique Compose projects, private per-run credential files, scoped cleanup, and collision-resistant AFFiNE resource names.
 - Stopped printing acquired session cookies from the E2E credential helper.
+- OAuth deployments now default to the read-only tool profile because all callers share one AFFiNE service credential.
+- Write-capable OAuth tool surfaces now fail closed unless operators explicitly set `AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true` in addition to selecting a write-capable profile.
+- OAuth deployment guidance now distinguishes MCP caller authentication from AFFiNE backend identity delegation.
 
 ### Fixed
 - Persisted document, block, property, organize, fractional-index suffix, and surface seed values now use unbiased cryptographically secure randomness instead of `Math.random` or modulo-biased bytes.
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added self-contained CI coverage for destructive-target validation, remote confirmation, URL normalization, and unique test resource naming.
 - Added self-contained regression coverage for config precedence, custom GraphQL paths, environment-only diagnostics, HTTP runtime flags, CORS, and upstream-aware readiness.
 - Added a self-contained mock AFFiNE regression suite for concurrent authentication, async request gating, credential exclusivity, failure propagation, and explicit recovery.
+- Added regression coverage for OAuth read-only defaults, explicit write acknowledgement, profile handling, and fully disabled write surfaces.
 
 ## [2.5.0] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ For common failures, see:
 - Use HTTPS for non-local deployments
 - Rotate access tokens regularly
 - Restrict exposed tools with `AFFINE_DISABLED_GROUPS` and `AFFINE_DISABLED_TOOLS` for least-privilege setups
+- Treat OAuth mode as a shared AFFiNE service-account deployment: it defaults to `read_only`, and write-capable profiles require `AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true`
 - Use `/healthz` and `/readyz` when running the HTTP server behind a container platform or load balancer
 
 ## Development

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -72,6 +72,7 @@ cookie, while setting a bearer credential removes any cookie header.
 | `AFFINE_OAUTH_ISSUER_URL` | Required in OAuth mode | none | OAuth issuer discovery URL |
 | `AFFINE_OAUTH_SCOPES` | No | `mcp` | Scopes advertised for OAuth-protected access |
 | `AFFINE_OAUTH_CLOCK_SKEW_SECONDS` | No | `60` | Positive integer tolerance for OAuth token timestamps |
+| `AFFINE_OAUTH_ALLOW_SERVICE_WRITES` | No | `false` | Explicitly acknowledge write-capable tools using the shared AFFiNE service identity |
 
 ## Auth strategy matrix
 
@@ -166,6 +167,18 @@ OAuth mode behavior:
 - disables `AFFINE_MCP_HTTP_TOKEN` and `?token=`
 - does not register `sign_in`
 - still requires `AFFINE_API_TOKEN` so the server can call AFFiNE
+- authenticates callers at the MCP boundary but does not delegate their identity to AFFiNE; every request uses the same `AFFINE_API_TOKEN` service identity
+- defaults `AFFINE_TOOL_PROFILE` to `read_only` when no profile is configured
+- refuses any write-capable tool surface unless `AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true` is also set
+
+To allow service-account writes, configure both controls explicitly:
+
+```bash
+export AFFINE_TOOL_PROFILE="authoring"
+export AFFINE_OAUTH_ALLOW_SERVICE_WRITES="true"
+```
+
+This grants every OAuth caller accepted by the configured issuer the same AFFiNE mutation permissions. Use separate deployments or backend credentials when callers require different AFFiNE authorization boundaries.
 
 ## Least-privilege tool exposure
 
@@ -183,7 +196,7 @@ Example:
 
 Available profiles:
 
-- `full`: expose the complete public tool surface; this is the default
+- `full`: expose the complete public tool surface; this is the default outside OAuth mode
 - `read_only`: expose discovery, reading, export, fidelity, and inspection tools, plus `sign_in`
 - `core`: expose the compact everyday surface for workspace/doc discovery, basic document authoring, tags, and database row/schema edits; omits admin tools, cleanup tools, experimental organize tools, and destructive tools
 - `authoring`: expose non-destructive creation and editing tools, including semantic pages, native templates, database composition, and edgeless canvas authoring; omits admin, cleanup, destructive, and experimental organize tools

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:pr-route-policy": "node tests/test-pr-route-policy.mjs",
     "test:tool-filtering": "node tests/test-tool-filtering.mjs",
     "test:secure-random": "node tests/test-secure-random.mjs",
+    "test:oauth-service-policy": "node tests/test-oauth-service-policy.mjs",
     "test:comprehensive": "bash tests/run-comprehensive.sh",
     "test:comprehensive:raw": "node test-comprehensive.mjs",
     "test:e2e": "bash tests/run-e2e.sh",
@@ -78,7 +79,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run pack:check",
+    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run test:config-consistency && npm run test:auth-session && npm run test:oauth-service-policy && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export type ServerConfig = {
   transportMode: TransportMode;
   loginAtStart: LoginAtStartMode;
   http: HttpServerConfig;
+  oauthAllowServiceWrites: boolean;
 };
 
 /** Config file location: ~/.config/affine-mcp/config */
@@ -225,7 +226,7 @@ function parseLoginAtStart(raw: string | undefined): LoginAtStartMode {
 }
 
 function parseBooleanEnv(name: string, raw: string | undefined, fallback: boolean): boolean {
-  if (!raw) return fallback;
+  if (raw === undefined || raw.trim() === "") return fallback;
   const normalized = raw.trim().toLowerCase();
   if (normalized === "true") return true;
   if (normalized === "false") return false;
@@ -318,6 +319,11 @@ export function loadConfig(): ServerConfig {
       false,
     ),
   };
+  const oauthAllowServiceWrites = parseBooleanEnv(
+    "AFFINE_OAUTH_ALLOW_SERVICE_WRITES",
+    env("AFFINE_OAUTH_ALLOW_SERVICE_WRITES", file),
+    false,
+  );
 
   return {
     baseUrl,
@@ -337,5 +343,6 @@ export function loadConfig(): ServerConfig {
     transportMode,
     loginAtStart,
     http,
+    oauthAllowServiceWrites,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import { runCli } from "./cli.js";
 import { startHttpMcpServer } from "./sse.js";
 import { existsSync } from "fs";
 import { createToolFilter, toolAnnotationsFor } from "./toolSurface.js";
+import {
+  assertOAuthServiceWritePolicy,
+  createToolFilterEnvironment,
+} from "./oauthServicePolicy.js";
 
 // CLI commands: affine-mcp login|status|logout|version
 const rawArgs = process.argv.slice(2);
@@ -57,8 +61,13 @@ function loadServerConfig(): ServerConfig {
 const config = loadServerConfig();
 const useHttpTransport = config.transportMode === "http";
 
+// OAuth callers share one AFFiNE service credential. Default that deployment
+// model to read-only unless operators explicitly enable both a write-capable
+// profile and the service-write acknowledgement.
+const toolFilterEnvironment = createToolFilterEnvironment(config.authMode, process.env);
+
 // Tool filtering is parsed once at module load (not per-session in HTTP mode).
-const toolFilter = createToolFilter(process.env);
+const toolFilter = createToolFilter(toolFilterEnvironment);
 
 if (config.authMode === "oauth" && !useHttpTransport) {
   throw new Error("AFFINE_MCP_AUTH_MODE=oauth requires MCP_TRANSPORT=http (or streamable/sse).");
@@ -139,6 +148,29 @@ if (authSource !== "not configured" && config.baseUrl.startsWith("http://")
 }
 console.error(`[affine-mcp] Workspace: ${config.defaultWorkspaceId ? 'set' : '(none)'}`);
 
+for (const warning of toolFilter.warnings) {
+  console.error(`[affine-mcp] WARNING: ${warning}`);
+}
+
+if (config.authMode === "oauth" && !useHttpTransport) {
+  throw new Error("AFFINE_MCP_AUTH_MODE=oauth requires MCP_TRANSPORT=http (or streamable/sse).");
+}
+assertOAuthServiceWritePolicy({
+  authMode: config.authMode,
+  allowServiceWrites: config.oauthAllowServiceWrites,
+  enabledWriteTools: toolFilter.enabledWriteTools,
+  toolFilterWarnings: toolFilter.warnings,
+});
+if (
+  config.authMode === "oauth"
+  && config.oauthAllowServiceWrites
+  && toolFilter.enabledWriteTools.length > 0
+) {
+  console.error(
+    "[affine-mcp] WARNING: OAuth service-account writes are enabled. Every authorized OAuth caller " +
+    "can mutate AFFiNE with the shared AFFINE_API_TOKEN permissions.",
+  );
+}
 
 async function buildServer() {
   const server = new McpServer({ name: "affine-mcp", version: VERSION });
@@ -171,8 +203,8 @@ async function buildServer() {
     };
   }
   console.error(`[affine-mcp] Tool profile: ${toolFilter.profile}`);
-  console.error(`[affine-mcp] Disabled groups: ${process.env.AFFINE_DISABLED_GROUPS || "(none)"}`);
-  console.error(`[affine-mcp] Disabled tools: ${process.env.AFFINE_DISABLED_TOOLS || "(none)"}`);
+  console.error(`[affine-mcp] Disabled groups: ${toolFilterEnvironment.AFFINE_DISABLED_GROUPS || "(none)"}`);
+  console.error(`[affine-mcp] Disabled tools: ${toolFilterEnvironment.AFFINE_DISABLED_TOOLS || "(none)"}`);
   console.error(`[affine-mcp] Enabled tools: ${toolFilter.enabledTools.length}/${toolFilter.totalToolCount}`);
 
   registerWorkspaceTools(server, gql);

--- a/src/oauthServicePolicy.ts
+++ b/src/oauthServicePolicy.ts
@@ -1,0 +1,34 @@
+export function createToolFilterEnvironment(
+  authMode: "bearer" | "oauth",
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const resolved = { ...environment };
+  if (authMode === "oauth" && !resolved.AFFINE_TOOL_PROFILE?.trim()) {
+    resolved.AFFINE_TOOL_PROFILE = "read_only";
+  }
+  return resolved;
+}
+
+export function assertOAuthServiceWritePolicy(input: {
+  authMode: "bearer" | "oauth";
+  allowServiceWrites: boolean;
+  enabledWriteTools: readonly string[];
+  toolFilterWarnings?: readonly string[];
+}): void {
+  if (
+    input.authMode === "oauth"
+    && input.toolFilterWarnings?.some(warning => warning.startsWith("Unknown AFFINE_TOOL_PROFILE"))
+  ) {
+    throw new Error("OAuth mode refuses an unknown AFFINE_TOOL_PROFILE instead of falling back to full.");
+  }
+  if (
+    input.authMode === "oauth"
+    && input.enabledWriteTools.length > 0
+    && !input.allowServiceWrites
+  ) {
+    throw new Error(
+      "OAuth mode uses one shared AFFiNE service identity. Write-capable tools require " +
+      "AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true. Prefer AFFINE_TOOL_PROFILE=read_only.",
+    );
+  }
+}

--- a/src/toolSurface.ts
+++ b/src/toolSurface.ts
@@ -381,12 +381,16 @@ export function createToolFilter(env: NodeJS.ProcessEnv = process.env) {
   }
 
   const enabledTools = ALL_TOOLS.filter(toolName => isEnabled(toolName));
+  const enabledWriteTools = enabledTools.filter(
+    toolName => toolName !== "sign_in" && TOOL_GROUPS[toolName].includes("write"),
+  );
 
   return {
     profile: validatedProfile,
     disabledGroups,
     disabledTools,
     enabledTools,
+    enabledWriteTools,
     totalToolCount: ALL_TOOLS.length,
     isEnabled,
   };

--- a/tests/test-oauth-service-policy.mjs
+++ b/tests/test-oauth-service-policy.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  assertOAuthServiceWritePolicy,
+  createToolFilterEnvironment,
+} from "../dist/oauthServicePolicy.js";
+import { createToolFilter } from "../dist/toolSurface.js";
+
+const oauthDefaultEnvironment = createToolFilterEnvironment("oauth", {});
+assert.equal(oauthDefaultEnvironment.AFFINE_TOOL_PROFILE, "read_only");
+const oauthDefaultFilter = createToolFilter(oauthDefaultEnvironment);
+assert.equal(oauthDefaultFilter.profile, "read_only");
+assert.deepEqual(oauthDefaultFilter.enabledWriteTools, []);
+assert.doesNotThrow(() => assertOAuthServiceWritePolicy({
+  authMode: "oauth",
+  allowServiceWrites: false,
+  enabledWriteTools: oauthDefaultFilter.enabledWriteTools,
+}));
+
+const bearerDefaultEnvironment = createToolFilterEnvironment("bearer", {});
+assert.equal(bearerDefaultEnvironment.AFFINE_TOOL_PROFILE, undefined);
+const bearerDefaultFilter = createToolFilter(bearerDefaultEnvironment);
+assert.equal(bearerDefaultFilter.profile, "full");
+assert(bearerDefaultFilter.enabledWriteTools.length > 0);
+assert.doesNotThrow(() => assertOAuthServiceWritePolicy({
+  authMode: "bearer",
+  allowServiceWrites: false,
+  enabledWriteTools: bearerDefaultFilter.enabledWriteTools,
+}));
+
+for (const profile of ["full", "core", "authoring"]) {
+  const filter = createToolFilter(createToolFilterEnvironment("oauth", {
+    AFFINE_TOOL_PROFILE: profile,
+  }));
+  assert(filter.enabledWriteTools.length > 0, `${profile} must expose write tools`);
+  assert.throws(
+    () => assertOAuthServiceWritePolicy({
+      authMode: "oauth",
+      allowServiceWrites: false,
+      enabledWriteTools: filter.enabledWriteTools,
+    }),
+    /AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true/,
+  );
+  assert.doesNotThrow(() => assertOAuthServiceWritePolicy({
+    authMode: "oauth",
+    allowServiceWrites: true,
+    enabledWriteTools: filter.enabledWriteTools,
+  }));
+}
+
+const explicitlyRestrictedFullFilter = createToolFilter(
+  createToolFilterEnvironment("oauth", {
+    AFFINE_TOOL_PROFILE: "full",
+    AFFINE_DISABLED_GROUPS: "write",
+  }),
+);
+assert.deepEqual(explicitlyRestrictedFullFilter.enabledWriteTools, []);
+assert.doesNotThrow(() => assertOAuthServiceWritePolicy({
+  authMode: "oauth",
+  allowServiceWrites: false,
+  enabledWriteTools: explicitlyRestrictedFullFilter.enabledWriteTools,
+}));
+
+const invalidProfileFilter = createToolFilter(
+  createToolFilterEnvironment("oauth", { AFFINE_TOOL_PROFILE: "readonly" }),
+);
+assert.throws(
+  () => assertOAuthServiceWritePolicy({
+    authMode: "oauth",
+    allowServiceWrites: true,
+    enabledWriteTools: invalidProfileFilter.enabledWriteTools,
+    toolFilterWarnings: invalidProfileFilter.warnings,
+  }),
+  /refuses an unknown AFFINE_TOOL_PROFILE/,
+);
+
+const inputEnvironment = { AFFINE_DISABLED_TOOLS: "delete_doc" };
+const resolvedEnvironment = createToolFilterEnvironment("oauth", inputEnvironment);
+assert.notEqual(resolvedEnvironment, inputEnvironment);
+assert.equal(inputEnvironment.AFFINE_TOOL_PROFILE, undefined, "input environment must not be mutated");
+
+const projectDirectory = path.resolve(new URL("..", import.meta.url).pathname);
+const isolatedEnvironment = {
+  ...process.env,
+  XDG_CONFIG_HOME: path.join(os.tmpdir(), `affine-oauth-policy-${process.pid}`),
+  AFFINE_API_TOKEN: "test-service-token",
+  AFFINE_MCP_AUTH_MODE: "oauth",
+  AFFINE_OAUTH_ALLOW_SERVICE_WRITES: "false",
+  AFFINE_TOOL_PROFILE: "full",
+  AFFINE_DISABLED_GROUPS: "",
+  AFFINE_DISABLED_TOOLS: "",
+  MCP_TRANSPORT: "http",
+};
+const deniedProcess = spawnSync(process.execPath, ["dist/index.js"], {
+  cwd: projectDirectory,
+  env: isolatedEnvironment,
+  encoding: "utf8",
+  timeout: 5_000,
+});
+assert.equal(deniedProcess.status, 1);
+assert.match(deniedProcess.stderr, /AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true/);
+
+const invalidBooleanProcess = spawnSync(process.execPath, ["dist/index.js"], {
+  cwd: projectDirectory,
+  env: {
+    ...isolatedEnvironment,
+    AFFINE_OAUTH_ALLOW_SERVICE_WRITES: "yes",
+  },
+  encoding: "utf8",
+  timeout: 5_000,
+});
+assert.equal(invalidBooleanProcess.status, 1);
+assert.match(invalidBooleanProcess.stderr, /must be "true" or "false"/);
+
+console.log("OAuth service-account policy tests passed");


### PR DESCRIPTION
# TL;DR
- Default OAuth deployments to read-only and require explicit acknowledgement for shared service-account writes.

# Context
- OAuth authenticates callers at the MCP boundary, but every backend request uses one AFFiNE API token rather than delegated user identity.
- Rebase after configuration and auth-session changes during integration.

# Changes
- Defaulted an unspecified OAuth tool profile to read_only.
- Refused write-capable OAuth surfaces without AFFINE_OAUTH_ALLOW_SERVICE_WRITES=true.
- Rejected invalid OAuth profile fallback and documented the shared-identity boundary.
- Added policy and real startup regressions; local CI passed.
