### PR TITLE
test: fail closed for destructive live targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify live-test safety guard
+        run: npm run test:live-safety
+
       - name: Verify tool manifest
         run: npm run test:tool-manifest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Raised the supported Node.js runtime floor to 20 to match the installed dependency graph and added CI coverage for Node.js 20 and 24.
 
+### Security
+- Added a fail-closed guard to destructive live-test entry points. Loopback targets remain available by default, while non-loopback targets require an explicit remote opt-in and an exact `DESTROY <target>` confirmation.
+- Isolated Docker-backed test runs with unique Compose projects, private per-run credential files, scoped cleanup, and collision-resistant AFFiNE resource names.
+- Stopped printing acquired session cookies from the E2E credential helper.
+
 ### Fixed
 - Persisted document, block, property, organize, fractional-index suffix, and surface seed values now use unbiased cryptographically secure randomness instead of `Math.random` or modulo-biased bytes.
 
 ### Tests
 - Added a source-wide regression guard that rejects `Math.random` in runtime TypeScript and validates identifier alphabets, lengths, uniqueness, seed ranges, and invalid generator inputs.
+- Added self-contained CI coverage for destructive-target validation, remote confirmation, URL normalization, and unique test resource naming.
 
 ## [2.5.0] - 2026-07-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,28 @@ AFFINE_PASSWORD=dev \
 npm run test:comprehensive
 ```
 
+## Destructive Live-Test Safety
+
+Live integration tests create, update, and delete AFFiNE resources. They are
+allowed against loopback targets by default and fail closed for every other
+host. The Docker-backed runners use a unique Compose project, private random
+credentials, and collision-resistant resource names for each run.
+
+Use `npm run test:live-safety` to verify the guard without contacting AFFiNE.
+Never point a live test at production. If a non-loopback disposable test
+instance is intentionally required, both values below must match the exact
+normalized target:
+
+```bash
+export AFFINE_BASE_URL="https://disposable-affine.example.test"
+export AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS=1
+export AFFINE_REMOTE_DESTRUCTIVE_TEST_CONFIRM="DESTROY https://disposable-affine.example.test"
+node tests/test-database-creation.mjs
+```
+
+Unset both opt-in variables immediately after the run. Do not store them in a
+shell profile, CI environment, or repository file.
+
 ## Tool Design Rules
 
 - Keep tool names short and action-oriented, using `snake_case`.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Run the main quality gates before opening a PR:
 
 ```bash
 npm run build
+npm run test:live-safety
 npm run test:tool-manifest
 npm run pack:check
 ```
@@ -239,6 +240,11 @@ Additional validation:
 - `npm run test:e2e` runs Docker, MCP, and Playwright together
 - `npm run test:playwright` runs the Playwright suite only
 - Focused runners for the new high-level tool surface include `npm run test:create-placement`, `npm run test:capabilities-fidelity`, `npm run test:native-template`, `node tests/test-database-intent.mjs`, `node tests/test-semantic-page-composer.mjs`, `node tests/test-structured-receipts.mjs`, `node tests/test-organize-tools.mjs`, and `node tests/test-supporting-tools.mjs`
+
+Live tests can mutate or delete AFFiNE data. They allow loopback targets by
+default and refuse non-loopback targets unless the disposable target is
+explicitly enabled and confirmed as documented in `CONTRIBUTING.md`. Never run
+them against production.
 
 Local clone flow:
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,8 +1,9 @@
 # AFFiNE E2E test environment.
 #
 # DO NOT hardcode real passwords here.
-# Run `. tests/generate-test-env.sh` to auto-generate docker/.env
-# with random credentials, or set them via environment variables.
+# Run `. tests/generate-test-env.sh` to create a private temporary env file
+# with random credentials, then pass it to Docker Compose:
+# `docker compose --env-file "$AFFINE_TEST_ENV_FILE" -f docker/docker-compose.yml ...`
 
 AFFINE_REVISION=stable
 PORT=3010

--- a/docs/edgeless-canvas-cookbook.md
+++ b/docs/edgeless-canvas-cookbook.md
@@ -188,12 +188,17 @@ From the repo root with Docker available:
 
 ```bash
 . tests/generate-test-env.sh
