### PR TITLE
fix: send x-affine-version header on HTTP sign-in and GraphQL/REST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Markdown import now converts `[label](LinkedPage:<docId>)` links into native inline linked-doc references, and Markdown export serializes those references back to the same `LinkedPage:` scheme, making inline doc references round-trip safe.
 
+### Fixed
+- Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
+
 ## [3.0.0] - 2026-07-20
 
 ### Changed

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -40,6 +40,7 @@ cookie, while setting a bearer credential removes any cookie header.
 | `AFFINE_HEADERS_JSON` | No | none | JSON object of additional string headers sent to AFFiNE; built-in token/cookie auth takes priority |
 | `AFFINE_WORKSPACE_ID` | No | Auto-detected when possible | Pins the active workspace |
 | `AFFINE_LOGIN_AT_START` | No | `async` | `async` starts one shared login without blocking transport startup; `sync` requires login before startup |
+| `AFFINE_CLIENT_VERSION` | No | `0.26.0` | AFFiNE web-client version sent as the `x-affine-version` header on GraphQL/REST requests. Servers that gate on client version reject sign-in with `403 UNSUPPORTED_CLIENT_VERSION` when it is too low; raise this if your deployment pins a higher minimum. Also used as the fallback default for `AFFINE_WS_CLIENT_VERSION` |
 | `XDG_CONFIG_HOME` | No | `~/.config` | Changes the parent directory used for the saved `affine-mcp/config` file |
 
 ### Blob upload safeguards
@@ -96,7 +97,7 @@ cookie, while setting a bearer credential removes any cookie header.
 
 | Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `AFFINE_WS_CLIENT_VERSION` | No | `0.26.0` | Environment-only AFFiNE client version sent during workspace socket connection |
+| `AFFINE_WS_CLIENT_VERSION` | No | `AFFINE_CLIENT_VERSION` (else `0.26.0`) | Environment-only AFFiNE client version sent during workspace socket connection; falls back to `AFFINE_CLIENT_VERSION` when unset |
 | `AFFINE_WS_CONNECT_TIMEOUT_MS` | No | `10000` | Environment-only milliseconds to wait for a workspace socket connection |
 | `AFFINE_WS_ACK_TIMEOUT_MS` | No | `10000` | Environment-only milliseconds to wait for a workspace socket acknowledgement |
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,6 +31,12 @@ function sanitizeSignInHeaders(headers?: Record<string, string>): Record<string,
   );
 }
 
+/** Case-insensitive presence check — HTTP header names are case-insensitive. */
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === lower);
+}
+
 /**
  * Exchange email/password for a session cookie.
  *
@@ -45,17 +51,23 @@ export async function loginWithPassword(
   configuredHeaders?: Record<string, string>,
 ): Promise<{ cookieHeader: string }> {
   const url = `${baseUrl.replace(/\/$/, "")}/api/auth/sign-in`;
+  // Configured headers first so an explicit override wins; only supply the
+  // default version when the caller did not set one in any casing, so Fetch
+  // can't coalesce two `x-affine-version` casings into one comma-joined value.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...sanitizeSignInHeaders(configuredHeaders),
+  };
+  if (!hasHeader(headers, "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), AUTH_FETCH_TIMEOUT_MS);
   let res;
   try {
     res = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-affine-version": AFFINE_CLIENT_VERSION,
-        ...sanitizeSignInHeaders(configuredHeaders),
-      },
+      headers,
       body: JSON.stringify({ email, password }),
       signal: controller.signal,
     });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,7 +20,30 @@ function assertNoCRLF(value: string, label: string): void {
   }
 }
 
-export async function loginWithPassword(baseUrl: string, email: string, password: string): Promise<{ cookieHeader: string }> {
+/**
+ * Drop authentication headers a sign-in must never carry — it establishes the
+ * session cookie itself, so any inherited `Authorization`/`Cookie` is stale.
+ */
+function sanitizeSignInHeaders(headers?: Record<string, string>): Record<string, string> {
+  if (!headers) return {};
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !/^(authorization|cookie)$/i.test(name)),
+  );
+}
+
+/**
+ * Exchange email/password for a session cookie.
+ *
+ * `configuredHeaders` (typically `config.headers` from `AFFINE_HEADERS_JSON`)
+ * is merged after the defaults so an explicit `x-affine-version` override wins,
+ * matching how the GraphQL/REST paths honor the same override.
+ */
+export async function loginWithPassword(
+  baseUrl: string,
+  email: string,
+  password: string,
+  configuredHeaders?: Record<string, string>,
+): Promise<{ cookieHeader: string }> {
   const url = `${baseUrl.replace(/\/$/, "")}/api/auth/sign-in`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), AUTH_FETCH_TIMEOUT_MS);
