### PR TITLE
feat: enrich workspace discovery metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Markdown import now converts `[label](LinkedPage:<docId>)` links into native inline linked-doc references, and Markdown export serializes those references back to the same `LinkedPage:` scheme, making inline doc references round-trip safe.
+- `list_workspaces` and `get_workspace` now include best-effort workspace profile names, avatar references, direct URLs, and an explicit profile status while preserving the existing GraphQL fields and list response shape.
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -16,13 +16,15 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 
 | Tool | Purpose | Notes |
 | --- | --- | --- |
-| `list_workspaces` | List all available workspaces | Good first discovery step |
-| `get_workspace` | Read workspace details | Includes settings and metadata |
+| `list_workspaces` | List all available workspaces | Includes best-effort profile names, avatar references, and direct URLs; set `includeProfile: false` for a faster GraphQL-only response |
+| `get_workspace` | Read workspace details | Includes permissions plus best-effort profile metadata and a direct URL |
 | `create_workspace` | Create a workspace with an initial document | Destructive in the sense that it creates new server state |
 | `update_workspace` | Update workspace settings | Use carefully in shared workspaces |
 | `delete_workspace` | Permanently delete a workspace | Destructive; `confirmWorkspaceId` must exactly match `id`; unconfirmed outcomes return an MCP error instead of a success receipt |
 | `list_workspace_tree` | Return the workspace document hierarchy as a tree | Useful before moving docs; depth is limited to 0-20 |
 | `get_orphan_docs` | Find documents that are not linked from a parent doc | Useful for cleanup and audits |
+
+`list_workspaces` and `get_workspace` add `name`, `avatar`, `url`, and `profileStatus` to the existing GraphQL fields. `profileStatus` is `available`, `unavailable`, or `skipped`. Profile loading is best effort, so a realtime metadata failure leaves the GraphQL workspace visible with nullable profile fields. The `avatar` value is AFFiNE's stored avatar reference and is not guaranteed to be an external URL.
 
 ## Organization
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:tag-deletion": "node tests/test-tag-deletion.mjs",
     "test:url-safety": "node tests/test-url-safety.mjs",
+    "test:workspace-discovery": "node tests/test-workspace-discovery.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:document-mutation-safety": "node tests/test-document-mutation-safety.mjs",
     "test:markdown-output-safety": "node tests/test-markdown-output-safety.mjs",

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -6,8 +6,123 @@ import FormData from "form-data";
 import fetch from "node-fetch";
 import { receipt, text, toolError } from "../util/mcp.js";
 import { secureRandomString } from "../util/random.js";
-import { connectWorkspaceSocket, joinWorkspace, pushDocUpdate, wsUrlFromGraphQLEndpoint } from "../ws.js";
+import {
+  connectWorkspaceSocket,
+  joinWorkspace,
+  loadDoc,
+  pushDocUpdate,
+  wsUrlFromGraphQLEndpoint,
+  type WorkspaceSocket,
+} from "../ws.js";
 import { requireMatchingConfirmation } from "../util/inputSchemas.js";