-docker compose -f docker/docker-compose.yml up -d
+docker compose --env-file "$AFFINE_TEST_ENV_FILE" -p "affine_mcp_cookbook_$$" -f docker/docker-compose.yml up -d
 node tests/acquire-credentials.mjs
 npm run build
 ```
 
 Then drop the calls above into a Node script that opens a `StdioClientTransport` against `dist/index.js` — `tests/test-canvas-tool-map-demo.mjs` is a complete example of the client wiring, minus the auth-flow content. The script prints the seeded doc URL; open it in a browser, switch to edgeless mode (icon next to the doc title), and the frame + its five owned elements select and drag as one.
+
+The live example is destructive and is loopback-only by default. See the
+live-test safety section in `CONTRIBUTING.md` before using any non-loopback
+disposable target. Remove the Compose project and the generated private env
+file when the manual run is complete.
 
 ## Advanced: the tool-map showcase
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start": "node dist/index.js",
     "start:http": "MCP_TRANSPORT=http node dist/index.js",
     "test": "npm run test:tool-manifest",
+    "test:live-safety": "node tests/test-live-test-safety.mjs",
     "test:cli-version": "node tests/test-cli-version.mjs",
     "test:cli-commands": "node tests/test-cli-commands.mjs",
     "test:cli-live": "node tests/test-cli-live.mjs",
@@ -75,7 +76,7 @@
     "test:markdown-rich-text-import": "node tests/test-markdown-rich-text-import.mjs",
     "test:playwright": "npx playwright test --config tests/playwright/playwright.config.ts",
     "pack:check": "npm pack --dry-run",
-    "ci": "npm run build && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run pack:check",
+    "ci": "npm run build && npm run test:live-safety && npm run test:tool-manifest && npm run test:secure-random && npm run test:tool-filtering && npm run test:pr-route-policy && npm run pack:check",
     "prepublishOnly": "npm run ci"
   },
   "files": [

--- a/scripts/test-append-block-expansion.mjs
+++ b/scripts/test-append-block-expansion.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from '../tests/require-destructive-test-safety.mjs';
+
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
@@ -213,6 +215,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: LOGIN_MODE,
+      XDG_CONFIG_HOME: testTempPath('append-block-expansion-config'),
     },
     stderr: 'pipe',
   });
@@ -251,7 +254,7 @@ async function main() {
     }
 
     await callTool('sign_in', { email: EMAIL, password: PASSWORD });
-    const ws = await callTool('create_workspace', { name: `append-expansion-${Date.now()}` });
+    const ws = await callTool('create_workspace', { name: testResourceName('append-expansion') });
     workspaceId = ws?.id;
     if (!workspaceId) throw new Error('create_workspace did not return workspace id');
 

--- a/test-comprehensive.mjs
+++ b/test-comprehensive.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './tests/require-destructive-test-safety.mjs';
+
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -10,7 +12,7 @@ const BASE_URL = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
 const EMAIL = process.env.AFFINE_EMAIL || process.env.AFFINE_ADMIN_EMAIL || 'test@affine.local';
 const PASSWORD = process.env.AFFINE_PASSWORD || process.env.AFFINE_ADMIN_PASSWORD;
 const LOGIN_MODE = process.env.AFFINE_LOGIN_AT_START || 'sync';
-const XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME || '/tmp/affine-mcp-comprehensive-noconfig';
+const XDG_CONFIG_HOME = testTempPath('comprehensive-config');
 const TOOL_TIMEOUT_MS = Number(process.env.MCP_TOOL_TIMEOUT_MS || '60000');
 const MANIFEST_PATH = path.join(process.cwd(), 'tool-manifest.json');
 const EXPECTED_TOOLS = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8')).tools;
@@ -90,6 +92,18 @@ function isBlockedByEnvironment(_toolName, errorMessage) {
   return false;
 }
 
+function redactSecrets(value) {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => {
+    if (/^(password|token|cookie|authorization|apiToken|accessToken|refreshToken)$/i.test(key)) {
+      return [key, '[redacted]'];
+    }
+    return [key, redactSecrets(entry)];
+  }));
+}
+
 class ComprehensiveRunner {
   constructor() {
     this.client = new Client({ name: 'affine-mcp-comprehensive-test', version: '3.0.0' });
@@ -137,7 +151,7 @@ class ComprehensiveRunner {
 
     const record = {
       name,
-      args,
+      args: redactSecrets(args),
       ok: false,
       blocked: false,
       durationMs: 0,
@@ -161,7 +175,7 @@ class ComprehensiveRunner {
       );
       const parsed = parseContent(result);
       const semanticError = toErrorMessage(parsed);
-      record.result = parsed;
+      record.result = redactSecrets(parsed);
       record.durationMs = Date.now() - start;
 
       if (semanticError) {
@@ -210,7 +224,7 @@ class ComprehensiveRunner {
     await this.callTool('sign_in', { email: EMAIL, password: PASSWORD });
 
     await this.callTool('list_workspaces');
-    await this.callTool('create_workspace', { name: `mcp-main-${Date.now()}` }, parsed => {
+    await this.callTool('create_workspace', { name: testResourceName('mcp-main') }, parsed => {
       this.workspaceId = parsed?.id || null;
     });
 
@@ -241,7 +255,7 @@ class ComprehensiveRunner {
     if (!docId) {
       throw new Error('create_doc did not return docId');
     }
-    const tagName = `mcp-tag-${Date.now()}`;
+    const tagName = testResourceName('mcp-tag');
 
     await this.callTool('create_tag', { workspaceId, tag: tagName });
     await this.callTool('add_tag_to_doc', { workspaceId, docId, tag: tagName });
@@ -286,7 +300,7 @@ class ComprehensiveRunner {
     if (!databaseBlockId) {
       throw new Error('append_block(database) did not return blockId');
     }
-    const databaseColumnName = `Status-${Date.now()}`;
+    const databaseColumnName = testResourceName('status');
     let databaseRowBlockId = null;
     await this.callTool('add_database_column', {
       workspaceId,
@@ -420,7 +434,7 @@ class ComprehensiveRunner {
     await this.callTool('list_histories', { workspaceId, guid: docId, take: 20 });
 
     await this.callTool('list_access_tokens');
-    await this.callTool('generate_access_token', { name: `token-main-${Date.now()}` }, parsed => {
+    await this.callTool('generate_access_token', { name: testResourceName('token-main') }, parsed => {
       this.tokenId = parsed?.id || null;
     });
     await this.callTool('revoke_access_token', { id: this.tokenId || 'missing-token-id' });
@@ -567,7 +581,7 @@ async function main() {
   }
 
   const summary = runner.summary();
-  const fileName = `comprehensive-test-results-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+  const fileName = `${testResourceName('comprehensive-test-results')}.json`;
   fs.writeFileSync(fileName, JSON.stringify(summary, null, 2));
 
   console.log(JSON.stringify({

--- a/tests/acquire-credentials.mjs
+++ b/tests/acquire-credentials.mjs
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+import {
+  announceRemoteDestructiveTestTarget,
+  assertDestructiveTestTarget,
+} from './live-test-safety.mjs';
+
 /**
  * Credential acquisition for E2E tests.
  *
@@ -8,7 +13,7 @@
  *   acquireCredentials(baseUrl, email, password)     — signs in, returns {cookie, baseUrl, email}
  *
  * CLI mode: reads AFFINE_BASE_URL, AFFINE_ADMIN_EMAIL, AFFINE_ADMIN_PASSWORD
- * from env and outputs credentials JSON to stdout.
+ * from env and outputs a non-secret authentication summary to stdout.
  */
 
 /**
@@ -116,6 +121,8 @@ function parsePositiveIntEnv(name, fallback) {
 
 async function runCli() {
   const baseUrl = process.env.AFFINE_BASE_URL || 'http://localhost:3010';
+  const target = assertDestructiveTestTarget({ target: baseUrl });
+  announceRemoteDestructiveTestTarget(target);
   const email = process.env.AFFINE_ADMIN_EMAIL || 'test@affine.local';
   const password = process.env.AFFINE_ADMIN_PASSWORD;
   if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required — run: . tests/generate-test-env.sh');
@@ -136,8 +143,8 @@ async function runCli() {
   console.error('[credentials] Signing in...');
   const creds = await acquireCredentials(baseUrl, email, password);
 
-  // Output JSON to stdout (logs go to stderr)
-  console.log(JSON.stringify(creds, null, 2));
+  // Keep the session cookie in-process. CI and local runner logs must not expose it.
+  console.log(JSON.stringify({ authenticated: true, baseUrl: creds.baseUrl, email: creds.email }, null, 2));
 }
 
 // --- CLI mode ---

--- a/tests/assert-destructive-test-target.mjs
+++ b/tests/assert-destructive-test-target.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import {
+  announceRemoteDestructiveTestTarget,
+  assertDestructiveTestTarget,
+  resolveTestRunId,
+} from './live-test-safety.mjs';
+
+try {
+  const target = assertDestructiveTestTarget();
+  const runId = resolveTestRunId();
+
+  announceRemoteDestructiveTestTarget(target, { runId });
+
+  if (process.argv.includes('--print-run-id')) {
+    console.log(runId);
+  }
+} catch (error) {
+  console.error(`[destructive-test-safety] ${error.message}`);
+  process.exitCode = 1;
+}

--- a/tests/generate-test-env.sh
+++ b/tests/generate-test-env.sh
@@ -7,7 +7,8 @@
 #   . tests/generate-test-env.sh
 #
 # It exports AFFINE_ADMIN_EMAIL, AFFINE_ADMIN_PASSWORD, DB_PASSWORD, etc.
-# and writes docker/.env so Docker Compose picks them up.
+# and writes a private, per-run env file. Pass AFFINE_TEST_ENV_FILE to
+# `docker compose --env-file` rather than sharing docker/.env between runs.
 #
 set -euo pipefail
 
@@ -19,8 +20,15 @@ rand_password() {
   printf '%s' "${raw:0:24}"
 }
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOCKER_DIR="$(cd "$SCRIPT_DIR/../docker" && pwd)"
+dotenv_quote() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\$/\$\$}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  printf '"%s"' "$value"
+}
 
 # Allow overrides from environment; generate if missing.
 export AFFINE_ADMIN_EMAIL="${AFFINE_ADMIN_EMAIL:-test@affine.local}"
@@ -31,15 +39,43 @@ export DB_DATABASE="${DB_DATABASE:-affine}"
 export AFFINE_REVISION="${AFFINE_REVISION:-stable}"
 export PORT="${PORT:-3010}"
 
-# Write docker/.env consumed by docker-compose.yml
-cat > "$DOCKER_DIR/.env" <<EOF
-AFFINE_REVISION=$AFFINE_REVISION
-PORT=$PORT
-DB_USERNAME=$DB_USERNAME
-DB_PASSWORD=$DB_PASSWORD
-DB_DATABASE=$DB_DATABASE
-AFFINE_ADMIN_EMAIL=$AFFINE_ADMIN_EMAIL
-AFFINE_ADMIN_PASSWORD=$AFFINE_ADMIN_PASSWORD
-EOF
+if [[ -z "${AFFINE_TEST_ENV_FILE:-}" ]]; then
+  temp_root="${TMPDIR:-/tmp}"
+  temp_root="${temp_root%/}"
+  AFFINE_TEST_ENV_FILE="$(mktemp "${temp_root}/affine-mcp-test-env.XXXXXX")"
+  AFFINE_TEST_ENV_FILE_OWNED=1
+else
+  if [[ -e "$AFFINE_TEST_ENV_FILE" && "${AFFINE_OVERWRITE_TEST_ENV_FILE:-0}" != "1" ]]; then
+    requested_env_file="$AFFINE_TEST_ENV_FILE"
+    temp_root="${TMPDIR:-/tmp}"
+    temp_root="${temp_root%/}"
+    AFFINE_TEST_ENV_FILE="$(mktemp "${temp_root}/affine-mcp-test-env.XXXXXX")"
+    AFFINE_TEST_ENV_FILE_OWNED=1
+    echo "[generate-test-env] Existing file was not overwritten: $requested_env_file" >&2
+    echo "[generate-test-env] Using private file instead: $AFFINE_TEST_ENV_FILE" >&2
+  else
+    AFFINE_TEST_ENV_FILE_OWNED=0
+  fi
+fi
 
-echo "[generate-test-env] Credentials generated → docker/.env"
+if [[ "$AFFINE_TEST_ENV_FILE_OWNED" == "1" ]]; then
+  env_file_tmp="$AFFINE_TEST_ENV_FILE"
+else
+  env_file_tmp="$(mktemp "${AFFINE_TEST_ENV_FILE}.tmp.XXXXXX")"
+fi
+{
+  printf 'AFFINE_REVISION=%s\n' "$(dotenv_quote "$AFFINE_REVISION")"
+  printf 'PORT=%s\n' "$(dotenv_quote "$PORT")"
+  printf 'DB_USERNAME=%s\n' "$(dotenv_quote "$DB_USERNAME")"
+  printf 'DB_PASSWORD=%s\n' "$(dotenv_quote "$DB_PASSWORD")"
+  printf 'DB_DATABASE=%s\n' "$(dotenv_quote "$DB_DATABASE")"
+  printf 'AFFINE_ADMIN_EMAIL=%s\n' "$(dotenv_quote "$AFFINE_ADMIN_EMAIL")"
+  printf 'AFFINE_ADMIN_PASSWORD=%s\n' "$(dotenv_quote "$AFFINE_ADMIN_PASSWORD")"
+} >"$env_file_tmp"
+chmod 600 "$env_file_tmp"
+if [[ "$env_file_tmp" != "$AFFINE_TEST_ENV_FILE" ]]; then
+  mv -f "$env_file_tmp" "$AFFINE_TEST_ENV_FILE"
+fi
+
+export AFFINE_TEST_ENV_FILE AFFINE_TEST_ENV_FILE_OWNED
+echo "[generate-test-env] Private credentials written to $AFFINE_TEST_ENV_FILE"

--- a/tests/live-test-safety.mjs
+++ b/tests/live-test-safety.mjs
@@ -1,0 +1,136 @@
+import { randomBytes } from 'node:crypto';
+
+export const DEFAULT_AFFINE_TEST_URL = 'http://localhost:3010';
+export const REMOTE_ALLOW_ENV = 'AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS';
+export const REMOTE_CONFIRM_ENV = 'AFFINE_REMOTE_DESTRUCTIVE_TEST_CONFIRM';
+export const TEST_RUN_ID_ENV = 'AFFINE_TEST_RUN_ID';
+
+const RUN_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{7,95}$/;
+
+/**
+ * Normalize the target so the confirmation value has one unambiguous form.
+ */
+export function normalizeDestructiveTestTarget(rawTarget = DEFAULT_AFFINE_TEST_URL) {
+  let target;
+  try {
+    target = new URL(rawTarget);
+  } catch {
+    throw new Error(`AFFINE_BASE_URL must be a valid absolute URL, got: ${rawTarget}`);
+  }
+
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    throw new Error(`AFFINE_BASE_URL must use http or https, got: ${target.protocol}`);
+  }
+  if (target.username || target.password) {
+    throw new Error('AFFINE_BASE_URL must not contain embedded credentials.');
+  }
+  if (target.search || target.hash) {
+    throw new Error('AFFINE_BASE_URL must not contain a query string or fragment.');
+  }
+
+  target.pathname = target.pathname.replace(/\/+$/, '') || '/';
+  return target.pathname === '/' ? target.origin : `${target.origin}${target.pathname}`;
+}
+
+/**
+ * Only actual loopback hosts are safe by default. URL parsing canonicalizes
+ * alternative IPv4 spellings such as 127.1 before this check runs.
+ */
+export function isLoopbackTarget(normalizedTarget) {
+  const { hostname } = new URL(normalizedTarget);
+  const canonicalHost = hostname
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/\.$/, '')
+    .toLowerCase();
+
+  if (canonicalHost === 'localhost' || canonicalHost === '::1' || canonicalHost === '0:0:0:0:0:0:0:1') {
+    return true;
+  }
+
+  const octets = canonicalHost.split('.');
+  return octets.length === 4
+    && octets.every(octet => /^\d+$/.test(octet) && Number(octet) >= 0 && Number(octet) <= 255)
+    && Number(octets[0]) === 127;
+}
+
+export function expectedRemoteConfirmation(normalizedTarget) {
+  return `DESTROY ${normalizedTarget}`;
+}
+
+/**
+ * Fail closed unless the target is loopback or both remote opt-ins match
+ * exactly. Call this before any setup, authentication, or mutation.
+ */
+export function assertDestructiveTestTarget({
+  env = process.env,
+  target = env.AFFINE_BASE_URL || DEFAULT_AFFINE_TEST_URL,
+} = {}) {
+  const normalizedTarget = normalizeDestructiveTestTarget(target);
+  const loopback = isLoopbackTarget(normalizedTarget);
+  if (loopback) {
+    return { target: normalizedTarget, loopback };
+  }
+
+  const expectedConfirmation = expectedRemoteConfirmation(normalizedTarget);
+  const remoteAllowed = env[REMOTE_ALLOW_ENV] === '1';
+  const targetConfirmed = env[REMOTE_CONFIRM_ENV] === expectedConfirmation;
+  if (!remoteAllowed || !targetConfirmed) {
+    throw new Error([
+      `Refusing destructive tests against non-loopback target: ${normalizedTarget}`,
+      'Remote destructive tests can mutate or delete real AFFiNE data.',
+      `Set ${REMOTE_ALLOW_ENV}=1 and`,
+      `${REMOTE_CONFIRM_ENV}=${JSON.stringify(expectedConfirmation)}`,
+      'only after verifying that this exact target is disposable.',
+    ].join('\n'));
+  }
+
+  return { target: normalizedTarget, loopback };
+}
+
+export function announceRemoteDestructiveTestTarget(target, { runId, write = console.error } = {}) {
+  if (target.loopback) return;
+
+  write('');
+  write('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+  write('REMOTE DESTRUCTIVE TESTS EXPLICITLY ENABLED');
+  write(`Target: ${target.target}`);
+  if (runId) write(`Run ID: ${runId}`);
+  write('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+  write('');
+}
+
+export function createTestRunId({ now = Date.now(), pid = process.pid, random = randomBytes } = {}) {
+  const entropy = random(8).toString('hex');
+  return `${now.toString(36)}-${pid.toString(36)}-${entropy}`;
+}
+
+export function resolveTestRunId(env = process.env) {
+  const existing = env[TEST_RUN_ID_ENV];
+  if (existing !== undefined && !RUN_ID_PATTERN.test(existing)) {
+    throw new Error(
+      `${TEST_RUN_ID_ENV} must be 8-96 characters and contain only letters, digits, dots, underscores, or hyphens.`,
+    );
+  }
+
+  const runId = existing || createTestRunId();
+  env[TEST_RUN_ID_ENV] = runId;
+  return runId;
+}
+
+export function createResourceNamer(env = process.env) {
+  const runId = resolveTestRunId(env);
+  let sequence = 0;
+
+  return function testResourceName(prefix, maxLength = 120) {
+    const safePrefix = String(prefix)
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'affine-test';
+    sequence += 1;
+    const suffix = `${runId}-${sequence.toString(36)}`;
+    const prefixBudget = Math.max(1, maxLength - suffix.length - 1);
+    return `${safePrefix.slice(0, prefixBudget)}-${suffix}`;
+  };
+}

--- a/tests/require-destructive-test-safety.mjs
+++ b/tests/require-destructive-test-safety.mjs
@@ -1,0 +1,42 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  announceRemoteDestructiveTestTarget,
+  assertDestructiveTestTarget,
+  createResourceNamer,
+  resolveTestRunId,
+} from './live-test-safety.mjs';
+
+export const destructiveTestTarget = assertDestructiveTestTarget();
+export const testRunId = resolveTestRunId();
+export const testResourceName = createResourceNamer();
+
+const inheritedTempRoot = process.env.AFFINE_TEST_TMP_DIR;
+export const testTempRoot = inheritedTempRoot
+  ? path.resolve(inheritedTempRoot)
+  : mkdtempSync(path.join(tmpdir(), 'affine-mcp-live-test-'));
+process.env.AFFINE_TEST_TMP_DIR = testTempRoot;
+mkdirSync(testTempRoot, { recursive: true, mode: 0o700 });
+
+if (!inheritedTempRoot) {
+  chmodSync(testTempRoot, 0o700);
+  process.once('exit', () => {
+    rmSync(testTempRoot, { recursive: true, force: true });
+  });
+}
+
+export function testTempPath(label) {
+  const safeLabel = String(label)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'runtime';
+  const directory = path.join(testTempRoot, safeLabel);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  return directory;
+}
+
+announceRemoteDestructiveTestTarget(destructiveTestTarget, { runId: testRunId });

--- a/tests/run-comprehensive.sh
+++ b/tests/run-comprehensive.sh
@@ -14,7 +14,12 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DOCKER_DIR="$PROJECT_DIR/docker"
 COMPOSE_FILE="$DOCKER_DIR/docker-compose.yml"
 
-export AFFINE_BASE_URL="${AFFINE_BASE_URL:-http://localhost:3010}"
+find_free_port() {
+  node -e 'const net=require("net");const server=net.createServer();server.listen(0,"127.0.0.1",()=>{const {port}=server.address();console.log(port);server.close();});'
+}
+
+export PORT="${PORT:-$(find_free_port)}"
+export AFFINE_BASE_URL="${AFFINE_BASE_URL:-http://localhost:${PORT}}"
 export AFFINE_HEALTH_MAX_RETRIES="${AFFINE_HEALTH_MAX_RETRIES:-90}"
 export AFFINE_HEALTH_INTERVAL_MS="${AFFINE_HEALTH_INTERVAL_MS:-5000}"
 export AFFINE_HEALTH_REQUEST_TIMEOUT_MS="${AFFINE_HEALTH_REQUEST_TIMEOUT_MS:-3000}"
@@ -24,52 +29,45 @@ export AFFINE_AUTH_READY_MAX_RETRIES="${AFFINE_AUTH_READY_MAX_RETRIES:-30}"
 export AFFINE_AUTH_READY_INTERVAL_SECONDS="${AFFINE_AUTH_READY_INTERVAL_SECONDS:-3}"
 export AFFINE_DOCKER_START_RETRIES="${AFFINE_DOCKER_START_RETRIES:-3}"
 export AFFINE_DOCKER_START_RETRY_DELAY_SECONDS="${AFFINE_DOCKER_START_RETRY_DELAY_SECONDS:-3}"
-export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-/tmp/affine-mcp-comprehensive-noconfig}"
-export AFFINE_ADMIN_EMAIL="${AFFINE_ADMIN_EMAIL:-test@affine.local}"
-export AFFINE_ADMIN_PASSWORD="${AFFINE_ADMIN_PASSWORD:-comprehensivepass123}"
-export DB_USERNAME="${DB_USERNAME:-affine}"
-export DB_PASSWORD="${DB_PASSWORD:-affinecomprehensive123}"
-export DB_DATABASE="${DB_DATABASE:-affine}"
+
+# Fail before Docker setup or authentication if the selected target is unsafe.
+AFFINE_TEST_RUN_ID="$(node "$SCRIPT_DIR/assert-destructive-test-target.mjs" --print-run-id)"
+compose_run_id="$(printf '%s' "$AFFINE_TEST_RUN_ID" | tr '[:upper:].' '[:lower:]_')"
+export COMPOSE_PROJECT_NAME="affine_mcp_comprehensive_${compose_run_id}"
+AFFINE_TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/affine-mcp-comprehensive.XXXXXX")"
+export AFFINE_TEST_RUN_ID AFFINE_TEST_TMP_DIR
+export XDG_CONFIG_HOME="$AFFINE_TEST_TMP_DIR/xdg"
+
+cleanup_test_files() {
+  if [[ "${AFFINE_TEST_ENV_FILE_OWNED:-0}" == "1" && -n "${AFFINE_TEST_ENV_FILE:-}" ]]; then
+    rm -f -- "$AFFINE_TEST_ENV_FILE"
+  fi
+  rm -rf -- "$AFFINE_TEST_TMP_DIR"
+}
+trap cleanup_test_files EXIT
 
 echo "=== Generating test credentials ==="
-# shellcheck source=generate-test-env.sh
+# shellcheck source=tests/generate-test-env.sh
 . "$SCRIPT_DIR/generate-test-env.sh"
+
+compose() {
+  docker compose --env-file "$AFFINE_TEST_ENV_FILE" -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
 
 cleanup() {
   echo ""
   echo "=== Tearing down Docker containers ==="
-  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
-  force_remove_stack_artifacts
+  compose down -v --remove-orphans 2>/dev/null || true
+  cleanup_test_files
 }
 trap cleanup EXIT
 
 docker_diagnostics() {
   echo ""
   echo "=== Docker diagnostics (on failure) ==="
-  docker compose -f "$COMPOSE_FILE" ps || true
+  compose ps || true
   echo ""
-  docker compose -f "$COMPOSE_FILE" logs --no-color --tail=200 affine affine_migration postgres redis || true
-}
-
-force_remove_stack_artifacts() {
-  docker rm -f affine_test_app affine_test_migration affine_test_postgres affine_test_redis >/dev/null 2>&1 || true
-  docker volume rm docker_affine_postgres_data docker_affine_config docker_affine_storage >/dev/null 2>&1 || true
-  docker network rm docker_default >/dev/null 2>&1 || true
-}
-
-wait_for_stack_teardown() {
-  local attempt
-
-  for ((attempt = 1; attempt <= 15; attempt++)); do
-    if ! docker ps -a --format '{{.Names}}' | grep -q '^affine_test_'; then
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "[comprehensive] WARNING: AFFiNE test containers still appear to exist after teardown wait."
-  docker ps -a --format '{{.Names}}\t{{.Status}}' | grep '^affine_test_' || true
-  return 1
+  compose logs --no-color --tail=200 affine affine_migration postgres redis || true
 }
 
 wait_for_auth_ready() {
@@ -78,18 +76,20 @@ wait_for_auth_ready() {
   local sign_in_status
   local base_url="${AFFINE_BASE_URL%/}"
   local payload
-  payload=$(printf '{"email":"%s","password":"%s"}' "$AFFINE_ADMIN_EMAIL" "$AFFINE_ADMIN_PASSWORD")
+  local setup_response="$AFFINE_TEST_TMP_DIR/setup-response.txt"
+  local sign_in_response="$AFFINE_TEST_TMP_DIR/sign-in-response.txt"
+  payload="$(node -e 'process.stdout.write(JSON.stringify({email:process.env.AFFINE_ADMIN_EMAIL,password:process.env.AFFINE_ADMIN_PASSWORD}))')"
 
   for ((attempt = 1; attempt <= AFFINE_AUTH_READY_MAX_RETRIES; attempt++)); do
     setup_status="$(
-      curl -sS -o /tmp/affine-comprehensive-setup-response.txt -w "%{http_code}" \
+      curl -sS -o "$setup_response" -w "%{http_code}" \
         -H "Content-Type: application/json" \
         -X POST "$base_url/api/setup/create-admin-user" \
         -d "$payload" || true
     )"
 
     sign_in_status="$(
-      curl -sS -o /tmp/affine-comprehensive-signin-response.txt -w "%{http_code}" \
+      curl -sS -o "$sign_in_response" -w "%{http_code}" \
         -H "Content-Type: application/json" \
         -X POST "$base_url/api/auth/sign-in" \
         -d "$payload" || true
@@ -107,9 +107,9 @@ wait_for_auth_ready() {
   done
 
   echo "[comprehensive] ERROR: AFFiNE sign-in endpoint did not become ready in time"
-  if [[ -s /tmp/affine-comprehensive-signin-response.txt ]]; then
+  if [[ -s "$sign_in_response" ]]; then
     echo "[comprehensive] Last sign-in response body (first 500 bytes):"
-    head -c 500 /tmp/affine-comprehensive-signin-response.txt
+    head -c 500 "$sign_in_response"
     echo ""
   fi
   docker_diagnostics
@@ -123,7 +123,7 @@ start_docker_stack_with_retry() {
 
   for ((attempt = 1; attempt <= AFFINE_DOCKER_START_RETRIES; attempt++)); do
     set +e
-    docker compose -f "$COMPOSE_FILE" up -d
+    compose up -d
     status=$?
     set -e
     if ((status == 0)); then
@@ -133,9 +133,7 @@ start_docker_stack_with_retry() {
     exit_code=$status
     echo "[comprehensive] Docker bootstrap failed (attempt ${attempt}/${AFFINE_DOCKER_START_RETRIES}, exit ${exit_code})"
     docker_diagnostics
-    docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
-    force_remove_stack_artifacts
-    wait_for_stack_teardown || true
+    compose down -v --remove-orphans 2>/dev/null || true
 
     if ((attempt < AFFINE_DOCKER_START_RETRIES)); then
       echo "[comprehensive] Retrying Docker bootstrap in ${AFFINE_DOCKER_START_RETRY_DELAY_SECONDS}s..."
@@ -150,9 +148,7 @@ export AFFINE_EMAIL="$AFFINE_ADMIN_EMAIL"
 export AFFINE_PASSWORD="$AFFINE_ADMIN_PASSWORD"
 export AFFINE_LOGIN_AT_START="${AFFINE_LOGIN_AT_START:-sync}"
 
-docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
-force_remove_stack_artifacts
-wait_for_stack_teardown || true
+compose down -v --remove-orphans 2>/dev/null || true
 
 echo "=== Starting AFFiNE via Docker Compose ==="
 start_docker_stack_with_retry

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -25,7 +25,6 @@ find_free_port() {
 
 # --- Configuration ---
 export PORT="${PORT:-$(find_free_port)}"
-export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-affine_mcp_e2e_${PORT}_$$}"
 export AFFINE_BASE_URL="${AFFINE_BASE_URL:-http://localhost:${PORT}}"
 export AFFINE_HEALTH_MAX_RETRIES="${AFFINE_HEALTH_MAX_RETRIES:-90}"
 export AFFINE_HEALTH_INTERVAL_MS="${AFFINE_HEALTH_INTERVAL_MS:-5000}"
@@ -37,29 +36,50 @@ export AFFINE_AUTH_READY_INTERVAL_SECONDS="${AFFINE_AUTH_READY_INTERVAL_SECONDS:
 export AFFINE_DOCKER_START_RETRIES="${AFFINE_DOCKER_START_RETRIES:-3}"
 export AFFINE_DOCKER_RETRY_DELAY_SECONDS="${AFFINE_DOCKER_RETRY_DELAY_SECONDS:-5}"
 
-# Generate random credentials (writes docker/.env, exports env vars)
+# Fail before Docker setup or authentication if the selected target is unsafe.
+AFFINE_TEST_RUN_ID="$(node "$SCRIPT_DIR/assert-destructive-test-target.mjs" --print-run-id)"
+compose_run_id="$(printf '%s' "$AFFINE_TEST_RUN_ID" | tr '[:upper:].' '[:lower:]_')"
+export COMPOSE_PROJECT_NAME="affine_mcp_e2e_${compose_run_id}"
+AFFINE_TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/affine-mcp-e2e.XXXXXX")"
+export AFFINE_TEST_RUN_ID AFFINE_TEST_TMP_DIR
+export XDG_CONFIG_HOME="$AFFINE_TEST_TMP_DIR/xdg"
+
+cleanup_test_files() {
+  if [[ "${AFFINE_TEST_ENV_FILE_OWNED:-0}" == "1" && -n "${AFFINE_TEST_ENV_FILE:-}" ]]; then
+    rm -f -- "$AFFINE_TEST_ENV_FILE"
+  fi
+  rm -rf -- "$AFFINE_TEST_TMP_DIR"
+}
+trap cleanup_test_files EXIT
+
+# Generate random credentials in a private per-run env file.
 echo "=== Generating test credentials ==="
-# shellcheck source=generate-test-env.sh
+# shellcheck source=tests/generate-test-env.sh
 . "$SCRIPT_DIR/generate-test-env.sh"
+
+compose() {
+  docker compose --env-file "$AFFINE_TEST_ENV_FILE" -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
 
 # --- Cleanup on exit ---
 cleanup() {
   echo ""
   echo "=== Tearing down Docker containers ==="
-  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+  compose down -v --remove-orphans 2>/dev/null || true
+  cleanup_test_files
 }
 trap cleanup EXIT
 
 compose_container_id() {
-  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" ps -aq "$1" 2>/dev/null || true
+  compose ps -aq "$1" 2>/dev/null || true
 }
 
 docker_diagnostics() {
   echo ""
   echo "=== Docker diagnostics (on failure) ==="
-  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" ps || true
+  compose ps || true
   echo ""
-  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" logs --no-color --tail=200 affine affine_migration postgres redis || true
+  compose logs --no-color --tail=200 affine affine_migration postgres redis || true
 }
 
 docker_compose_with_retry() {
@@ -67,10 +87,10 @@ docker_compose_with_retry() {
   shift
   local attempt
   local output_file
-  output_file="$(mktemp)"
+  output_file="$(mktemp "$AFFINE_TEST_TMP_DIR/docker-compose.XXXXXX")"
 
   for ((attempt = 1; attempt <= AFFINE_DOCKER_START_RETRIES; attempt++)); do
-    if docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" "$@" >"$output_file" 2>&1; then
+    if compose "$@" >"$output_file" 2>&1; then
       cat "$output_file"
       rm -f "$output_file"
       return 0
@@ -79,7 +99,7 @@ docker_compose_with_retry() {
     echo "[e2e] ${description} failed (attempt ${attempt}/${AFFINE_DOCKER_START_RETRIES})"
     cat "$output_file"
     docker_diagnostics
-    docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+    compose down -v --remove-orphans 2>/dev/null || true
 
     if ((attempt < AFFINE_DOCKER_START_RETRIES)); then
       echo "[e2e] Retrying ${description} in ${AFFINE_DOCKER_RETRY_DELAY_SECONDS}s..."
@@ -209,18 +229,20 @@ wait_for_auth_ready() {
   local sign_in_status
   local base_url="${AFFINE_BASE_URL%/}"
   local payload
-  payload=$(printf '{"email":"%s","password":"%s"}' "$AFFINE_ADMIN_EMAIL" "$AFFINE_ADMIN_PASSWORD")
+  local setup_response="$AFFINE_TEST_TMP_DIR/setup-response.txt"
+  local sign_in_response="$AFFINE_TEST_TMP_DIR/sign-in-response.txt"
+  payload="$(node -e 'process.stdout.write(JSON.stringify({email:process.env.AFFINE_ADMIN_EMAIL,password:process.env.AFFINE_ADMIN_PASSWORD}))')"
 
   for ((attempt = 1; attempt <= AFFINE_AUTH_READY_MAX_RETRIES; attempt++)); do
     setup_status="$(
-      curl -sS -o /tmp/affine-setup-response.txt -w "%{http_code}" \
+      curl -sS -o "$setup_response" -w "%{http_code}" \
         -H "Content-Type: application/json" \
         -X POST "$base_url/api/setup/create-admin-user" \
         -d "$payload" || true
     )"
 
     sign_in_status="$(
-      curl -sS -o /tmp/affine-signin-response.txt -w "%{http_code}" \
+      curl -sS -o "$sign_in_response" -w "%{http_code}" \
         -H "Content-Type: application/json" \
         -X POST "$base_url/api/auth/sign-in" \
         -d "$payload" || true
@@ -238,9 +260,9 @@ wait_for_auth_ready() {
   done
 
   echo "[e2e] ERROR: AFFiNE sign-in endpoint did not become ready in time"
-  if [[ -s /tmp/affine-signin-response.txt ]]; then
+  if [[ -s "$sign_in_response" ]]; then
     echo "[e2e] Last sign-in response body (first 500 bytes):"
-    head -c 500 /tmp/affine-signin-response.txt
+    head -c 500 "$sign_in_response"
     echo ""
   fi
   docker_diagnostics
@@ -258,13 +280,13 @@ ensure_affine_ui_ready() {
   echo "[e2e] AFFiNE UI is not reachable before Playwright; attempting service recovery..."
   docker_diagnostics
 
-  docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" up -d --no-deps affine
+  compose up -d --no-deps affine
   acquire_credentials_with_retry
   wait_for_auth_ready
 }
 
 # --- Step 0: Clean up any stale containers from previous runs ---
-docker compose -p "$COMPOSE_PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+compose down -v --remove-orphans 2>/dev/null || true
 
 # --- Step 1: Start Docker ---
 echo "=== Starting AFFiNE via Docker Compose ==="

--- a/tests/test-bearer-auth.mjs
+++ b/tests/test-bearer-auth.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * E2E test: bearer-token authentication mode.
  *
@@ -104,7 +106,7 @@ async function main() {
     AFFINE_PASSWORD: PASSWORD,
     AFFINE_LOGIN_AT_START: 'sync',
     // Isolate from local config file — pure email/password for token generation.
-    XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+    XDG_CONFIG_HOME: testTempPath('bearer-token-generation-config'),
   }, 'pw-session');
 
   let bearerToken;
@@ -113,27 +115,41 @@ async function main() {
     // Authentication already happened at startup via AFFINE_LOGIN_AT_START=sync.
     // No explicit sign_in needed — go straight to token generation.
     const tokenResult = await call(pwClient, 'generate_access_token', {
-      name: `e2e-bearer-test-${Date.now()}`,
+      name: testResourceName('e2e-bearer-token'),
     });
     bearerToken = tokenResult?.token;
     tokenId = tokenResult?.id;
     if (!bearerToken) throw new Error('generate_access_token did not return a token');
+    if (!tokenId) throw new Error('generate_access_token did not return an id');
     console.log(`  Token ID: ${tokenId}`);
-    console.log(`  Token prefix: ${bearerToken.slice(0, 12)}...`);
-  } finally {
+  } catch (error) {
     await pwTransport.close();
+    throw error;
   }
 
   // ─── Phase 2: Use ONLY the bearer token — no email/password ───
   console.log();
   console.log('--- Phase 2: Bearer-token-only MCP session ---');
-  const { client: bearerClient, transport: bearerTransport } = await launchMCP({
-    AFFINE_BASE_URL: BASE_URL,
-    AFFINE_API_TOKEN: bearerToken,
-    // Intentionally NO AFFINE_EMAIL, NO AFFINE_PASSWORD, NO AFFINE_LOGIN_AT_START.
-    // Isolate from local config file — pure bearer token auth.
-    XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
-  }, 'bearer-session');
+  let bearerClient;
+  let bearerTransport;
+  try {
+    const launched = await launchMCP({
+      AFFINE_BASE_URL: BASE_URL,
+      AFFINE_API_TOKEN: bearerToken,
+      // Intentionally NO AFFINE_EMAIL, NO AFFINE_PASSWORD, NO AFFINE_LOGIN_AT_START.
+      // Isolate from local config file — pure bearer token auth.
+      XDG_CONFIG_HOME: testTempPath('bearer-session-config'),
+    }, 'bearer-session');
+    bearerClient = launched.client;
+    bearerTransport = launched.transport;
+  } catch (error) {
+    try {
+      await call(pwClient, 'revoke_access_token', { id: tokenId });
+    } finally {
+      await pwTransport.close();
+    }
+    throw error;
+  }
 
   const state = {
     baseUrl: BASE_URL,
@@ -156,7 +172,7 @@ async function main() {
     console.log(`  Authenticated as: ${user.email}`);
 
     // Create workspace
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     state.workspaceName = `bearer-db-test-${timestamp}`;
     const ws = await call(bearerClient, 'create_workspace', { name: state.workspaceName });
     state.workspaceId = ws?.id;
@@ -265,9 +281,17 @@ async function main() {
     console.error();
     console.error(`FAILED: ${err.message}`);
     fs.writeFileSync(STATE_OUTPUT_PATH, JSON.stringify({ ...state, error: err.message }, null, 2));
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
-    await bearerTransport.close();
+    try {
+      await bearerTransport.close();
+    } finally {
+      try {
+        await call(pwClient, 'revoke_access_token', { id: tokenId });
+      } finally {
+        await pwTransport.close();
+      }
+    }
   }
 }
 

--- a/tests/test-canvas-tool-map-demo.mjs
+++ b/tests/test-canvas-tool-map-demo.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * End-to-end regression guard for layout helpers: stackAfter (single + array form),
  * childElementIds frame ownership, y-omitted auto-stack-below, connector auto-snap,
@@ -20,7 +22,7 @@ if (!BASE || !EMAIL || !PASSWORD) {
   console.error("Set AFFINE_BASE_URL, AFFINE_ADMIN_EMAIL, AFFINE_ADMIN_PASSWORD first.");
   console.error("Typical flow (from repo root):");
   console.error("  . tests/generate-test-env.sh");
-  console.error("  docker compose -f docker/docker-compose.yml up -d");
+  console.error('  docker compose --env-file "$AFFINE_TEST_ENV_FILE" -p "affine_mcp_manual_$$" -f docker/docker-compose.yml up -d');
   console.error("  node tests/acquire-credentials.mjs");
   console.error("  node tests/test-canvas-tool-map-demo.mjs");
   process.exit(1);
@@ -36,7 +38,7 @@ const transport = new StdioClientTransport({
     AFFINE_EMAIL: EMAIL,
     AFFINE_PASSWORD: PASSWORD,
     AFFINE_LOGIN_AT_START: "sync",
-    XDG_CONFIG_HOME: "/tmp/affine-mcp-tool-map-example",
+    XDG_CONFIG_HOME: testTempPath('tool-map-config'),
   },
   stderr: "pipe",
 });
@@ -58,7 +60,7 @@ async function call(name, args = {}) {
 
 await client.connect(transport);
 try {
-  const ws = await call("create_workspace", { name: `affine-mcp-tool-map-${Date.now()}` });
+  const ws = await call("create_workspace", { name: testResourceName('affine-mcp-tool-map') });
   const docId = (await call("create_doc", { workspaceId: ws.id, title: "AFFiNE MCP Server — Tool Map" })).docId;
   const W = ws.id;
   const D = docId;

--- a/tests/test-capabilities-fidelity.mjs
+++ b/tests/test-capabilities-fidelity.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for capability negotiation and fidelity reporting.
  *
@@ -66,7 +68,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-capabilities-fidelity-noconfig',
+      XDG_CONFIG_HOME: testTempPath('capabilities-fidelity-config'),
     },
     stderr: 'pipe',
   });
@@ -112,7 +114,7 @@ async function main() {
     expectEqual(capabilities?.workspace?.workspaceBlueprints, true, 'workspaceBlueprints flag');
     expectEqual(capabilities?.collaboration?.replyCreation, false, 'replyCreation flag');
 
-    const workspace = await call('create_workspace', { name: `cap-fidelity-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('cap-fidelity') });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace id');
 

--- a/tests/test-cli-live.mjs
+++ b/tests/test-cli-live.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Live CLI integration test against a running AFFiNE instance.
  *
@@ -55,23 +57,67 @@ async function generateAccessToken() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-cli-live-token",
+      XDG_CONFIG_HOME: testTempPath('cli-live-token-config'),
     },
   });
 
   await client.connect(transport);
+  let workspaceId;
+  let tokenId;
+  const cleanupTool = async (name, args) => {
+    const result = await client.callTool({ name, arguments: args });
+    if (result?.isError) throw new Error(`${name} failed: ${result.content?.[0]?.text || 'unknown error'}`);
+    const parsed = JSON.parse(result.content?.[0]?.text || '{}');
+    if (parsed?.error || parsed?.success !== true) {
+      throw new Error(`${name} cleanup failed: ${parsed?.error || 'success was not true'}`);
+    }
+  };
   try {
-    const workspace = JSON.parse((await client.callTool({
+    const workspaceResult = await client.callTool({
       name: "create_workspace",
-      arguments: { name: `cli-live-${Date.now()}` },
-    })).content[0].text);
-    const token = JSON.parse((await client.callTool({
+      arguments: { name: testResourceName('cli-live') },
+    });
+    if (workspaceResult?.isError) throw new Error(workspaceResult.content?.[0]?.text || 'create_workspace failed');
+    const workspace = JSON.parse(workspaceResult.content[0].text);
+    workspaceId = workspace.id;
+    expect(workspaceId, 'create_workspace did not return an id');
+
+    const tokenResult = await client.callTool({
       name: "generate_access_token",
-      arguments: { name: `cli-live-token-${Date.now()}` },
-    })).content[0].text).token;
-    return { token, workspaceId: workspace.id };
-  } finally {
-    await transport.close();
+      arguments: { name: testResourceName('cli-live-token') },
+    });
+    if (tokenResult?.isError) throw new Error(tokenResult.content?.[0]?.text || 'generate_access_token failed');
+    const tokenPayload = JSON.parse(tokenResult.content[0].text);
+    tokenId = tokenPayload.id;
+    expect(tokenPayload.token, 'generate_access_token did not return a token');
+    expect(tokenId, 'generate_access_token did not return an id');
+
+    return {
+      token: tokenPayload.token,
+      workspaceId,
+      async cleanup() {
+        try {
+          await cleanupTool('delete_workspace', { id: workspaceId });
+        } finally {
+          try {
+            await cleanupTool('revoke_access_token', { id: tokenId });
+          } finally {
+            await transport.close();
+          }
+        }
+      },
+    };
+  } catch (error) {
+    try {
+      if (workspaceId) await cleanupTool('delete_workspace', { id: workspaceId });
+    } finally {
+      try {
+        if (tokenId) await cleanupTool('revoke_access_token', { id: tokenId });
+      } finally {
+        await transport.close();
+      }
+    }
+    throw error;
   }
 }
 
@@ -79,8 +125,10 @@ const tempDir = mkdtempSync(path.join(os.tmpdir(), "affine-mcp-cli-live-"));
 const xdgConfigHome = path.join(tempDir, "config-home");
 mkdirSync(xdgConfigHome, { recursive: true });
 
+let remoteArtifacts;
 try {
-  const { token, workspaceId } = await generateAccessToken();
+  remoteArtifacts = await generateAccessToken();
+  const { token, workspaceId } = remoteArtifacts;
 
   const login = runCli("login", [
     "login",
@@ -123,5 +171,9 @@ try {
     ],
   }, null, 2));
 } finally {
-  rmSync(tempDir, { recursive: true, force: true });
+  try {
+    if (remoteArtifacts) await remoteArtifacts.cleanup();
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 }

--- a/tests/test-create-doc-folder-placement.mjs
+++ b/tests/test-create-doc-folder-placement.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for create_doc folder placement.
  *
@@ -73,7 +75,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-create-doc-folder-placement-noconfig',
+      XDG_CONFIG_HOME: testTempPath('create-doc-folder-placement-config'),
     },
     stderr: 'pipe',
   });
@@ -100,7 +102,7 @@ async function main() {
   let workspaceId;
   try {
     console.log('\n[1] Create workspace');
-    const workspace = await call('create_workspace', { name: `folder-placement-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('folder-placement') });
     workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'workspace id');
 
@@ -121,7 +123,7 @@ async function main() {
     expectEqual(baz.warnings.length, 0, 'create_doc warning count');
 
     console.log('\n[4] Create doc with missing folderId');
-    const missingFolderId = `missing-folder-${Date.now()}`;
+    const missingFolderId = testResourceName('missing-folder');
     const unplaced = await call('create_doc', {
       workspaceId,
       title: 'not placed',

--- a/tests/test-create-placement.mjs
+++ b/tests/test-create-placement.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for placement-first document creation.
  *
@@ -91,7 +93,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-create-placement-noconfig",
+      XDG_CONFIG_HOME: testTempPath('create-placement-config'),
     },
     stderr: "pipe",
   });
@@ -138,7 +140,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `create-placement-${timestamp}` });
     expectTruthy(workspace?.id, "create_workspace id");
     expectTruthy(workspace?.firstDocId, "create_workspace firstDocId");

--- a/tests/test-data-view.mjs
+++ b/tests/test-data-view.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for preset-backed data_view creation.
  *
@@ -61,7 +63,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('data-view-config'),
     },
     stderr: 'pipe',
   });
@@ -103,7 +105,7 @@ async function main() {
   };
 
   try {
-    const workspace = await call('create_workspace', { name: `data-view-test-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('data-view-test') });
     state.workspaceId = workspace?.id;
     if (!state.workspaceId) throw new Error('create_workspace did not return workspace id');
 

--- a/tests/test-database-cells.mjs
+++ b/tests/test-database-cells.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Comprehensive live integration test for issue #50.
  *
@@ -90,7 +92,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-cells-config'),
     },
     stderr: 'pipe',
   });
@@ -164,7 +166,7 @@ async function main() {
       }
     }
 
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     state.workspaceName = `db-cells-test-${timestamp}`;
     state.docTitle = 'Database Cell Test';
 

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * E2E test: EMAIL/PASSWORD auth mode.
  *
@@ -54,7 +56,7 @@ async function main() {
       AFFINE_LOGIN_AT_START: 'sync',
       // Isolate from local config file (~/.config/affine-mcp/config) which may
       // contain an API token — we want pure email/password auth for this test.
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-creation-config'),
     },
     stderr: 'pipe',
   });
@@ -130,7 +132,7 @@ async function main() {
     // auto-login path, not the sign_in MCP tool.
 
     // 1. Create workspace
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     state.workspaceName = `mcp-db-test-${timestamp}`;
     const ws = await call('create_workspace', { name: state.workspaceName });
     state.workspaceId = ws?.id;

--- a/tests/test-database-intent.mjs
+++ b/tests/test-database-intent.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for intent-driven database composition.
  *
@@ -76,7 +78,7 @@ async function main() {
     env: {
       AFFINE_BASE_URL: BASE_URL,
       AFFINE_COOKIE: auth.cookie,
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-database-intent-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-intent-config'),
     },
     stderr: 'pipe',
   });
@@ -187,7 +189,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const workspace = await call('create_workspace', { name: `database-intent-test-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('database-intent-test') });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace id');
 

--- a/tests/test-database-linked-doc.mjs
+++ b/tests/test-database-linked-doc.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for database row linked-doc support.
  *
@@ -65,7 +67,7 @@ async function main() {
       AFFINE_LOGIN_AT_START: 'sync',
       // Isolate from local config file (~/.config/affine-mcp/config) which may
       // contain an API token — we want pure email/password auth for this test.
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-linked-doc-config'),
     },
     stderr: 'pipe',
   });
@@ -97,15 +99,11 @@ async function main() {
     await client.connect(transport);
     console.log('MCP client connected.\n');
 
-    // --- Setup: get workspace ---
-    console.log('[Setup] Finding workspace...');
-    const workspaces = await call('list_workspaces');
-    workspaceId = workspaces[0]?.id;
-    if (!workspaceId) {
-      const workspace = await call('create_workspace', { name: `linked-doc-test-${Date.now()}` });
-      workspaceId = workspace?.id;
-    }
-    if (!workspaceId) throw new Error('No workspace available');
+    // --- Setup: create a dedicated disposable workspace ---
+    console.log('[Setup] Creating workspace...');
+    const workspace = await call('create_workspace', { name: testResourceName('linked-doc-test') });
+    workspaceId = workspace?.id;
+    if (!workspaceId) throw new Error('create_workspace did not return an id');
     console.log(`  Workspace: ${workspaceId}\n`);
 
     // --- Setup: create host doc with a database ---
@@ -258,6 +256,7 @@ async function main() {
     try {
       if (hostDocId) await call('delete_doc', { workspaceId, docId: hostDocId }).catch(() => {});
       if (targetDocId) await call('delete_doc', { workspaceId, docId: targetDocId }).catch(() => {});
+      if (workspaceId) await call('delete_workspace', { id: workspaceId }).catch(() => {});
     } catch { /* best effort */ }
     await client.close();
   }

--- a/tests/test-database-schema.mjs
+++ b/tests/test-database-schema.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for database schema discovery on empty databases.
  *
@@ -58,7 +60,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-schema-config'),
     },
     stderr: 'pipe',
   });
@@ -95,7 +97,7 @@ async function main() {
       throw new Error('Expected tool "read_database_columns" to be registered');
     }
 
-    const workspace = await call('create_workspace', { name: `db-schema-test-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('db-schema-test') });
     const workspaceId = workspace?.id;
     if (!workspaceId) throw new Error('create_workspace did not return workspace id');
 

--- a/tests/test-database-ui-rows.mjs
+++ b/tests/test-database-ui-rows.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Live regression test for UI-created database rows.
  *
@@ -72,7 +74,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-noconfig',
+      XDG_CONFIG_HOME: testTempPath('database-ui-rows-config'),
     },
     stderr: 'pipe',
   });
@@ -100,7 +102,7 @@ async function main() {
     await client.connect(transport);
     console.log('MCP client connected.\n');
 
-    const workspace = await call('create_workspace', { name: `db-ui-rows-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('db-ui-rows') });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace did not return workspace id');
 

--- a/tests/test-doc-discovery.mjs
+++ b/tests/test-doc-discovery.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for document discovery helpers.
  *
@@ -69,7 +71,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-doc-discovery-noconfig",
+      XDG_CONFIG_HOME: testTempPath('doc-discovery-config'),
     },
     stderr: "pipe",
   });
