### PR TITLE
fix: let environment credentials override saved auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
+- Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
+- Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
+
+### Tests
+- Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
 
 ## [3.0.0] - 2026-07-20
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -81,6 +81,30 @@ Self-hosted email/password example:
 }
 ```
 
+## MCP Inspector
+
+MCP Inspector does not automatically read Claude Desktop's server
+configuration. Starting it with only `affine-mcp` launches a separate process
+without the `AFFINE_*` environment variables from
+`claude_desktop_config.json`.
+
+To inspect the same `affine` server configuration on macOS, pass the Claude
+Desktop config file explicitly:
+
+```bash
+npx @modelcontextprotocol/inspector \
+  --config "$HOME/Library/Application Support/Claude/claude_desktop_config.json" \
+  --server affine
+```
+
+On Linux, use `~/.config/Claude/claude_desktop_config.json`. On Windows, use
+`%APPDATA%\Claude\claude_desktop_config.json`. The value passed to `--server`
+must match the key under `mcpServers`.
+
+Inspector also accepts individual server environment variables through
+repeated `-e KEY=value` arguments. Prefer the config-file form for passwords
+and other secrets so they are not copied into shell history.
+
 ## Codex CLI
 
 With saved config:
@@ -176,4 +200,5 @@ browser history.
 - Use a dedicated least-privilege account for automated self-hosted environments
 - Use `AFFINE_API_TOKEN` only when the target deployment still accepts a compatible GraphQL bearer token
 - If your shell treats `!` specially, wrap passwords in single quotes
+- When using MCP Inspector, pass `--config` and `--server` or supply the required `AFFINE_*` values with `-e`
 - Use `affine-mcp doctor` whenever a client config looks correct but the connection still fails

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -12,11 +12,24 @@ The server resolves configuration in this order:
 
 The saved config file uses the same `KEY=value` names shown below. Environment variables always override saved values, and the CLI diagnostics report the source selected for each runtime option.
 
+Authentication credentials are resolved as one source-scoped group. If the
+environment provides any of `AFFINE_API_TOKEN`, `AFFINE_COOKIE`,
+`AFFINE_EMAIL`, or `AFFINE_PASSWORD`, saved authentication credentials are not
+mixed into that environment configuration. An `Authorization` or `Cookie`
+entry in an environment-provided `AFFINE_HEADERS_JSON` also selects the
+environment authentication group. Non-authentication headers from saved
+configuration remain available when no environment `AFFINE_HEADERS_JSON`
+replaces them.
+
 Auth priority within the active configuration:
 
 1. `AFFINE_API_TOKEN`
 2. `AFFINE_COOKIE`
 3. `AFFINE_EMAIL` and `AFFINE_PASSWORD`
+
+This priority is applied only within the selected environment or saved-config
+group. For example, environment email/password credentials take precedence
+over an older saved API token or session cookie.
 
 Email/password authentication is process-scoped. Concurrent HTTP MCP sessions
 share one sign-in attempt and the resulting cookie. In the default `async`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,6 +205,15 @@ function getConfigValueSource(name: string, file: Record<string, string>, fallba
   return "unset";
 }
 
+function getEffectiveAuthValueSource(
+  name: string,
+  value: string | undefined,
+  file: Record<string, string>,
+): "env" | "config" | "unset" {
+  if (!value) return "unset";
+  return process.env[name] ? "env" : file[name] ? "config" : "unset";
+}
+
 function buildEffectiveConfigSummary(effective: ServerConfig = loadConfig()) {
   const stored = loadConfigFile();
   const authKind = effective.apiToken
@@ -245,10 +254,10 @@ function buildEffectiveConfigSummary(effective: ServerConfig = loadConfig()) {
       baseUrl: getConfigValueSource("AFFINE_BASE_URL", stored, "http://localhost:3010"),
       graphqlPath: getConfigValueSource("AFFINE_GRAPHQL_PATH", stored, "/graphql"),
       additionalHeaders: getConfigValueSource("AFFINE_HEADERS_JSON", stored),
-      apiToken: getConfigValueSource("AFFINE_API_TOKEN", stored),
-      cookie: getConfigValueSource("AFFINE_COOKIE", stored),
-      email: getConfigValueSource("AFFINE_EMAIL", stored),
-      password: getConfigValueSource("AFFINE_PASSWORD", stored),
+      apiToken: getEffectiveAuthValueSource("AFFINE_API_TOKEN", effective.apiToken, stored),
+      cookie: getEffectiveAuthValueSource("AFFINE_COOKIE", effective.cookie, stored),
+      email: getEffectiveAuthValueSource("AFFINE_EMAIL", effective.email, stored),
+      password: getEffectiveAuthValueSource("AFFINE_PASSWORD", effective.password, stored),
       workspaceId: getConfigValueSource("AFFINE_WORKSPACE_ID", stored),
       authMode: getConfigValueSource("AFFINE_MCP_AUTH_MODE", stored, "bearer"),
       publicBaseUrl: getConfigValueSource("AFFINE_MCP_PUBLIC_BASE_URL", stored),

--- a/src/config.ts
+++ b/src/config.ts
@@ -245,6 +245,20 @@ function resolveAuthenticationConfig(file: Record<string, string>) {
   const environmentProvidesAuthentication = AUTH_CREDENTIAL_VARIABLES.some(
     (name) => Boolean(process.env[name]),
   ) || (headersSource === "env" && hasAuthenticationHeader(headers));
+
+  const environmentHasEmail = Boolean(process.env.AFFINE_EMAIL);
+  const environmentHasPassword = Boolean(process.env.AFFINE_PASSWORD);
+  if (
+    environmentProvidesAuthentication &&
+    environmentHasEmail !== environmentHasPassword &&
+    Boolean(file.AFFINE_EMAIL || file.AFFINE_PASSWORD)
+  ) {
+    console.warn(
+      "[affine-mcp] WARNING: Environment provides only one of AFFINE_EMAIL or AFFINE_PASSWORD. " +
+        "Saved email/password credentials are ignored; set both environment variables to use email/password authentication.",
+    );
+  }
+
   const credentials = environmentProvidesAuthentication ? process.env : file;
 
   const apiToken = credentials.AFFINE_API_TOKEN || undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -213,6 +213,60 @@ function removeHeadersCaseInsensitive(
   return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
+const AUTH_CREDENTIAL_VARIABLES = [
+  "AFFINE_API_TOKEN",
+  "AFFINE_COOKIE",
+  "AFFINE_EMAIL",
+  "AFFINE_PASSWORD",
+] as const;
+
+function hasAuthenticationHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers || {}).some((name) => /^(authorization|cookie)$/i.test(name));
+}
+
+/**
+ * Resolve authentication as one source-scoped group.
+ *
+ * Mixing individual keys first and choosing an auth method afterwards lets a
+ * saved token or cookie outrank environment email/password credentials. Once
+ * the environment provides any authentication value, all saved authentication
+ * values are ignored while unrelated saved headers remain available.
+ */
+function resolveAuthenticationConfig(file: Record<string, string>) {
+  const environmentHeadersJson = process.env.AFFINE_HEADERS_JSON;
+  const savedHeadersJson = file.AFFINE_HEADERS_JSON;
+  const headersSource = environmentHeadersJson
+    ? "env"
+    : savedHeadersJson
+      ? "config"
+      : "unset";
+  let headers = parseHeadersJson(environmentHeadersJson || savedHeadersJson);
+
+  const environmentProvidesAuthentication = AUTH_CREDENTIAL_VARIABLES.some(
+    (name) => Boolean(process.env[name]),
+  ) || (headersSource === "env" && hasAuthenticationHeader(headers));
+  const credentials = environmentProvidesAuthentication ? process.env : file;
+
+  const apiToken = credentials.AFFINE_API_TOKEN || undefined;
+  const cookie = credentials.AFFINE_COOKIE || undefined;
+  const email = credentials.AFFINE_EMAIL || undefined;
+  const password = credentials.AFFINE_PASSWORD || undefined;
+
+  if (environmentProvidesAuthentication && headersSource === "config") {
+    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
+  }
+  if (apiToken) {
+    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
+  } else if (cookie) {
+    headers = {
+      ...(removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]) || {}),
+      Cookie: cookie,
+    };
+  }
+
+  return { apiToken, cookie, email, password, headers };
+}
+
 function parseAuthMode(raw: string | undefined): "bearer" | "oauth" {
   if (!raw) return "bearer";
   const normalized = raw.trim().toLowerCase();
@@ -323,19 +377,7 @@ export function loadConfig(): ServerConfig {
     },
   );
   const authMode = parseAuthMode(env("AFFINE_MCP_AUTH_MODE", file, "bearer"));
-  const apiToken = env("AFFINE_API_TOKEN", file);
-  const cookie = env("AFFINE_COOKIE", file);
-  const email = env("AFFINE_EMAIL", file);
-  const password = env("AFFINE_PASSWORD", file);
-  let headers: Record<string, string> | undefined = parseHeadersJson(env("AFFINE_HEADERS_JSON", file));
-  if (apiToken) {
-    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
-  } else if (cookie) {
-    headers = {
-      ...(removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]) || {}),
-      Cookie: cookie,
-    };
-  }
+  const { apiToken, cookie, email, password, headers } = resolveAuthenticationConfig(file);
   const graphqlPath = validateGraphqlPath(env("AFFINE_GRAPHQL_PATH", file, "/graphql")!);
   const graphqlEndpoint = `${baseUrl}${graphqlPath}`;
   const defaultWorkspaceId = env("AFFINE_WORKSPACE_ID", file);

--- a/tests/test-auth-session.mjs
+++ b/tests/test-auth-session.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
@@ -106,6 +107,7 @@ async function startMockAffine(options = {}) {
         state.graphqlHeaders.push({
           authorization: req.headers.authorization || "",
           cookie: req.headers.cookie || "",
+          tenant: req.headers["x-tenant"] || "",
           receivedAt: Date.now(),
         });
         await readRequestBody(req);
@@ -156,7 +158,7 @@ async function startMockAffine(options = {}) {
   };
 }
 
-function cleanServerEnvironment(port, baseUrl) {
+function cleanServerEnvironment(port, baseUrl, configHome) {
   const env = { ...process.env };
   for (const key of [
     "AFFINE_API_TOKEN",
@@ -179,7 +181,7 @@ function cleanServerEnvironment(port, baseUrl) {
     AFFINE_LOGIN_AT_START: "async",
     AFFINE_MCP_AUTH_MODE: "bearer",
     AFFINE_MCP_HTTP_HOST: "127.0.0.1",
-    XDG_CONFIG_HOME: `/tmp/affine-mcp-auth-session-${process.pid}-${port}`,
+    XDG_CONFIG_HOME: configHome || `/tmp/affine-mcp-auth-session-${process.pid}-${port}`,
   };
 }
 
@@ -204,11 +206,11 @@ async function waitForHealth(child, url, logs, timeoutMs = 8_000) {
   throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(logs())}`);
 }
 