+
+type WorkspaceRecord = Record<string, unknown> & { id: string };
+type WorkspaceProfileStatus = "available" | "unavailable" | "skipped";
+
+type WorkspaceSummary = WorkspaceRecord & {
+  name: string | null;
+  avatar: string | null;
+  url: string;
+  profileStatus: WorkspaceProfileStatus;
+};
+
+type WorkspaceToolDependencies = {
+  connectWorkspaceSocket: typeof connectWorkspaceSocket;
+  joinWorkspace: typeof joinWorkspace;
+  loadDoc: typeof loadDoc;
+};
+
+const DEFAULT_WORKSPACE_TOOL_DEPENDENCIES: WorkspaceToolDependencies = {
+  connectWorkspaceSocket,
+  joinWorkspace,
+  loadDoc,
+};
+
+function affineBaseUrl(endpoint: string): string {
+  const configuredBaseUrl = process.env.AFFINE_BASE_URL?.trim();
+  return (configuredBaseUrl || new URL(endpoint).origin).replace(/\/+$/, "");
+}
+
+function summarizeWorkspace(
+  workspace: WorkspaceRecord,
+  endpoint: string,
+  profileStatus: WorkspaceProfileStatus,
+  profile?: { name: string | null; avatar: string | null },
+): WorkspaceSummary {
+  const existingName = typeof workspace.name === "string" ? workspace.name : null;
+  const existingAvatar = typeof workspace.avatar === "string" ? workspace.avatar : null;
+  return {
+    ...workspace,
+    name: profile?.name ?? existingName,
+    avatar: profile?.avatar ?? existingAvatar,
+    url: `${affineBaseUrl(endpoint)}/workspace/${encodeURIComponent(workspace.id)}`,
+    profileStatus,
+  };
+}
+
+async function readWorkspaceProfile(
+  socket: WorkspaceSocket,
+  workspaceId: string,
+  dependencies: WorkspaceToolDependencies,
+): Promise<{ name: string | null; avatar: string | null }> {
+  await dependencies.joinWorkspace(socket, workspaceId);
+  const snapshot = await dependencies.loadDoc(socket, workspaceId, workspaceId);
+  if (!snapshot.missing) {
+    throw new Error(`Workspace profile metadata is unavailable for ${workspaceId}.`);
+  }
+
+  const workspaceDoc = new Y.Doc();
+  Y.applyUpdate(workspaceDoc, Buffer.from(snapshot.missing, "base64"));
+  const meta = workspaceDoc.getMap("meta");
+  const name = meta.get("name");
+  const avatar = meta.get("avatar");
+  return {
+    name: typeof name === "string" ? name : null,
+    avatar: typeof avatar === "string" ? avatar : null,
+  };
+}
+
+async function enrichWorkspaceProfiles(
+  gql: GraphQLClient,
+  workspaces: WorkspaceRecord[],
+  includeProfile: boolean,
+  dependencies: WorkspaceToolDependencies,
+): Promise<WorkspaceSummary[]> {
+  const endpoint = gql.endpoint;
+  if (!includeProfile) {
+    return workspaces.map(workspace => summarizeWorkspace(workspace, endpoint, "skipped"));
+  }
+  if (workspaces.length === 0) {
+    return [];
+  }
+
+  let socket: WorkspaceSocket;
+  try {
+    const { endpoint: connectionEndpoint, cookie, bearer } = await gql.getConnectionAuth();
+    socket = await dependencies.connectWorkspaceSocket(
+      wsUrlFromGraphQLEndpoint(connectionEndpoint),
+      cookie,
+      bearer,
+    );
+  } catch {
+    return workspaces.map(workspace => summarizeWorkspace(workspace, endpoint, "unavailable"));
+  }
+
+  try {
+    const enriched: WorkspaceSummary[] = [];
+    for (const workspace of workspaces) {
+      try {
+        const profile = await readWorkspaceProfile(socket, workspace.id, dependencies);
+        enriched.push(summarizeWorkspace(workspace, endpoint, "available", profile));
+      } catch {
+        enriched.push(summarizeWorkspace(workspace, endpoint, "unavailable"));
+      }
+    }
+    return enriched;
+  } finally {
+    socket.disconnect();
+  }
+}
 
 // Generate AFFiNE-style document ID
 function generateDocId(): string {
@@ -129,13 +244,28 @@ function createInitialWorkspaceData(workspaceName: string = 'New Workspace', ava
   };
 }
 