@@ -116,7 +118,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `doc-discovery-${timestamp}` });
     expectTruthy(workspace?.id, "create_workspace id");
 

--- a/tests/test-doc-properties.mjs
+++ b/tests/test-doc-properties.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for document custom-property tools.
  *
@@ -66,7 +68,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-doc-properties-noconfig",
+      XDG_CONFIG_HOME: testTempPath('doc-properties-config'),
     },
     stderr: "pipe",
   });
@@ -131,7 +133,7 @@ async function main() {
   let docId;
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `doc-properties-${timestamp}` });
     expectTruthy(workspace?.id, "create_workspace id");
     workspaceId = workspace.id;

--- a/tests/test-edgeless-canvas-cookbook.mjs
+++ b/tests/test-edgeless-canvas-cookbook.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /** Executes the auth-flow scene from docs/edgeless-canvas-cookbook.md end-to-end
  *  and asserts the cookbook's claims: connector auto-snap + labelXYWH seeding,
  *  frame auto-size via childElementIds, update_frame_children (resizeToFit true/false),
@@ -19,7 +21,7 @@ if (!BASE || !EMAIL || !PASSWORD) {
   console.error("Set AFFINE_BASE_URL, AFFINE_ADMIN_EMAIL, AFFINE_ADMIN_PASSWORD first.");
   console.error("Typical flow (from repo root):");
   console.error("  . tests/generate-test-env.sh");
-  console.error("  docker compose -f docker/docker-compose.yml up -d");
+  console.error('  docker compose --env-file "$AFFINE_TEST_ENV_FILE" -p "affine_mcp_manual_$$" -f docker/docker-compose.yml up -d');
   console.error("  node tests/acquire-credentials.mjs");
   console.error("  node tests/test-edgeless-canvas-cookbook.mjs");
   process.exit(1);
@@ -35,7 +37,7 @@ const transport = new StdioClientTransport({
     AFFINE_EMAIL: EMAIL,
     AFFINE_PASSWORD: PASSWORD,
     AFFINE_LOGIN_AT_START: "sync",
-    XDG_CONFIG_HOME: "/tmp/affine-mcp-cookbook-auth-flow",
+    XDG_CONFIG_HOME: testTempPath('cookbook-auth-flow-config'),
   },
   stderr: "pipe",
 });
@@ -60,7 +62,7 @@ const expect = (cond, msg) => { if (!cond) throw new Error(`ASSERTION FAILED: ${
 await client.connect(transport);
 try {
   // ────────────── §1 Fresh doc ──────────────
-  const ws = await call("create_workspace", { name: `affine-mcp-cookbook-${Date.now()}` });
+  const ws = await call("create_workspace", { name: testResourceName('affine-mcp-cookbook') });
   const W = ws.id;
   const { docId: D } = await call("create_doc", {
     workspaceId: W,

--- a/tests/test-edgeless-canvas-setup.mjs
+++ b/tests/test-edgeless-canvas-setup.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /** Seeds a clean, centered edgeless-canvas layout via stackAfter/childElementIds
  *  wherever the tool supports them, and asserts the default-note xywh +
  *  connector labelXYWH + frame ownership invariants at the CRDT level. Writes
@@ -41,7 +43,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-edgeless-setup-noconfig",
+      XDG_CONFIG_HOME: testTempPath('edgeless-setup-config'),
     },
     stderr: "pipe",
   });
@@ -55,7 +57,7 @@ async function main() {
 
   await client.connect(transport);
   try {
-    const workspace = await call("create_workspace", { name: `edgeless-canvas-${Date.now()}` });
+    const workspace = await call("create_workspace", { name: testResourceName('edgeless-canvas') });
     const doc = await call("create_doc", { workspaceId: workspace.id, title: "Edgeless Canvas Verify" });
     const W = workspace.id, D = doc.docId;
 

--- a/tests/test-find-doc-by-title.mjs
+++ b/tests/test-find-doc-by-title.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for find_doc_by_title.
  *
@@ -53,7 +55,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-find-doc-by-title-noconfig",
+      XDG_CONFIG_HOME: testTempPath('find-doc-by-title-config'),
     },
   });
   const client = new Client({ name: "find-doc-by-title-test", version: "0.0.1" }, { capabilities: {} });
@@ -86,7 +88,7 @@ async function main() {
 
   let workspace;
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     workspace = await call("create_workspace", { name: `find-doc-by-title-${timestamp}` });
     if (!workspace?.id) throw new Error("create_workspace did not return an id");
     console.log(`  workspace created: ${workspace.id}`);

--- a/tests/test-http-bearer.mjs
+++ b/tests/test-http-bearer.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for HTTP bearer-token protection on /mcp.
  *
@@ -90,7 +92,7 @@ async function generateAffineApiToken() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-http-bearer-token-noconfig",
+      XDG_CONFIG_HOME: testTempPath('http-bearer-token-config'),
     },
     stderr: "pipe",
   });
@@ -102,15 +104,37 @@ async function generateAffineApiToken() {
   await client.connect(transport);
   try {
     const tokenResult = await client.callTool(
-      { name: "generate_access_token", arguments: { name: `http-bearer-${Date.now()}` } },
+      { name: "generate_access_token", arguments: { name: testResourceName('http-bearer') } },
       undefined,
       { timeout: TOOL_TIMEOUT_MS },
     );
     const parsed = parseContent(tokenResult);
     expectTruthy(parsed?.token, "generate_access_token token");
-    return parsed.token;
-  } finally {
+    expectTruthy(parsed?.id, "generate_access_token id");
+    return {
+      token: parsed.token,
+      async cleanup() {
+        try {
+          const result = await client.callTool(
+            { name: "revoke_access_token", arguments: { id: parsed.id } },
+            undefined,
+            { timeout: TOOL_TIMEOUT_MS },
+          );
+          if (result?.isError) {
+            throw new Error(`revoke_access_token failed: ${result.content?.[0]?.text || 'unknown error'}`);
+          }
+          const revoked = parseContent(result);
+          if (revoked?.error || revoked?.success !== true) {
+            throw new Error(`revoke_access_token cleanup failed: ${revoked?.error || 'success was not true'}`);
+          }
+        } finally {
+          await transport.close();
+        }
+      },
+    };
+  } catch (error) {
     await transport.close();
+    throw error;
   }
 }
 
@@ -128,7 +152,7 @@ async function startBearerHttpServer(affineApiToken, staticToken) {
       AFFINE_MCP_AUTH_MODE: "bearer",
       AFFINE_MCP_HTTP_HOST: "127.0.0.1",
       AFFINE_MCP_HTTP_TOKEN: staticToken,
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-http-bearer-server-noconfig",
+      XDG_CONFIG_HOME: testTempPath('http-bearer-server-config'),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -154,11 +178,12 @@ async function main() {
   console.log(`AFFiNE Base URL: ${BASE_URL}`);
   console.log();
 
-  const affineApiToken = await generateAffineApiToken();
-  const staticToken = `http-bearer-${Date.now()}`;
-  const server = await startBearerHttpServer(affineApiToken, staticToken);
+  const affineCredential = await generateAffineApiToken();
+  const staticToken = testResourceName('http-bearer-static');
+  let server;
 
   try {
+    server = await startBearerHttpServer(affineCredential.token, staticToken);
     const healthz = await fetch(`${server.publicBaseUrl}/healthz`);
     expectEqual(healthz.status, 200, "healthz status");
     const readyz = await fetch(`${server.publicBaseUrl}/readyz`);
@@ -222,7 +247,11 @@ async function main() {
     console.log();
     console.log("=== HTTP bearer integration test passed ===");
   } finally {
-    await server.close();
+    try {
+      if (server) await server.close();
+    } finally {
+      await affineCredential.cleanup();
+    }
   }
 }
 

--- a/tests/test-http-email-password.mjs
+++ b/tests/test-http-email-password.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for HTTP transport using AFFiNE email/password auth.
  *
@@ -83,7 +85,7 @@ async function startEmailPasswordHttpServer() {
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
       AFFINE_MCP_HTTP_HOST: "127.0.0.1",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-http-email-password-server-noconfig",
+      XDG_CONFIG_HOME: testTempPath('http-email-password-server-config'),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/tests/test-icons.mjs
+++ b/tests/test-icons.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for the explorer-icon tools.
  *
@@ -84,7 +86,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-icons-noconfig",
+      XDG_CONFIG_HOME: testTempPath('icons-config'),
     },
     stderr: "pipe",
   });
@@ -135,7 +137,7 @@ async function main() {
   let folderId;
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `icons-${timestamp}` });
     expectTruthy(workspace?.id, "create_workspace id");
     workspaceId = workspace.id;

--- a/tests/test-live-test-safety.mjs
+++ b/tests/test-live-test-safety.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  announceRemoteDestructiveTestTarget,
+  assertDestructiveTestTarget,
+  createResourceNamer,
+  createTestRunId,
+  expectedRemoteConfirmation,
+  isLoopbackTarget,
+  normalizeDestructiveTestTarget,
+  resolveTestRunId,
+} from './live-test-safety.mjs';
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(testDirectory, '..');
+
+const remoteTarget = 'https://affine.example.test/sandbox';
+const confirmation = expectedRemoteConfirmation(remoteTarget);
+
+assert.equal(normalizeDestructiveTestTarget('http://LOCALHOST:3010/'), 'http://localhost:3010');
+assert.equal(normalizeDestructiveTestTarget('https://affine.example.test/sandbox/'), remoteTarget);
+assert.equal(isLoopbackTarget('http://localhost:3010'), true);
+assert.equal(isLoopbackTarget('http://127.1:3010'), true);
+assert.equal(isLoopbackTarget('http://[::1]:3010'), true);
+assert.equal(isLoopbackTarget('https://localhost.example.test'), false);
+
+assert.deepEqual(
+  assertDestructiveTestTarget({ env: {}, target: 'http://127.0.0.9:3010' }),
+  { target: 'http://127.0.0.9:3010', loopback: true },
+);
+
+assert.throws(
+  () => assertDestructiveTestTarget({ env: {}, target: remoteTarget }),
+  /Refusing destructive tests against non-loopback target/,
+);
+assert.throws(
+  () => assertDestructiveTestTarget({
+    env: { AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS: 'true' },
+    target: remoteTarget,
+  }),
+  /AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS=1/,
+);
+assert.throws(
+  () => assertDestructiveTestTarget({
+    env: {
+      AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS: '1',
+      AFFINE_REMOTE_DESTRUCTIVE_TEST_CONFIRM: 'DESTROY https://another.example.test',
+    },
+    target: remoteTarget,
+  }),
+  /AFFINE_REMOTE_DESTRUCTIVE_TEST_CONFIRM/,
+);
+assert.deepEqual(
+  assertDestructiveTestTarget({
+    env: {
+      AFFINE_ALLOW_REMOTE_DESTRUCTIVE_TESTS: '1',
+      AFFINE_REMOTE_DESTRUCTIVE_TEST_CONFIRM: confirmation,
+    },
+    target: remoteTarget,
+  }),
+  { target: remoteTarget, loopback: false },
+);
+
+const warningLines = [];
+announceRemoteDestructiveTestTarget(
+  { target: remoteTarget, loopback: false },
+  { runId: 'ci-run-12345678', write: line => warningLines.push(line) },
+);
+assert.match(warningLines.join('\n'), /REMOTE DESTRUCTIVE TESTS EXPLICITLY ENABLED/);
+assert.match(warningLines.join('\n'), /Target: https:\/\/affine\.example\.test\/sandbox/);
+
+assert.throws(() => normalizeDestructiveTestTarget('file:///tmp/affine'), /http or https/);
+assert.throws(() => normalizeDestructiveTestTarget('https://user:secret@example.test'), /embedded credentials/);
+assert.throws(() => normalizeDestructiveTestTarget('https://example.test/?target=prod'), /query string or fragment/);
+
+const deterministicRunId = createTestRunId({
+  now: 1_700_000_000_000,
+  pid: 42,
+  random: size => Buffer.alloc(size, 0xab),
+});
+assert.equal(deterministicRunId, 'loyw3v28-16-abababababababab');
+
+const env = { AFFINE_TEST_RUN_ID: 'ci-run-12345678' };
+assert.equal(resolveTestRunId(env), 'ci-run-12345678');
+const resourceName = createResourceNamer(env);
+const firstName = resourceName('Workspace Safety');
+const secondName = resourceName('Workspace Safety');
+assert.match(firstName, /^workspace-safety-ci-run-12345678-1$/);
+assert.match(secondName, /^workspace-safety-ci-run-12345678-2$/);
+assert.notEqual(firstName, secondName);
+assert.throws(
+  () => resolveTestRunId({ AFFINE_TEST_RUN_ID: '../../unsafe' }),
+  /AFFINE_TEST_RUN_ID must be 8-96 characters/,
+);
+
+const mutationPattern = /\b(create_workspace|delete_workspace|create_doc|delete_doc|generate_access_token|append_block|update_profile|ensureAdminUser)\b/;
+const staticOnlyFiles = new Set(['test-tool-filtering.mjs']);
+const liveTestFiles = fs.readdirSync(testDirectory)
+  .filter(name => name.endsWith('.mjs'))
+  .filter(name => !staticOnlyFiles.has(name))
+  .map(name => path.join(testDirectory, name));
+liveTestFiles.push(
+  path.join(repositoryRoot, 'test-comprehensive.mjs'),
+  path.join(repositoryRoot, 'scripts', 'test-append-block-expansion.mjs'),
+);
+
+for (const filePath of liveTestFiles) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const mutationPosition = source.search(mutationPattern);
+  if (mutationPosition < 0) continue;
+  const guardPosition = source.search(/(?:require-destructive-test-safety|assertDestructiveTestTarget)/);
+  const relativePath = path.relative(repositoryRoot, filePath);
+  assert.ok(guardPosition >= 0, `${relativePath} must load the destructive-test safety guard`);
+  assert.ok(guardPosition < mutationPosition, `${relativePath} must load the guard before mutation code`);
+}
+
+for (const runner of ['run-e2e.sh', 'run-comprehensive.sh']) {
+  const source = fs.readFileSync(path.join(testDirectory, runner), 'utf8');
+  const guardPosition = source.indexOf('assert-destructive-test-target.mjs');
+  const credentialPosition = source.indexOf('. "$SCRIPT_DIR/generate-test-env.sh"');
+  const composePosition = source.indexOf('compose down');
+  assert.ok(guardPosition >= 0, `${runner} must invoke the safety guard`);
+  assert.ok(credentialPosition > guardPosition, `${runner} must guard before generating credentials`);
+  assert.ok(composePosition > guardPosition, `${runner} must guard before Docker cleanup`);
+}
+
+const generatedEnv = spawnSync(
+  'bash',
+  ['-c', '. tests/generate-test-env.sh >/dev/null; printf "%s" "$AFFINE_TEST_ENV_FILE"'],
+  {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      AFFINE_TEST_ENV_FILE: '',
+      AFFINE_ADMIN_PASSWORD: 'p"ass\\word\nline$VALUE${OTHER}$$end',
+      DB_PASSWORD: 'db"pass\\word$VALUE${OTHER}$$end',
+    },
+  },
+);
+assert.equal(generatedEnv.status, 0, generatedEnv.stderr);
+const generatedEnvPath = generatedEnv.stdout;
+try {
+  const mode = fs.statSync(generatedEnvPath).mode & 0o777;
+  assert.equal(mode, 0o600, 'generated credential env file must be mode 0600');
+  const contents = fs.readFileSync(generatedEnvPath, 'utf8');
+  assert.match(contents, /AFFINE_ADMIN_PASSWORD="p\\"ass\\\\word\\nline\$\$VALUE\$\$\{OTHER\}\$\$\$\$end"/);
+  assert.match(contents, /DB_PASSWORD="db\\"pass\\\\word\$\$VALUE\$\$\{OTHER\}\$\$\$\$end"/);
+} finally {
+  fs.rmSync(generatedEnvPath, { force: true });
+}
+
+console.log('Live destructive-test safety checks passed');

--- a/tests/test-markdown-rich-text-import.mjs
+++ b/tests/test-markdown-rich-text-import.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -197,7 +199,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-markdown-richtext",
+      XDG_CONFIG_HOME: testTempPath('markdown-richtext-config'),
     },
     stderr: "pipe",
   });
@@ -217,7 +219,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const workspace = await call("create_workspace", { name: `markdown-richtext-${Date.now()}` });
+    const workspace = await call("create_workspace", { name: testResourceName('markdown-richtext') });
     const workspaceId = workspace?.id;
     expect(workspaceId, "create_workspace did not return id");
 

--- a/tests/test-native-template-instantiation.mjs
+++ b/tests/test-native-template-instantiation.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for native template instantiation.
  *
@@ -67,7 +69,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-native-template-noconfig',
+      XDG_CONFIG_HOME: testTempPath('native-template-config'),
     },
     stderr: 'pipe',
   });
@@ -97,7 +99,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const workspace = await call('create_workspace', { name: `native-template-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('native-template') });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace id');
 

--- a/tests/test-oauth-http.mjs
+++ b/tests/test-oauth-http.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for optional OAuth mode on the HTTP MCP server.
  *
@@ -99,7 +101,7 @@ async function generateAffineApiToken() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-oauth-http-token-noconfig",
+      XDG_CONFIG_HOME: testTempPath('oauth-http-token-config'),
     },
     stderr: "pipe",
   });
@@ -111,7 +113,7 @@ async function generateAffineApiToken() {
   await client.connect(transport);
   try {
     const tokenResult = await client.callTool(
-      { name: "generate_access_token", arguments: { name: `oauth-http-${Date.now()}` } },
+      { name: "generate_access_token", arguments: { name: testResourceName('oauth-http') } },
       undefined,
       { timeout: TOOL_TIMEOUT_MS },
     );
@@ -120,9 +122,31 @@ async function generateAffineApiToken() {
     }
     const parsed = parseContent(tokenResult);
     expectTruthy(parsed?.token, "generate_access_token token");
-    return parsed.token;
-  } finally {
+    expectTruthy(parsed?.id, "generate_access_token id");
+    return {
+      token: parsed.token,
+      async cleanup() {
+        try {
+          const result = await client.callTool(
+            { name: "revoke_access_token", arguments: { id: parsed.id } },
+            undefined,
+            { timeout: TOOL_TIMEOUT_MS },
+          );
+          if (result?.isError) {
+            throw new Error(`revoke_access_token failed: ${result.content?.[0]?.text || 'unknown error'}`);
+          }
+          const revoked = parseContent(result);
+          if (revoked?.error || revoked?.success !== true) {
+            throw new Error(`revoke_access_token cleanup failed: ${revoked?.error || 'success was not true'}`);
+          }
+        } finally {
+          await transport.close();
+        }
+      },
+    };
+  } catch (error) {
     await transport.close();
+    throw error;
   }
 }
 
@@ -215,7 +239,7 @@ async function startOAuthHttpServer(affineApiToken, issuerBaseUrl) {
       AFFINE_MCP_PUBLIC_BASE_URL: publicBaseUrl,
       AFFINE_OAUTH_ISSUER_URL: issuerBaseUrl,
       AFFINE_OAUTH_SCOPES: "mcp",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-oauth-http-server-noconfig",
+      XDG_CONFIG_HOME: testTempPath('oauth-http-server-config'),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -241,12 +265,13 @@ async function main() {
   console.log(`AFFiNE Base URL: ${BASE_URL}`);
   console.log();
 
-  const affineApiToken = await generateAffineApiToken();
-  const issuer = await startMockIssuer();
+  const affineCredential = await generateAffineApiToken();
+  let issuer = null;
   let server = null;
 
   try {
-    server = await startOAuthHttpServer(affineApiToken, issuer.issuerBaseUrl);
+    issuer = await startMockIssuer();
+    server = await startOAuthHttpServer(affineCredential.token, issuer.issuerBaseUrl);
     issuer.setAudienceBase(server.publicBaseUrl);
 
     const healthz = await fetch(`${server.publicBaseUrl}/healthz`);
@@ -347,10 +372,15 @@ async function main() {
     console.log();
     console.log("=== OAuth HTTP integration test passed ===");
   } finally {
-    if (server) {
-      await server.close();
+    try {
+      if (server) await server.close();
+    } finally {
+      try {
+        if (issuer) await issuer.close();
+      } finally {
+        await affineCredential.cleanup();
+      }
     }
-    await issuer.close();
   }
 }
 

--- a/tests/test-organize-tools.mjs
+++ b/tests/test-organize-tools.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Integration test for sidebar-oriented tooling:
  * - collection CRUD / allow-list updates
@@ -63,7 +65,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-organize-tools-noconfig',
+      XDG_CONFIG_HOME: testTempPath('organize-tools-config'),
     },
     stderr: 'pipe',
   });
@@ -96,7 +98,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call('create_workspace', { name: `organize-tools-${timestamp}` });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace id');

--- a/tests/test-read-doc-linked-refs.mjs
+++ b/tests/test-read-doc-linked-refs.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for read_doc inline LinkedPage references.
  *
@@ -119,7 +121,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-read-doc-linked-refs-noconfig",
+      XDG_CONFIG_HOME: testTempPath('read-doc-linked-refs-config'),
     },
     stderr: "pipe",
   });
@@ -169,7 +171,7 @@ async function main() {
   try {
     await client.connect(transport);
 
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `linked-ref-read-doc-${timestamp}` });
     workspaceId = workspace?.id;
     expectTruthy(workspaceId, "workspace id");

--- a/tests/test-semantic-page-composer.mjs
+++ b/tests/test-semantic-page-composer.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -78,7 +80,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-semantic-page",
+      XDG_CONFIG_HOME: testTempPath('semantic-page-config'),
     },
     stderr: "pipe",
   });
@@ -107,7 +109,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const workspace = await call("create_workspace", { name: `semantic-page-${Date.now()}` });
+    const workspace = await call("create_workspace", { name: testResourceName('semantic-page') });
     expectTruthy(workspace?.id, "create_workspace id");
 
     const parent = await call("create_doc", {

--- a/tests/test-stack-after-directions.mjs
+++ b/tests/test-stack-after-directions.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /** End-to-end test for `stackAfter` in all four directions: asserts the stack axis
  *  advances correctly with gap ≥ caller-provided, and the orthogonal axis stays
  *  centered on the anchor's center. */