-async function startMcpServer(baseUrl) {
+async function startMcpServer(baseUrl, options = {}) {
   const port = await findFreePort();
   const child = spawn("node", [MCP_SERVER_PATH], {
     cwd: PROJECT_DIR,
-    env: cleanServerEnvironment(port, baseUrl),
+    env: cleanServerEnvironment(port, baseUrl, options.configHome),
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stdout = "";
@@ -235,6 +237,15 @@ async function startMcpServer(baseUrl) {
       }
     },
   };
+}
+
+function writeSavedConfig(configHome, values) {
+  const directory = path.join(configHome, "affine-mcp");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    path.join(directory, "config"),
+    `${Object.entries(values).map(([key, value]) => `${key}=${value}`).join("\n")}\n`,
+  );
 }
 
 async function createMcpClient(mcpUrl, name) {
@@ -359,6 +370,68 @@ async function testFailureNeverFallsBack() {
   }
 }
 
+async function testEnvironmentCredentialsOverrideSavedAuthentication() {
+  const scenarios = [
+    {
+      label: "saved API token",
+      values: { AFFINE_API_TOKEN: "stale-saved-token" },
+    },
+    {
+      label: "saved cookie",
+      values: { AFFINE_COOKIE: "affine_session=stale-saved-cookie" },
+    },
+    {
+      label: "saved authentication headers",
+      values: {
+        AFFINE_HEADERS_JSON: JSON.stringify({
+          Authorization: "Bearer stale-saved-header-token",
+          Cookie: "affine_session=stale-saved-header-cookie",
+        }),
+      },
+    },
+  ];
+
+  for (const [index, scenario] of scenarios.entries()) {
+    const configHome = mkdtempSync(path.join(os.tmpdir(), "affine-mcp-env-auth-"));
+    const tenant = `saved-tenant-${index}`;
+    const existingHeaders = scenario.values.AFFINE_HEADERS_JSON
+      ? JSON.parse(scenario.values.AFFINE_HEADERS_JSON)
+      : {};
+    writeSavedConfig(configHome, {
+      ...scenario.values,
+      AFFINE_HEADERS_JSON: JSON.stringify({ ...existingHeaders, "X-Tenant": tenant }),
+    });
+
+    const mock = await startMockAffine();
+    const mcp = await startMcpServer(mock.baseUrl, { configHome });
+    let client;
+    try {
+      client = await createMcpClient(mcp.mcpUrl, `environment-auth-${index}`);
+      const result = await client.client.callTool({ name: "current_user", arguments: {} });
+
+      assertEqual(parseToolContent(result)?.email, EMAIL, `${scenario.label} current_user email`);
+      assertEqual(mock.state.signInCalls, 1, `${scenario.label} did not trigger environment login`);
+      assertEqual(mock.state.graphqlCalls, 1, `${scenario.label} GraphQL request count`);
+      assertEqual(
+        mock.state.unauthenticatedGraphqlCalls,
+        0,
+        `${scenario.label} reached AFFiNE with stale authentication`,
+      );
+      assertEqual(mock.state.graphqlHeaders[0]?.cookie, COOKIE, `${scenario.label} session cookie`);
+      assertEqual(mock.state.graphqlHeaders[0]?.authorization, "", `${scenario.label} bearer header`);
+      assertEqual(mock.state.graphqlHeaders[0]?.tenant, tenant, `${scenario.label} non-auth header`);
+    } finally {
+      if (client) {
+        try { await client.client.close(); } catch {}
+        try { await client.transport.close(); } catch {}
+      }
+      await mcp.close();
+      await mock.close();
+      rmSync(configHome, { recursive: true, force: true });
+    }
+  }
+}
+
 async function testConcurrentHttpSessionsAndDirectMultipart() {
   const mock = await startMockAffine({ blockLogin: true });
   const mcp = await startMcpServer(mock.baseUrl);
@@ -425,6 +498,7 @@ async function main() {
   await testSingleFlightPrimitive();
   await testExclusiveAuthState();
   await testFailureNeverFallsBack();
+  await testEnvironmentCredentialsOverrideSavedAuthentication();
   await testConcurrentHttpSessionsAndDirectMultipart();
   console.log("Authentication session regression tests passed.");
 }

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -209,6 +209,8 @@ try {
     AFFINE_BASE_URL: baseUrl,
     AFFINE_API_TOKEN: "stale-saved-token",
     AFFINE_COOKIE: "affine_session=stale-saved-cookie",
+    AFFINE_EMAIL: "saved@example.test",
+    AFFINE_PASSWORD: "saved-password",
     AFFINE_HEADERS_JSON: JSON.stringify({
       Authorization: "Bearer stale-saved-header-token",
       Cookie: "affine_session=stale-saved-header-cookie",
@@ -254,6 +256,57 @@ try {
   expect(
     environmentAuthSummary.sources.password === "env",
     "environment password source was not reported",
+  );
+
+  const partialCredentialWarning =
+    "Environment provides only one of AFFINE_EMAIL or AFFINE_PASSWORD";
+  expect(
+    !environmentAuthConfig.stderr.includes(partialCredentialWarning),
+    "complete environment email/password credentials produced a partial-credential warning",
+  );
+
+  const environmentEmailOnlyConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_EMAIL: "environment@example.test",
+    }),
+  );
+  expect(
+    environmentEmailOnlyConfig.code === 0,
+    `partial environment email config failed: ${environmentEmailOnlyConfig.stderr}`,
+  );
+  expect(
+    environmentEmailOnlyConfig.stderr.includes(partialCredentialWarning),
+    "environment email without a password did not warn that saved credentials were ignored",
+  );
+  const environmentEmailOnlySummary = JSON.parse(environmentEmailOnlyConfig.stdout);
+  expect(
+    environmentEmailOnlySummary.sources.email === "env" &&
+      environmentEmailOnlySummary.sources.password === "unset",
+    "environment email was combined with the saved password",
+  );
+
+  const environmentPasswordOnlyConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_PASSWORD: "environment-password",
+    }),
+  );
+  expect(
+    environmentPasswordOnlyConfig.code === 0,
+    `partial environment password config failed: ${environmentPasswordOnlyConfig.stderr}`,
+  );
+  expect(
+    environmentPasswordOnlyConfig.stderr.includes(partialCredentialWarning),
+    "environment password without an email did not warn that saved credentials were ignored",
+  );
+  const environmentPasswordOnlySummary = JSON.parse(environmentPasswordOnlyConfig.stdout);
+  expect(
+    environmentPasswordOnlySummary.sources.email === "unset" &&
+      environmentPasswordOnlySummary.sources.password === "env",
+    "environment password was combined with the saved email",
   );
 
   const nonAuthEnvironmentHeaders = await runNode(

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -204,6 +204,79 @@ try {
   expect(summary.sources.graphqlPath === "env", "GraphQL path source should be env");
   expect(summary.apiToken !== "env-token", "show-config exposed the API token");
 
+  const staleSavedAuthHome = path.join(TEMP_ROOT, "stale-saved-auth");
+  writeConfig(staleSavedAuthHome, {
+    AFFINE_BASE_URL: baseUrl,
+    AFFINE_API_TOKEN: "stale-saved-token",
+    AFFINE_COOKIE: "affine_session=stale-saved-cookie",
+    AFFINE_HEADERS_JSON: JSON.stringify({
+      Authorization: "Bearer stale-saved-header-token",
+      Cookie: "affine_session=stale-saved-header-cookie",
+      "X-Tenant": "saved-tenant",
+    }),
+  });
+  const environmentCredentials = cleanEnvironment({
+    XDG_CONFIG_HOME: staleSavedAuthHome,
+    AFFINE_EMAIL: "environment@example.test",
+    AFFINE_PASSWORD: "environment-password",
+  });
+  const environmentAuthConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    environmentCredentials,
+  );
+  expect(
+    environmentAuthConfig.code === 0,
+    `environment auth config failed: ${environmentAuthConfig.stderr}`,
+  );
+  const environmentAuthSummary = JSON.parse(environmentAuthConfig.stdout);
+  expect(
+    environmentAuthSummary.authKind === "email-password",
+    "saved token or cookie overrode environment email/password credentials",
+  );
+  expect(environmentAuthSummary.apiToken === null, "ignored saved API token remained effective");
+  expect(environmentAuthSummary.cookie === null, "ignored saved cookie remained effective");
+  expect(
+    environmentAuthSummary.email === "environment@example.test",
+    "environment email was not selected",
+  );
+  expect(
+    environmentAuthSummary.sources.apiToken === "unset",
+    "ignored saved API token source remained active",
+  );
+  expect(
+    environmentAuthSummary.sources.cookie === "unset",
+    "ignored saved cookie source remained active",
+  );
+  expect(
+    environmentAuthSummary.sources.email === "env",
+    "environment email source was not reported",
+  );
+  expect(
+    environmentAuthSummary.sources.password === "env",
+    "environment password source was not reported",
+  );
+
+  const nonAuthEnvironmentHeaders = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_HEADERS_JSON: JSON.stringify({ "X-Tenant": "environment-tenant" }),
+    }),
+  );
+  expect(
+    nonAuthEnvironmentHeaders.code === 0,
+    `non-auth environment headers config failed: ${nonAuthEnvironmentHeaders.stderr}`,
+  );
+  const savedAuthSummary = JSON.parse(nonAuthEnvironmentHeaders.stdout);
+  expect(
+    savedAuthSummary.authKind === "api-token",
+    "non-auth environment headers incorrectly disabled saved authentication",
+  );
+  expect(
+    savedAuthSummary.sources.apiToken === "config",
+    "saved API token source was not reported after non-auth environment headers",
+  );
+
   const status = await runNode([DIST_ENTRY, "status", "--json"], effectiveEnv);
   expect(status.code === 0, `status failed: ${status.stderr}`);
   const statusPayload = JSON.parse(status.stdout);