-export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
+export function registerWorkspaceTools(
+  server: McpServer,
+  gql: GraphQLClient,
+  dependencyOverrides: Partial<WorkspaceToolDependencies> = {},
+) {
+  const dependencies = {
+    ...DEFAULT_WORKSPACE_TOOL_DEPENDENCIES,
+    ...dependencyOverrides,
+  };
+
   // LIST WORKSPACES
-  const listWorkspacesHandler = async () => {
+  const listWorkspacesHandler = async ({ includeProfile = true }: { includeProfile?: boolean } = {}) => {
     try {
       const query = `query { workspaces { id public enableAi createdAt } }`;
-      const data = await gql.request<{ workspaces: any[] }>(query);
-      return text(data.workspaces || []);
+      const data = await gql.request<{ workspaces: WorkspaceRecord[] }>(query);
+      const workspaces = await enrichWorkspaceProfiles(
+        gql,
+        data.workspaces || [],
+        includeProfile,
+        dependencies,
+      );
+      return text(workspaces);
     } catch (error: any) {
       return toolError(error, { code: "workspace_list_failed" });
     }
@@ -145,7 +275,12 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
     "list_workspaces",
     {
       title: "List Workspaces",
-      description: "List all available AFFiNE workspaces"
+      description: "List available AFFiNE workspaces with best-effort profile metadata and direct URLs",
+      inputSchema: {
+        includeProfile: z.boolean().optional().default(true).describe(
+          "Load workspace names and avatar references from realtime metadata. Set false for a faster GraphQL-only response.",
+        ),
+      },
     },
     listWorkspacesHandler as any
   );
@@ -165,8 +300,12 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
           } 
         } 
       }`;
-      const data = await gql.request<{ workspace: any }>(query, { id });
-      return text(data.workspace);
+      const data = await gql.request<{ workspace: WorkspaceRecord }>(query, { id });
+      if (!data.workspace || typeof data.workspace !== "object") {
+        return text(data.workspace);
+      }
+      const [workspace] = await enrichWorkspaceProfiles(gql, [data.workspace], true, dependencies);
+      return text(workspace);
     } catch (error: any) {
       return toolError(error, { code: "workspace_get_failed" });
     }
@@ -176,7 +315,7 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
     "get_workspace",
     {
       title: "Get Workspace",
-      description: "Get details of a specific workspace",
+      description: "Get workspace details with best-effort profile metadata and a direct URL",
       inputSchema: { 
         id: z.string().describe("Workspace ID") 
       }

--- a/tests/test-suites.json
+++ b/tests/test-suites.json
@@ -59,7 +59,8 @@
     "test-test-suite-verifier.mjs": "fast",
     "test-theme-defaults-setup.mjs": "integration",
     "test-tool-filtering.mjs": "fast",
-    "test-url-safety.mjs": "fast"
+    "test-url-safety.mjs": "fast",
+    "test-workspace-discovery.mjs": "fast"
   },
   "suites": {
     "fast": [
@@ -87,7 +88,8 @@
       "test-secure-random.mjs",
       "test-test-suite-verifier.mjs",
       "test-tool-filtering.mjs",
-      "test-url-safety.mjs"
+      "test-url-safety.mjs",
+      "test-workspace-discovery.mjs"
     ],
     "e2e": [
       "test-database-creation.mjs",

--- a/tests/test-supporting-tools.mjs
+++ b/tests/test-supporting-tools.mjs
@@ -127,12 +127,19 @@ async function main() {
 
     const listedWorkspacesAfter = await call('list_workspaces');
     expectArray(listedWorkspacesAfter, 'list_workspaces after create');
-    if (!listedWorkspacesAfter.some(entry => entry?.id === workspaceId)) {
+    const listedWorkspace = listedWorkspacesAfter.find(entry => entry?.id === workspaceId);
+    if (!listedWorkspace) {
       throw new Error('list_workspaces did not include created workspace');
     }
+    expectEqual(listedWorkspace.name, workspaceName, 'list_workspaces workspace name');
+    expectEqual(listedWorkspace.profileStatus, 'available', 'list_workspaces profileStatus');
+    expectTruthy(listedWorkspace.url, 'list_workspaces workspace URL');
 
     const fetchedWorkspace = await call('get_workspace', { id: workspaceId });
     expectEqual(fetchedWorkspace?.id, workspaceId, 'get_workspace id');
+    expectEqual(fetchedWorkspace?.name, workspaceName, 'get_workspace workspace name');
+    expectEqual(fetchedWorkspace?.profileStatus, 'available', 'get_workspace profileStatus');
+    expectTruthy(fetchedWorkspace?.url, 'get_workspace workspace URL');
 
     const updatedWorkspace = await call('update_workspace', {
       id: workspaceId,

--- a/tests/test-workspace-discovery.mjs
+++ b/tests/test-workspace-discovery.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import * as Y from "yjs";
+
+import { registerWorkspaceTools } from "../dist/tools/workspaces.js";
+
+class ToolRegistry {
+  tools = new Map();
+
+  registerTool(name, definition, handler) {
+    this.tools.set(name, { definition, handler });
+  }
+}
+
+function parseTextContent(result) {
+  const raw = result?.content?.[0]?.text;
+  return raw ? JSON.parse(raw) : null;
+}
+
+function parseToolResult(result) {
+  return result?.structuredContent ?? parseTextContent(result);
+}
+
+function encodedWorkspaceProfile(name, avatar) {
+  const doc = new Y.Doc();
+  const meta = doc.getMap("meta");
+  if (name !== undefined) meta.set("name", name);
+  if (avatar !== undefined) meta.set("avatar", avatar);
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+}
+
+function makeSocket() {
+  return {
+    disconnected: false,
+    disconnect() {
+      this.disconnected = true;
+    },
+  };
+}
+
+async function testListEnrichesProfilesBestEffort() {
+  const originalBaseUrl = process.env.AFFINE_BASE_URL;
+  process.env.AFFINE_BASE_URL = "https://affine.example/";
+  try {
+    const registry = new ToolRegistry();
+    const socket = makeSocket();
+    const joins = [];
+    const loads = [];
+    let connectionAuthCalls = 0;
+    let connectCalls = 0;
+
+    const gql = {
+      endpoint: "https://api.example/graphql",
+      async request(query) {
+        assert.match(query, /workspaces \{ id public enableAi createdAt \}/);
+        return {
+          workspaces: [
+            { id: "workspace-1", public: false, enableAi: true, createdAt: "2026-07-27T00:00:00.000Z" },
+            { id: "workspace-2", public: true, enableAi: false, createdAt: "2026-07-26T00:00:00.000Z" },
+          ],
+        };
+      },
+      async getConnectionAuth() {
+        connectionAuthCalls += 1;
+        return {
+          endpoint: "https://api.example/graphql",
+          cookie: "session=value",
+          bearer: "",
+          headers: {},
+        };
+      },
+    };
+
+    registerWorkspaceTools(registry, gql, {
+      async connectWorkspaceSocket(url, cookie, bearer) {
+        connectCalls += 1;
+        assert.equal(url, "wss://api.example");
+        assert.equal(cookie, "session=value");
+        assert.equal(bearer, "");
+        return socket;
+      },
+      async joinWorkspace(_socket, workspaceId) {
+        joins.push(workspaceId);
+        if (workspaceId === "workspace-2") throw new Error("profile denied");
+      },
+      async loadDoc(_socket, workspaceId, docId) {
+        loads.push({ workspaceId, docId });
+        return { missing: encodedWorkspaceProfile("Product", "blob-avatar") };
+      },
+    });
+
+    const listTool = registry.tools.get("list_workspaces");
+    assert.ok(listTool, "list_workspaces must be registered");
+    assert.ok(listTool.definition.inputSchema.includeProfile, "includeProfile input must be declared");
+
+    const result = await listTool.handler({});
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(parseTextContent(result), [
+      {
+        id: "workspace-1",
+        public: false,
+        enableAi: true,
+        createdAt: "2026-07-27T00:00:00.000Z",
+        name: "Product",
+        avatar: "blob-avatar",
+        url: "https://affine.example/workspace/workspace-1",
+        profileStatus: "available",
+      },
+      {
+        id: "workspace-2",
+        public: true,
+        enableAi: false,
+        createdAt: "2026-07-26T00:00:00.000Z",
+        name: null,
+        avatar: null,
+        url: "https://affine.example/workspace/workspace-2",
+        profileStatus: "unavailable",
+      },
+    ]);
+    assert.equal(connectionAuthCalls, 1);
+    assert.equal(connectCalls, 1, "one socket must be reused for the full list");
+    assert.deepEqual(joins, ["workspace-1", "workspace-2"]);
+    assert.deepEqual(loads, [{ workspaceId: "workspace-1", docId: "workspace-1" }]);
+    assert.equal(socket.disconnected, true, "the shared socket must always disconnect");
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.AFFINE_BASE_URL;
+    else process.env.AFFINE_BASE_URL = originalBaseUrl;
+  }
+}
+
+async function testListCanSkipProfileLoading() {
+  const registry = new ToolRegistry();
+  let connectionAuthCalls = 0;
+  const gql = {
+    endpoint: "https://affine.example/custom-graphql",
+    async request() {
+      return { workspaces: [{ id: "workspace-fast", public: false, enableAi: false, createdAt: "now" }] };
+    },
+    async getConnectionAuth() {
+      connectionAuthCalls += 1;
+      throw new Error("profile loading must be skipped");
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      throw new Error("profile loading must be skipped");
+    },
+  });
+
+  const result = parseTextContent(await registry.tools.get("list_workspaces").handler({ includeProfile: false }));
+  assert.deepEqual(result, [{
+    id: "workspace-fast",
+    public: false,
+    enableAi: false,
+    createdAt: "now",
+    name: null,
+    avatar: null,
+    url: "https://affine.example/workspace/workspace-fast",
+    profileStatus: "skipped",
+  }]);
+  assert.equal(connectionAuthCalls, 0);
+}
+
+async function testGetWorkspaceUsesTheSameProfileContract() {
+  const registry = new ToolRegistry();
+  const socket = makeSocket();
+  const requests = [];
+  const gql = {
+    endpoint: "https://affine.example/graphql",
+    async request(query, variables) {
+      requests.push({ query, variables });
+      return {
+        workspace: {
+          id: "workspace-detail",
+          public: false,
+          enableAi: true,
+          createdAt: "2026-07-27T00:00:00.000Z",
+          permissions: { Workspace_Read: true, Workspace_CreateDoc: true },
+        },
+      };
+    },
+    async getConnectionAuth() {
+      return { endpoint: this.endpoint, cookie: "", bearer: "token", headers: {} };
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      return socket;
+    },
+    async joinWorkspace(_socket, workspaceId) {
+      assert.equal(workspaceId, "workspace-detail");
+    },
+    async loadDoc(_socket, workspaceId, docId) {
+      assert.equal(workspaceId, "workspace-detail");
+      assert.equal(docId, "workspace-detail");
+      return { missing: encodedWorkspaceProfile("Detailed Workspace", "") };
+    },
+  });
+
+  const result = await registry.tools.get("get_workspace").handler({ id: "workspace-detail" });
+  assert.deepEqual(result.structuredContent, {
+    id: "workspace-detail",
+    public: false,
+    enableAi: true,
+    createdAt: "2026-07-27T00:00:00.000Z",
+    permissions: { Workspace_Read: true, Workspace_CreateDoc: true },
+    name: "Detailed Workspace",
+    avatar: "",
+    url: "https://affine.example/workspace/workspace-detail",
+    profileStatus: "available",
+  });
+  assert.deepEqual(requests[0].variables, { id: "workspace-detail" });
+  assert.equal(socket.disconnected, true);
+}
+
+async function testProfileFailuresDoNotHideGraphqlResults() {
+  const registry = new ToolRegistry();
+  let requestMode = "success";
+  const gql = {
+    endpoint: "https://affine.example/graphql",
+    async request() {
+      if (requestMode === "failure") throw new Error("GraphQL unavailable");
+      return { workspaces: [{ id: "workspace-1", public: false, enableAi: true, createdAt: "now" }] };
+    },
+    async getConnectionAuth() {
+      return { endpoint: this.endpoint, cookie: "", bearer: "", headers: {} };
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      throw new Error("WebSocket unavailable");
+    },
+  });
+
+  const degraded = await registry.tools.get("list_workspaces").handler({});
+  assert.equal(degraded.isError, undefined);
+  assert.equal(parseTextContent(degraded)[0].profileStatus, "unavailable");
+
+  requestMode = "failure";
+  const failed = await registry.tools.get("list_workspaces").handler({});
+  assert.equal(failed.isError, true);
+  assert.equal(failed.structuredContent.code, "workspace_list_failed");
+  assert.match(failed.structuredContent.error, /GraphQL unavailable/);
+}
+
+await testListEnrichesProfilesBestEffort();
+await testListCanSkipProfileLoading();
+await testGetWorkspaceUsesTheSameProfileContract();
+await testProfileFailuresDoNotHideGraphqlResults();
+console.log("Workspace discovery tests passed");


### PR DESCRIPTION
## Summary

- enrich `list_workspaces` and `get_workspace` with workspace names, avatar references, direct URLs, and explicit profile status
- preserve the existing GraphQL fields and top-level list response shape while degrading profile lookup failures per workspace
- add an `includeProfile: false` fast path plus deterministic and live integration coverage

## Validation

- `npm run ci`
- `npm run test:comprehensive` (15 integration tests and 107 regression checks)
- `npm run test:e2e` (21 release integration tests and 14 Playwright tests)
- `git diff --check`
- repository Hangul scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace listings and details now include best-effort profile metadata: name, avatar, direct URL, and profile status.
  * Added an option to skip profile enrichment for faster workspace listings.
  * Profile-loading failures now preserve workspace results and clearly indicate unavailable metadata.

* **Documentation**
  * Updated workspace tool documentation and changelog with the new metadata and behavior.

* **Tests**
  * Added coverage for workspace discovery, profile enrichment, failure handling, and optimized listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->