@@ -29,7 +31,7 @@ const transport = new StdioClientTransport({
     AFFINE_EMAIL: EMAIL,
     AFFINE_PASSWORD: PASSWORD,
     AFFINE_LOGIN_AT_START: "sync",
-    XDG_CONFIG_HOME: "/tmp/affine-mcp-stack-after-directions",
+    XDG_CONFIG_HOME: testTempPath('stack-after-directions-config'),
   },
   stderr: "pipe",
 });
@@ -50,7 +52,7 @@ const ROOT = { x: 2000, y: 2000, w: 400, h: 200 };
 
 await client.connect(transport);
 try {
-  const ws = await call("create_workspace", { name: `affine-stack-directions-${Date.now()}` });
+  const ws = await call("create_workspace", { name: testResourceName('affine-stack-directions') });
   const { docId } = await call("create_doc", { workspaceId: ws.id, title: "stackAfter directions" });
   const W = ws.id, D = docId;
 

--- a/tests/test-structured-receipts.mjs
+++ b/tests/test-structured-receipts.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for structured MCP receipts.
  *
@@ -86,7 +88,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-structured-receipts-noconfig',
+      XDG_CONFIG_HOME: testTempPath('structured-receipts-config'),
     },
     stderr: 'pipe',
   });
@@ -123,7 +125,7 @@ async function main() {
   let commentId = null;
 
   try {
-    const workspace = await call('create_workspace', { name: `structured-receipts-${Date.now()}` });
+    const workspace = await call('create_workspace', { name: testResourceName('structured-receipts') });
     const workspaceReceipt = assertReceipt(workspace, 'workspace.create', {
     });
     workspaceId = workspaceReceipt.structured.workspaceId || workspaceReceipt.structured.id;

--- a/tests/test-supporting-tools.mjs
+++ b/tests/test-supporting-tools.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * Focused integration test for tool groups that previously relied mostly on the
  * comprehensive runner:
@@ -68,7 +70,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-supporting-tools-noconfig',
+      XDG_CONFIG_HOME: testTempPath('supporting-tools-config'),
     },
     stderr: 'pipe',
   });
