### PR TITLE
fix: accept AFFiNE delete success acknowledgements

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -651,6 +651,8 @@ export async function deleteDocFromWorkspace(
 }
 
 export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults: { workspaceId?: string }) {
+  const acknowledgedDeletedDocIds = new Map<string, Set<string>>();
+
   // helpers
   function generateId(): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
@@ -4182,7 +4184,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const inTrashByDocId = new Map<string, boolean>();
       let workspacePageCount: number | null = null;
       let workspacePageIds: Set<string> | null = null;
-      const deletedDocIds = new Set<string>();
+      const deletedDocIds = new Set(acknowledgedDeletedDocIds.get(workspaceId) || []);
       try {
         const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -4197,6 +4199,12 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             const pages = getWorkspacePageEntries(meta);
             workspacePageCount = pages.length;
             workspacePageIds = new Set(pages.map(page => page.id));
+            for (const docId of deletedDocIds) {
+              if (workspacePageIds.has(docId)) {
+                deletedDocIds.delete(docId);
+                acknowledgedDeletedDocIds.get(workspaceId)?.delete(docId);
+              }
+            }
             const { byId } = getWorkspaceTagOptionMaps(meta);
             for (const page of pages) {
               if (page.title) {
@@ -6330,7 +6338,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
-      return await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
+      const result = await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
+      const deletion = result.structuredContent as { ok?: boolean; status?: string } | undefined;
+      if (deletion?.ok === true && (deletion.status === "deleted" || deletion.status === "already_absent")) {
+        const deletedIds = acknowledgedDeletedDocIds.get(workspaceId) || new Set<string>();
+        deletedIds.add(parsed.docId);
+        acknowledgedDeletedDocIds.set(workspaceId, deletedIds);
+      }
+      return result;
     } finally {
       socket.disconnect();
     }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -14,15 +14,19 @@ function ackErrorMessage(ack: any, fallback: string): string | null {
 function deleteAcknowledged(ack: any): boolean {
   return ack === true
     || ack?.deleted === true
+    || ack?.success === true
     || ack?.data === true
-    || ack?.data?.deleted === true;
+    || ack?.data?.deleted === true
+    || ack?.data?.success === true;
 }
 
 function deleteRejected(ack: any): boolean {
   return ack === false
     || ack?.deleted === false
+    || ack?.success === false
     || ack?.data === false
-    || ack?.data?.deleted === false;
+    || ack?.data?.deleted === false
+    || ack?.data?.success === false;
 }
 
 function emitWithAck<T>(
@@ -164,11 +168,10 @@ export type DeleteDocOptions = {
 /**
  * Delete a document and wait for a trustworthy completion signal.
  *
- * AFFiNE 0.26 returns an error acknowledgement, but its successful
- * `space:delete-doc` handler returns void. NestJS filters that void response and
- * therefore sends no success acknowledgement. To remain compatible, this
- * helper accepts a future success acknowledgement and otherwise verifies that
- * `space:load-doc` returns DOC_NOT_FOUND before resolving.
+ * AFFiNE versions may return no successful acknowledgement, `{ deleted: true }`,
+ * or `{ data: { success: true } }`. AFFiNE 0.27.3 also retains the underlying
+ * snapshot for garbage collection, so a successful acknowledgement must be
+ * recognized instead of relying exclusively on a follow-up DOC_NOT_FOUND.
  */
 export function deleteDoc(
   socket: WorkspaceSocket,

--- a/tests/test-destructive-mutation-ack.mjs
+++ b/tests/test-destructive-mutation-ack.mjs
@@ -115,6 +115,14 @@ class FakeWorkspaceSocket {
           ack?.({ data: { deleted: false } });
           return;
         }
+        if (this.deleteMode === "server-success-ack") {
+          ack?.({ data: { success: true } });
+          return;
+        }
+        if (this.deleteMode === "server-negative-ack") {
+          ack?.({ data: { success: false } });
+          return;
+        }
         if (this.deleteMode === "empty-ack-still-present") {
           ack?.({});
           return;
@@ -164,6 +172,13 @@ async function testDeleteDocProtocol() {
   });
   assert.deepEqual(acknowledged, { acknowledged: true, verifiedAbsent: false });
 
+  const serverAcknowledgedSocket = new FakeWorkspaceSocket({ deleteMode: "server-success-ack" });
+  const serverAcknowledged = await deleteDoc(serverAcknowledgedSocket, "workspace-1", "doc-1", {
+    timeoutMs: 100,
+    verificationIntervalMs: 5,
+  });
+  assert.deepEqual(serverAcknowledged, { acknowledged: true, verifiedAbsent: false });
+
   const voidSuccessSocket = new FakeWorkspaceSocket({ deleteMode: "void-success" });
   const verified = await deleteDoc(voidSuccessSocket, "workspace-1", "doc-1", {
     timeoutMs: 100,
@@ -185,6 +200,15 @@ async function testDeleteDocProtocol() {
   const negativeAcknowledgementSocket = new FakeWorkspaceSocket({ deleteMode: "negative-ack" });
   await assert.rejects(
     deleteDoc(negativeAcknowledgementSocket, "workspace-1", "doc-1", {
+      timeoutMs: 100,
+      verificationIntervalMs: 5,
+    }),
+    /did not confirm document deletion/,
+  );
+
+  const serverNegativeAcknowledgementSocket = new FakeWorkspaceSocket({ deleteMode: "server-negative-ack" });
+  await assert.rejects(
+    deleteDoc(serverNegativeAcknowledgementSocket, "workspace-1", "doc-1", {
       timeoutMs: 100,
       verificationIntervalMs: 5,
     }),


### PR DESCRIPTION
## Summary

Recognize AFFiNE's current `space:delete-doc` success acknowledgement so successful document deletions do not time out after 10 seconds, and keep acknowledged deletions out of `list_docs` while upstream indexing converges.

## Root cause

AFFiNE 0.27.3 returns `{ data: { success: true } }` after handling `space:delete-doc` and retains the underlying snapshot for garbage collection. The MCP client only recognized `true` and `deleted: true` acknowledgement shapes, then waited for `space:load-doc` to return `DOC_NOT_FOUND`. Because the retained snapshot remains loadable, the valid success acknowledgement was ignored and the operation was reported as `doc_content_delete_failed`.

The retained snapshot can also keep a stale GraphQL document edge visible after the deletion is acknowledged. Treating every document outside workspace metadata as deleted would hide legitimate orphan documents, so the compatibility filter is limited to document IDs successfully deleted through the current MCP server instance.

## Changes

- Accept top-level and nested `success: true` delete acknowledgements.
- Treat matching `success: false` acknowledgements as explicit rejection.
- Track successfully acknowledged deletions per workspace and filter only those stale edges from `list_docs`.
- Clear the compatibility tombstone if the document appears in workspace metadata again.
- Add regression coverage for the AFFiNE server success and rejection response shapes while the snapshot remains present.
- Update the protocol comment to describe the current AFFiNE behavior.

## Validation

- `npm run ci`
- `npm run test:e2e`
  - 21/21 MCP integration tests passed.
  - 14/14 Playwright UI tests passed.
  - The previously failing `test-doc-discovery.mjs` deletion and post-delete listing path passed against the current AFFiNE `stable` image.

## Checklist

- [x] Branch targets `develop` from a dedicated non-protected head branch.
- [x] Focused delete acknowledgement regression coverage added.
- [x] Full local CI and E2E gates passed.
- [x] No release, tag, or deployment changes included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document deletion handling across supported acknowledgement formats.
  * Deleted documents are now hidden from listings immediately after deletion is confirmed.
  * Prevented stale pagination data from showing documents that were successfully deleted.
  * Correctly reports deletion failures when the server explicitly rejects the operation.

* **Tests**
  * Added coverage for successful and unsuccessful deletion acknowledgements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->