@@ -31,6 +54,7 @@ export async function loginWithPassword(baseUrl: string, email: string, password
       headers: {
         "Content-Type": "application/json",
         "x-affine-version": AFFINE_CLIENT_VERSION,
+        ...sanitizeSignInHeaders(configuredHeaders),
       },
       body: JSON.stringify({ email, password }),
       signal: controller.signal,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,7 @@
 import { fetch } from "undici";
 
+import { AFFINE_CLIENT_VERSION } from "./config.js";
+
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
 
 function extractCookiePairs(setCookies: string[]): string {
@@ -26,7 +28,10 @@ export async function loginWithPassword(baseUrl: string, email: string, password
   try {
     res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-affine-version": AFFINE_CLIENT_VERSION,
+      },
       body: JSON.stringify({ email, password }),
       signal: controller.signal,
     });

--- a/src/authSession.ts
+++ b/src/authSession.ts
@@ -15,6 +15,8 @@ type AuthSessionOptions = {
   cookie?: string;
   email?: string;
   password?: string;
+  /** Extra headers (e.g. from AFFINE_HEADERS_JSON) forwarded to email/password sign-in. */
+  headers?: Record<string, string>;
   login?: LoginFunction;
 };
 
@@ -29,6 +31,7 @@ export function parseLoginMode(raw: string | undefined): LoginMode {
 export class AuthSession {
   private readonly baseUrl: string;
   private readonly login: LoginFunction;
+  private readonly headers?: Record<string, string>;
   private email?: string;
   private password?: string;
   private immediate: AuthSnapshot;
@@ -42,6 +45,7 @@ export class AuthSession {
 
     this.baseUrl = options.baseUrl;
     this.login = options.login || loginWithPassword;
+    this.headers = options.headers;
     this.email = hasImmediateAuth ? undefined : options.email;
     this.password = hasImmediateAuth ? undefined : options.password;
 
@@ -89,7 +93,7 @@ export class AuthSession {
     console.error("[affine-mcp] Authenticating with email/password...");
 
     this.pending = Promise.resolve()
-      .then(() => this.login(this.baseUrl, email, password))
+      .then(() => this.login(this.baseUrl, email, password, this.headers))
       .then(({ cookieHeader }) => {
         this.immediate = { kind: "cookie", cookie: cookieHeader };
         console.error("[affine-mcp] Email/password authentication succeeded");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as readline from "readline";
 
 import {
+  AFFINE_CLIENT_VERSION,
   buildGraphqlEndpoint,
   CONFIG_FILE,
   loadConfig,
@@ -115,6 +116,7 @@ async function gql(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
+    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(auth.headers || {}),
   };
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -280,7 +280,7 @@ async function resolveCliAuth(effective: ServerConfig): Promise<{ auth: CliAuth;
     };
   }
   if (effective.email && effective.password) {
-    const { cookieHeader } = await loginWithPassword(effective.baseUrl, effective.email, effective.password);
+    const { cookieHeader } = await loginWithPassword(effective.baseUrl, effective.email, effective.password, effective.headers);
     return {
       auth: { cookie: cookieHeader, headers: effective.headers },
       authKind: "email-password",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,17 @@ const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 export const VERSION: string = pkg.version;
 
+/**
+ * AFFiNE gates GraphQL/REST requests behind a minimum web-client version,
+ * advertised via the `x-affine-version` request header. Newer / self-hosted
+ * servers reject sign-in with `403 ACTION_FORBIDDEN`
+ * (`UNSUPPORTED_CLIENT_VERSION`) when the header is missing. This is the
+ * HTTP counterpart to `AFFINE_WS_CLIENT_VERSION` (used for the realtime
+ * socket); override it if your deployment pins a different minimum.
+ */
+export const AFFINE_CLIENT_VERSION: string =
+  process.env.AFFINE_CLIENT_VERSION || "0.26.0";
+
 export type TransportMode = "stdio" | "http";
 export type LoginAtStartMode = "async" | "sync";
 

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -109,10 +109,24 @@ export class GraphQLClient {
     return this.opts.endpoint;
   }
 
+  /**
+   * Build the outgoing header set for a snapshot. `x-affine-version` goes first
+   * so an explicit override in `baseHeaders` (from `AFFINE_HEADERS_JSON`) wins,
+   * and auth headers last so they are never shadowed. Shared by the `headers`
+   * getter and `getConnectionAuth()` so every request path stays consistent.
+   */
+  private composeHeaders(snapshot: AuthSnapshot): Record<string, string> {
+    return {
+      "x-affine-version": AFFINE_CLIENT_VERSION,
+      ...this.baseHeaders,
+      ...authHeaders(snapshot),
+    };
+  }
+
   /** Synchronous snapshot for compatibility. Async consumers must use getConnectionAuth(). */
   get headers(): Record<string, string> {
     const snapshot = this.authOverride || this.resolvedAuth;
-    return { ...this.baseHeaders, ...authHeaders(snapshot) };
+    return this.composeHeaders(snapshot);
   }
 
   get cookie(): string {
@@ -169,14 +183,9 @@ export class GraphQLClient {
   /** Await authentication and return one normalized credential set for HTTP or WebSocket consumers. */
   async getConnectionAuth(): Promise<ConnectionAuth> {
     const snapshot = this.authOverride || await this.resolveAuth();
-    // `x-affine-version` first so an explicit AFFINE_HEADERS_JSON override (in
-    // baseHeaders) still wins. Injecting it here covers every consumer —
-    // request() below and the direct multipart/blob uploads in tools/.
-    const headers = {
-      "x-affine-version": AFFINE_CLIENT_VERSION,
-      ...this.baseHeaders,
-      ...authHeaders(snapshot),
-    };
+    // Injected here (not only in request()) so it also covers the direct
+    // multipart/blob uploads in tools/ that build their own fetch from this.
+    const headers = this.composeHeaders(snapshot);
     return {
       bearer: snapshot.kind === "bearer" ? snapshot.token : "",
       cookie: snapshot.kind === "cookie" ? snapshot.cookie : "",

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -1,7 +1,7 @@
 import { fetch } from "undici";
 
 import type { AuthSnapshot } from "./authSession.js";
-import { VERSION } from "./config.js";
+import { VERSION, AFFINE_CLIENT_VERSION } from "./config.js";
 
 const GQL_FETCH_TIMEOUT_MS = 30_000;
 
@@ -169,7 +169,14 @@ export class GraphQLClient {
   /** Await authentication and return one normalized credential set for HTTP or WebSocket consumers. */
   async getConnectionAuth(): Promise<ConnectionAuth> {
     const snapshot = this.authOverride || await this.resolveAuth();
-    const headers = { ...this.baseHeaders, ...authHeaders(snapshot) };
+    // `x-affine-version` first so an explicit AFFINE_HEADERS_JSON override (in
+    // baseHeaders) still wins. Injecting it here covers every consumer —
+    // request() below and the direct multipart/blob uploads in tools/.
+    const headers = {
+      "x-affine-version": AFFINE_CLIENT_VERSION,
+      ...this.baseHeaders,
+      ...authHeaders(snapshot),
+    };
     return {
       bearer: snapshot.kind === "bearer" ? snapshot.token : "",
       cookie: snapshot.kind === "cookie" ? snapshot.cookie : "",

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -116,11 +116,14 @@ export class GraphQLClient {
    * getter and `getConnectionAuth()` so every request path stays consistent.
    */
   private composeHeaders(snapshot: AuthSnapshot): Record<string, string> {
-    return {
-      "x-affine-version": AFFINE_CLIENT_VERSION,
-      ...this.baseHeaders,
-      ...authHeaders(snapshot),
-    };
+    const headers: Record<string, string> = { ...this.baseHeaders };
+    // Only supply the default when baseHeaders (AFFINE_HEADERS_JSON) has no
+    // `x-affine-version` in any casing, so Fetch can't coalesce two casings
+    // into one comma-joined value.
+    if (findHeader(headers, "x-affine-version") === undefined) {
+      headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+    }
+    return { ...headers, ...authHeaders(snapshot) };
   }
 
   /** Synchronous snapshot for compatibility. Async consumers must use getConnectionAuth(). */

--- a/src/httpDiagnostics.ts
+++ b/src/httpDiagnostics.ts
@@ -2,7 +2,7 @@ import type express from "express";
 import type { NextFunction, Request, Response } from "express";
 import { fetch } from "undici";
 
-import { VERSION, type ServerConfig } from "./config.js";
+import { VERSION, AFFINE_CLIENT_VERSION, type ServerConfig } from "./config.js";
 import type { HttpAuthState } from "./httpAuth.js";
 import { getOAuthResourceUrl, probeOAuthReadiness } from "./oauth.js";
 
@@ -12,6 +12,7 @@ async function probeAffineGraphql(config: ServerConfig): Promise<void> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
+    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(config.headers || {}),
   };
   if (config.apiToken) headers.Authorization = `Bearer ${config.apiToken}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ const authSession = new AuthSession({
   cookie: sessionCookie,
   email: sessionBearer || sessionCookie ? undefined : config.email,
   password: sessionBearer || sessionCookie ? undefined : config.password,
+  headers: config.headers,
 });
 
 if (config.authMode === "oauth" && !authSession.hasConfiguredAuth) {

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,7 +1,7 @@
 import { io, Socket } from "socket.io-client";
 
 export type WorkspaceSocket = Socket<any, any>;
-const DEFAULT_WS_CLIENT_VERSION = process.env.AFFINE_WS_CLIENT_VERSION || '0.26.0';
+const DEFAULT_WS_CLIENT_VERSION = process.env.AFFINE_WS_CLIENT_VERSION || process.env.AFFINE_CLIENT_VERSION || '0.26.0';
 const WS_CONNECT_TIMEOUT_MS = Number(process.env.AFFINE_WS_CONNECT_TIMEOUT_MS || 10000);
 const WS_ACK_TIMEOUT_MS = Number(process.env.AFFINE_WS_ACK_TIMEOUT_MS || 10000);
 


### PR DESCRIPTION
## Problem

AFFiNE gates GraphQL/REST requests behind a **minimum web-client version**, advertised via the `x-affine-version` request header. When a server enforces it (self-hosted upgrades, and AFFiNE Cloud), email/password **sign-in is rejected before it can succeed**:

```
403 {"status":403,"code":"Forbidden","type":"ACTION_FORBIDDEN",
     "name":"UNSUPPORTED_CLIENT_VERSION",
     "message":"Unsupported client with version [unset_or_invalid], required version is [>=0.25.0]."}
```

The server then fails to start at all:

```
[affine-mcp] Authenticating with email/password...
[affine-mcp] Email/password authentication failed: Sign-in failed: 403 ... UNSUPPORTED_CLIENT_VERSION ...
Failed to start affine-mcp server
```

Only the realtime socket path sent a client version (`AFFINE_WS_CLIENT_VERSION`); none of the HTTP paths did.

## Fix

Add a single `AFFINE_CLIENT_VERSION` config (default `0.26.0`, matching the existing WS default) and send `x-affine-version` from every HTTP path that reaches AFFiNE:

- **email/password sign-in** — `auth.ts` (`loginWithPassword`), the connect-blocking call, also used by the CLI and the shared auth session
- **`GraphQLClient.getConnectionAuth()`** — one injection point that covers `request()` **and** the direct multipart/blob uploads in `tools/` (`blobStorage.ts`, `workspaces.ts`), which build their own `fetch` from these headers
- **CLI GraphQL helper** — `cli.ts`
- **HTTP readiness probe** — `httpDiagnostics.ts`

`AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, so a single variable can govern both the HTTP and socket client versions. An explicit `x-affine-version` supplied via `AFFINE_HEADERS_JSON` still overrides the default (it is spread after the injected header in `getConnectionAuth`).

## Notes / choices

- Default `0.26.0` mirrors the current `AFFINE_WS_CLIENT_VERSION` default — no behavior change for servers that don't gate on version; it only adds a header they'll accept.
- Configurable so operators whose server pins a higher minimum can bump one env var instead of waiting for a release.
- Focused, single logical change; targets `develop` from a dedicated non-protected branch per CONTRIBUTING.
- Documented in `docs/configuration-and-deployment.md` (Core configuration table + the WebSocket row) and `CHANGELOG.md` (Unreleased).

## Validation

- `npm run ci` — passes (build, fast/metadata tests, and `npm pack` dry-run all green).
- Against a live self-hosted AFFiNE that enforces the gate: **before** — sign-in 403 `UNSUPPORTED_CLIENT_VERSION`; **after** — `Email/password authentication succeeded`, `Enabled tools: 92/92`, and a `list_workspaces` tool call returns workspace data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with AFFiNE servers by sending the `x-affine-version` header on email/password sign-in and GraphQL/REST requests.
  * Reduced authentication failures by allowing configurable sign-in headers, while blocking `Authorization`/`Cookie` overrides.
  * Added `x-affine-version` to GraphQL readiness probes.
  * Updated WebSocket version behavior so `AFFINE_WS_CLIENT_VERSION` falls back to `AFFINE_CLIENT_VERSION`.

* **Documentation**
  * Documented `AFFINE_CLIENT_VERSION` and its relationship to the WebSocket fallback behavior for `AFFINE_WS_CLIENT_VERSION`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->