@@ -111,7 +113,7 @@ async function main() {
     originalName = currentUser?.name || null;
     expectTruthy(currentUser?.email, 'current_user email');
 
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspaceName = `supporting-tools-${timestamp}`;
 
     const listedWorkspacesBefore = await call('list_workspaces');

--- a/tests/test-surface-elements.mjs
+++ b/tests/test-surface-elements.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /** Integration test: append_block edgeless positioning, add/update/delete_surface_element (shape/connector/text/group),
  *  xywh merge semantics, pruneConnectors, and get_edgeless_canvas readback. */
 import fs from "node:fs";
@@ -61,7 +63,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
-      XDG_CONFIG_HOME: "/tmp/affine-mcp-e2e-surface-elements-noconfig",
+      XDG_CONFIG_HOME: testTempPath('surface-elements-config'),
       ...(process.env.AFFINE_MCP_DEBUG_SURFACE_INDEX
         ? { AFFINE_MCP_DEBUG_SURFACE_INDEX: process.env.AFFINE_MCP_DEBUG_SURFACE_INDEX }
         : {}),
@@ -97,7 +99,7 @@ async function main() {
   await client.connect(transport);
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspace = await call("create_workspace", { name: `surface-elements-${timestamp}` });
     expectTruthy(workspace?.id, "create_workspace id");
 

--- a/tests/test-tag-deletion.mjs
+++ b/tests/test-tag-deletion.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * E2E regression test: tag deletion data path.
  *
@@ -48,7 +50,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: `/tmp/affine-mcp-e2e-tag-deletion-noconfig-${process.pid}-${Date.now()}`,
+      XDG_CONFIG_HOME: testTempPath('tag-deletion-config'),
     },
     stderr: 'pipe',
   });