@@ -427,6 +500,7 @@ try {
     ok: true,
     cases: [
       "environment precedence",
+      "authentication source precedence",
       "custom GraphQL path",
       "custom-path workspace socket origin",
       "effective status auth",

--- a/tests/test-http-email-password.mjs
+++ b/tests/test-http-email-password.mjs
@@ -6,11 +6,14 @@ import { testTempPath } from './require-destructive-test-safety.mjs';
  *
  * Reproduces the multi-session flow where buildServer() is invoked for each
  * Streamable HTTP session. Credentials must remain available so each new
- * session can authenticate successfully.
+ * session can authenticate successfully. The saved config deliberately holds
+ * stale token, cookie, and authentication-header credentials to verify that
+ * environment email/password credentials select the active auth source.
  */
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -74,10 +77,31 @@ async function waitForSuccessfulFetch(url, timeoutMs = 15000) {
 async function startEmailPasswordHttpServer() {
   const port = await findFreePort();
   const publicBaseUrl = `http://127.0.0.1:${port}`;
+  const configHome = testTempPath("http-email-password-server-config");
+  const configDirectory = path.join(configHome, "affine-mcp");
+  mkdirSync(configDirectory, { recursive: true });
+  writeFileSync(
+    path.join(configDirectory, "config"),
+    [
+      "AFFINE_API_TOKEN=stale-saved-token",
+      "AFFINE_COOKIE=affine_session=stale-saved-cookie",
+      `AFFINE_HEADERS_JSON=${JSON.stringify({
+        Authorization: "Bearer stale-saved-header-token",
+        Cookie: "affine_session=stale-saved-header-cookie",
+        "X-Affine-Mcp-Test": "saved-non-auth-header",
+      })}`,
+      "",
+    ].join("\n"),
+  );
+
+  const childEnvironment = { ...process.env };
+  delete childEnvironment.AFFINE_API_TOKEN;
+  delete childEnvironment.AFFINE_COOKIE;
+  delete childEnvironment.AFFINE_HEADERS_JSON;
   const child = spawn("node", [MCP_SERVER_PATH], {
     cwd: PROJECT_DIR,
     env: {
-      ...process.env,
+      ...childEnvironment,
       MCP_TRANSPORT: "http",
       PORT: String(port),
       AFFINE_BASE_URL: BASE_URL,
@@ -85,7 +109,7 @@ async function startEmailPasswordHttpServer() {
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
       AFFINE_MCP_HTTP_HOST: "127.0.0.1",
-      XDG_CONFIG_HOME: testTempPath('http-email-password-server-config'),
+      XDG_CONFIG_HOME: configHome,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });


### PR DESCRIPTION
## Summary

- resolve AFFiNE authentication credentials as a source-scoped group
- let client-provided environment credentials override stale saved tokens, cookies, and authentication headers
- preserve unrelated saved headers and report only effective auth sources in CLI diagnostics
- document how MCP Inspector must load the Claude Desktop server configuration explicitly

## Root cause

Configuration values were merged one key at a time, then the runtime selected token, cookie, or email/password authentication by method priority. A saved API token, cookie, or auth header could therefore outrank environment email/password credentials even though environment configuration is documented as higher priority.

The issue reproduction also starts MCP Inspector as a standalone process. Inspector does not inherit claude_desktop_config.json unless it is launched with --config and --server, or the required environment variables are supplied with -e.

## Impact

When any authentication value is supplied by the environment, saved authentication values are excluded from the active credential group. Saved non-authentication headers remain available. Configurations without environment authentication retain the existing saved-auth behavior and method priority.

## Verification

- npm run ci
- AFFINE_REVISION=0.27.3 npm run test:e2e
  - 21 release integration tests passed
  - 14 Playwright UI checks passed
  - the email/password integration test used a saved config containing stale token, cookie, and auth-header credentials and still authenticated automatically
- Node 22.22.2 container: build, config consistency regression, and authentication session regression passed
- pre-fix regression reproduced as: saved token or cookie overrode environment email/password credentials

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment authentication credentials now take precedence over saved tokens, cookies, and authentication headers.
  - Prevented stale saved credentials from overriding environment-provided email and password.
  - Preserved unrelated saved headers while applying environment authentication settings.
  - Improved authentication source reporting in configuration summaries.

- **Documentation**
  - Added guidance for launching MCP Inspector with Claude Desktop server configuration.
  - Clarified authentication precedence and environment variable usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->