@@ -111,7 +113,7 @@ async function main() {
   }
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     const workspaceName = `mcp-tag-deletion-${timestamp}`;
     const docTitle = `MCP TAG DELETION ${timestamp}`;
     const tag = `disposable-${timestamp}`;

--- a/tests/test-tag-visibility.mjs
+++ b/tests/test-tag-visibility.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /**
  * E2E regression test: tag visibility data path.
  *
@@ -46,7 +48,7 @@ async function main() {
       AFFINE_EMAIL: EMAIL,
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: 'sync',
-      XDG_CONFIG_HOME: '/tmp/affine-mcp-e2e-tag-visibility-noconfig',
+      XDG_CONFIG_HOME: testTempPath('tag-visibility-config'),
     },
     stderr: 'pipe',
   });
@@ -97,7 +99,7 @@ async function main() {
   }
 
   try {
-    const timestamp = Date.now();
+    const timestamp = testResourceName('run');
     state.workspaceName = `mcp-tag-visibility-${timestamp}`;
     state.docTitle = `MCP TAG VISIBILITY ${timestamp}`;
     state.tag = `guide-${timestamp}`;

--- a/tests/test-theme-defaults-setup.mjs
+++ b/tests/test-theme-defaults-setup.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
+
 /** Locks in color-default conventions at the CRDT level and writes a state file
  *  for the Playwright verifier. Shape fill/stroke/label stay on fixed palette
  *  tokens (+ literal `#000000` label); canvas text and connector stroke/label
@@ -32,7 +34,7 @@ const transport = new StdioClientTransport({
     AFFINE_EMAIL: EMAIL,
     AFFINE_PASSWORD: PASSWORD,
     AFFINE_LOGIN_AT_START: "sync",
-    XDG_CONFIG_HOME: "/tmp/affine-mcp-theme-defaults",
+    XDG_CONFIG_HOME: testTempPath('theme-defaults-config'),
   },
   stderr: "pipe",
 });
@@ -55,7 +57,7 @@ const isRawHex       = v => typeof v === "string" && /^#[0-9a-f]{3,8}$/i.test(v)
 
 await client.connect(transport);
 try {
-  const ws = await call("create_workspace", { name: `affine-theme-defaults-${Date.now()}` });
+  const ws = await call("create_workspace", { name: testResourceName('affine-theme-defaults') });
   const { docId } = await call("create_doc", { workspaceId: ws.id, title: "Theme Defaults" });
   const W = ws.id, D = docId;
 


### PR DESCRIPTION
# TL;DR
- Refuse destructive live tests against non-loopback AFFiNE targets unless the exact target is explicitly acknowledged.

# Context
- Integration scripts could inherit a remote AFFINE_BASE_URL and mutate real data while sharing credentials, ports, files, and Docker resources across runs.
- Merge before the final test-inventory gate and classify the new self-contained safety test there.

# Changes
- Added a common pre-network target guard with exact remote confirmation and prominent warnings.
- Added collision-resistant run/resource identifiers, isolated Compose projects and ports, and private per-run temporary/config files.
- Prevented credential output and safely quoted generated env values.
- Applied the guard to every mutating live runner and added non-destructive guard regressions; local CI and shell checks passed without running destructive tests.
