### PR TITLE
chore: prepare v3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-27
+
 ### Added
 - `list_workspaces` and `get_workspace` now include best-effort workspace profile names, avatar references, direct URLs, and an explicit profile status while preserving the existing GraphQL fields and list response shape.
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
 - Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
+- Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and filters only locally acknowledged deletions from stale `list_docs` edges while upstream indexing converges.
 - Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
 
 ### Tests
 - Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
+- Added deterministic and live integration coverage for workspace profile enrichment, failure isolation, and the GraphQL-only `includeProfile: false` fast path.
+
+### Dependencies
+- Updated `jose` from 6.2.3 to 6.2.4.
+- Refreshed locked HTTP and URI parser dependencies, including `hono`, `body-parser`, `type-is`, and `fast-uri`, clearing the current high-severity audit finding.
 
 ## [3.0.1] - 2026-07-21
 
@@ -620,8 +628,9 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
-[3.0.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.0
+[3.1.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.1.0
 [3.0.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.1
+[3.0.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.0
 [2.5.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.5.0
 [2.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.4.0
 [2.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.3.0
@@ -649,4 +658,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Markdown import now converts `[label](LinkedPage:<docId>)` links into native inline linked-doc references, and Markdown export serializes those references back to the same `LinkedPage:` scheme, making inline doc references round-trip safe.
+- `list_workspaces` and `get_workspace` now include best-effort workspace profile names, avatar references, direct URLs, and an explicit profile status while preserving the existing GraphQL fields and list response shape.
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
+- Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
+- Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
+
+### Tests
+- Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
 
 ## [3.0.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Markdown import now converts `[label](LinkedPage:<docId>)` links into native inline linked-doc references, and Markdown export serializes those references back to the same `LinkedPage:` scheme, making inline doc references round-trip safe.
 
+### Fixed
+- Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
+
 ## [3.0.0] - 2026-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
 - Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
 - Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and filters only locally acknowledged deletions from stale `list_docs` edges while upstream indexing converges.
+- Acknowledged deletion tombstones now expire after ten minutes and retain at most 10,000 entries, bounding process memory while preserving the index-convergence window.
+- Case-insensitive `x-affine-version` overrides now replace the default cleanly in CLI and readiness requests instead of producing duplicate header values.
+- Created-workspace URLs now derive from the same canonical AFFiNE origin resolver used by workspace discovery, including custom GraphQL paths.
 - Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
 
 ### Tests
 - Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
 - Added deterministic and live integration coverage for workspace profile enrichment, failure isolation, and the GraphQL-only `includeProfile: false` fast path.
+- Hardened Playwright sign-in setup against clicks that occur before the self-hosted AFFiNE page finishes hydrating.
 
 ### Dependencies
 - Updated `jose` from 6.2.3 to 6.2.4.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.0.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.1.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -49,7 +49,7 @@ Scope boundaries:
 - AFFiNE 0.27+ removed the legacy personal-access-token GraphQL API; this server no longer exposes token-management tools
 - AFFiNE Cloud requires browser-session authentication for this external GraphQL integration; programmatic email/password sign-in is blocked by Cloudflare
 
-> New in v3.0.1: Markdown import/export now preserves AFFiNE inline LinkedPage references for safe round-tripping.
+> New in v3.1.0: Workspace discovery now includes profile metadata and direct links, with improved authentication and document deletion compatibility for AFFiNE 0.27.3.
 
 ## Choose Your Path
 | Goal | Start here |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,12 +14,15 @@
   - Profile lookup failures are isolated per workspace instead of failing the entire result.
 - Authentication and compatibility
   - Added `AFFINE_CLIENT_VERSION` with a default of `0.26.0` and send `x-affine-version` on sign-in, GraphQL, REST, CLI, and readiness requests.
-  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides remain supported.
+  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides replace the default without duplicate values.
   - Environment authentication is resolved as one credential group, preventing saved tokens, cookies, or authentication headers from masking client-provided email/password credentials.
   - MCP Inspector setup guidance now explains how to load a named Claude Desktop server configuration.
 - Document lifecycle
   - `delete_doc` accepts top-level and nested success acknowledgements returned by current AFFiNE servers.
   - Successfully acknowledged deletions are filtered from stale document listings without hiding unrelated orphan documents.
+  - Acknowledged deletion tombstones expire after ten minutes and retain at most 10,000 entries.
+- Workspace URLs
+  - Newly created workspaces use the same canonical AFFiNE origin resolver as workspace discovery, including deployments with custom GraphQL paths.
 - Dependencies and security
   - Updated `jose` from 6.2.3 to 6.2.4.
   - Refreshed locked HTTP and URI parser dependencies and cleared the current high-severity `fast-uri` audit finding.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,41 @@
 # Release Notes
 
+## Version 3.1.0 (2026-07-27)
+
+### Highlights
+- Workspace discovery now returns best-effort profile names, avatar references, direct URLs, and explicit profile status without changing the existing top-level result shape.
+- Self-hosted email/password authentication is more reliable on AFFiNE 0.27.3 because environment credentials override stale saved authentication and every HTTP path sends the required client-version header.
+- Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and hides only confirmed deletions while upstream indexes converge.
+
+### What Changed
+- Workspace discovery
+  - `list_workspaces` and `get_workspace` enrich GraphQL results with profile metadata when available.
+  - `list_workspaces` accepts `includeProfile: false` for a faster GraphQL-only response.
+  - Profile lookup failures are isolated per workspace instead of failing the entire result.
+- Authentication and compatibility
+  - Added `AFFINE_CLIENT_VERSION` with a default of `0.26.0` and send `x-affine-version` on sign-in, GraphQL, REST, CLI, and readiness requests.
+  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides remain supported.
+  - Environment authentication is resolved as one credential group, preventing saved tokens, cookies, or authentication headers from masking client-provided email/password credentials.
+  - MCP Inspector setup guidance now explains how to load a named Claude Desktop server configuration.
+- Document lifecycle
+  - `delete_doc` accepts top-level and nested success acknowledgements returned by current AFFiNE servers.
+  - Successfully acknowledged deletions are filtered from stale document listings without hiding unrelated orphan documents.
+- Dependencies and security
+  - Updated `jose` from 6.2.3 to 6.2.4.
+  - Refreshed locked HTTP and URI parser dependencies and cleared the current high-severity `fast-uri` audit finding.
+
+### Compatibility
+- No tools were removed and no existing input is required to change.
+- Node.js 20 or newer remains required.
+- Operators can override `AFFINE_CLIENT_VERSION` when an AFFiNE deployment requires a newer minimum client version.
+
+### Validation Evidence
+- `npm run ci`
+- `npm audit --audit-level=high`
+- `npm run test:comprehensive`
+- `AFFINE_REVISION=0.27.3 npm run test:e2e`
+- package smoke test and `npm publish --dry-run --access public --ignore-scripts`
+
 ## Version 3.0.1 (2026-07-21)
 
 ### Highlights

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -81,6 +81,30 @@ Self-hosted email/password example:
 }
 ```
 
+## MCP Inspector
+
+MCP Inspector does not automatically read Claude Desktop's server
+configuration. Starting it with only `affine-mcp` launches a separate process
+without the `AFFINE_*` environment variables from
+`claude_desktop_config.json`.
+
+To inspect the same `affine` server configuration on macOS, pass the Claude
+Desktop config file explicitly:
+
+```bash
+npx @modelcontextprotocol/inspector \
+  --config "$HOME/Library/Application Support/Claude/claude_desktop_config.json" \
+  --server affine
+```
+
+On Linux, use `~/.config/Claude/claude_desktop_config.json`. On Windows, use
+`%APPDATA%\Claude\claude_desktop_config.json`. The value passed to `--server`
+must match the key under `mcpServers`.
+
+Inspector also accepts individual server environment variables through
+repeated `-e KEY=value` arguments. Prefer the config-file form for passwords
+and other secrets so they are not copied into shell history.
+
 ## Codex CLI
 
 With saved config:
@@ -176,4 +200,5 @@ browser history.
 - Use a dedicated least-privilege account for automated self-hosted environments
 - Use `AFFINE_API_TOKEN` only when the target deployment still accepts a compatible GraphQL bearer token
 - If your shell treats `!` specially, wrap passwords in single quotes
+- When using MCP Inspector, pass `--config` and `--server` or supply the required `AFFINE_*` values with `-e`
 - Use `affine-mcp doctor` whenever a client config looks correct but the connection still fails

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -12,11 +12,24 @@ The server resolves configuration in this order:
 
 The saved config file uses the same `KEY=value` names shown below. Environment variables always override saved values, and the CLI diagnostics report the source selected for each runtime option.
 
+Authentication credentials are resolved as one source-scoped group. If the
+environment provides any of `AFFINE_API_TOKEN`, `AFFINE_COOKIE`,
+`AFFINE_EMAIL`, or `AFFINE_PASSWORD`, saved authentication credentials are not
+mixed into that environment configuration. An `Authorization` or `Cookie`
+entry in an environment-provided `AFFINE_HEADERS_JSON` also selects the
+environment authentication group. Non-authentication headers from saved
+configuration remain available when no environment `AFFINE_HEADERS_JSON`
+replaces them.
+
 Auth priority within the active configuration:
 
 1. `AFFINE_API_TOKEN`
 2. `AFFINE_COOKIE`
 3. `AFFINE_EMAIL` and `AFFINE_PASSWORD`
+
+This priority is applied only within the selected environment or saved-config
+group. For example, environment email/password credentials take precedence
+over an older saved API token or session cookie.
 
 Email/password authentication is process-scoped. Concurrent HTTP MCP sessions
 share one sign-in attempt and the resulting cookie. In the default `async`

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -40,6 +40,7 @@ cookie, while setting a bearer credential removes any cookie header.
 | `AFFINE_HEADERS_JSON` | No | none | JSON object of additional string headers sent to AFFiNE; built-in token/cookie auth takes priority |
 | `AFFINE_WORKSPACE_ID` | No | Auto-detected when possible | Pins the active workspace |
 | `AFFINE_LOGIN_AT_START` | No | `async` | `async` starts one shared login without blocking transport startup; `sync` requires login before startup |
+| `AFFINE_CLIENT_VERSION` | No | `0.26.0` | AFFiNE web-client version sent as the `x-affine-version` header on GraphQL/REST requests. Servers that gate on client version reject sign-in with `403 UNSUPPORTED_CLIENT_VERSION` when it is too low; raise this if your deployment pins a higher minimum. Also used as the fallback default for `AFFINE_WS_CLIENT_VERSION` |
 | `XDG_CONFIG_HOME` | No | `~/.config` | Changes the parent directory used for the saved `affine-mcp/config` file |
 
 ### Blob upload safeguards
@@ -96,7 +97,7 @@ cookie, while setting a bearer credential removes any cookie header.
 
 | Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `AFFINE_WS_CLIENT_VERSION` | No | `0.26.0` | Environment-only AFFiNE client version sent during workspace socket connection |
+| `AFFINE_WS_CLIENT_VERSION` | No | `AFFINE_CLIENT_VERSION` (else `0.26.0`) | Environment-only AFFiNE client version sent during workspace socket connection; falls back to `AFFINE_CLIENT_VERSION` when unset |
 | `AFFINE_WS_CONNECT_TIMEOUT_MS` | No | `10000` | Environment-only milliseconds to wait for a workspace socket connection |
 | `AFFINE_WS_ACK_TIMEOUT_MS` | No | `10000` | Environment-only milliseconds to wait for a workspace socket acknowledgement |
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -16,13 +16,15 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 
 | Tool | Purpose | Notes |
 | --- | --- | --- |
-| `list_workspaces` | List all available workspaces | Good first discovery step |
-| `get_workspace` | Read workspace details | Includes settings and metadata |
+| `list_workspaces` | List all available workspaces | Includes best-effort profile names, avatar references, and direct URLs; set `includeProfile: false` for a faster GraphQL-only response |
+| `get_workspace` | Read workspace details | Includes permissions plus best-effort profile metadata and a direct URL |
 | `create_workspace` | Create a workspace with an initial document | Destructive in the sense that it creates new server state |
 | `update_workspace` | Update workspace settings | Use carefully in shared workspaces |
 | `delete_workspace` | Permanently delete a workspace | Destructive; `confirmWorkspaceId` must exactly match `id`; unconfirmed outcomes return an MCP error instead of a success receipt |
 | `list_workspace_tree` | Return the workspace document hierarchy as a tree | Useful before moving docs; depth is limited to 0-20 |
 | `get_orphan_docs` | Find documents that are not linked from a parent doc | Useful for cleanup and audits |
+
+`list_workspaces` and `get_workspace` add `name`, `avatar`, `url`, and `profileStatus` to the existing GraphQL fields. `profileStatus` is `available`, `unavailable`, or `skipped`. Profile loading is best effort, so a realtime metadata failure leaves the GraphQL workspace visible with nullable profile fields. The `avatar` value is AFFiNE's stored avatar reference and is not guaranteed to be an external URL.
 
 ## Organization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1086,21 +1086,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1528,9 +1541,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1776,9 +1789,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2496,17 +2509,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "test:tag-visibility": "node tests/test-tag-visibility.mjs",
     "test:tag-deletion": "node tests/test-tag-deletion.mjs",
     "test:url-safety": "node tests/test-url-safety.mjs",
+    "test:workspace-discovery": "node tests/test-workspace-discovery.mjs",
     "test:markdown-roundtrip": "node tests/test-markdown-roundtrip.mjs",
     "test:document-mutation-safety": "node tests/test-document-mutation-safety.mjs",
     "test:markdown-output-safety": "node tests/test-markdown-output-safety.mjs",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -31,6 +31,12 @@ function sanitizeSignInHeaders(headers?: Record<string, string>): Record<string,
   );
 }
 
+/** Case-insensitive presence check — HTTP header names are case-insensitive. */
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((key) => key.toLowerCase() === lower);
+}
+
 /**
  * Exchange email/password for a session cookie.
  *
@@ -45,17 +51,23 @@ export async function loginWithPassword(
   configuredHeaders?: Record<string, string>,
 ): Promise<{ cookieHeader: string }> {
   const url = `${baseUrl.replace(/\/$/, "")}/api/auth/sign-in`;
+  // Configured headers first so an explicit override wins; only supply the
+  // default version when the caller did not set one in any casing, so Fetch
+  // can't coalesce two `x-affine-version` casings into one comma-joined value.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...sanitizeSignInHeaders(configuredHeaders),
+  };
+  if (!hasHeader(headers, "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), AUTH_FETCH_TIMEOUT_MS);
   let res;
   try {
     res = await fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-affine-version": AFFINE_CLIENT_VERSION,
-        ...sanitizeSignInHeaders(configuredHeaders),
-      },
+      headers,
       body: JSON.stringify({ email, password }),
       signal: controller.signal,
     });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -20,7 +20,30 @@ function assertNoCRLF(value: string, label: string): void {
   }
 }
 
-export async function loginWithPassword(baseUrl: string, email: string, password: string): Promise<{ cookieHeader: string }> {
+/**
+ * Drop authentication headers a sign-in must never carry — it establishes the
+ * session cookie itself, so any inherited `Authorization`/`Cookie` is stale.
+ */
+function sanitizeSignInHeaders(headers?: Record<string, string>): Record<string, string> {
+  if (!headers) return {};
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !/^(authorization|cookie)$/i.test(name)),
+  );
+}
+
+/**
+ * Exchange email/password for a session cookie.
+ *
+ * `configuredHeaders` (typically `config.headers` from `AFFINE_HEADERS_JSON`)
+ * is merged after the defaults so an explicit `x-affine-version` override wins,
+ * matching how the GraphQL/REST paths honor the same override.
+ */
+export async function loginWithPassword(
+  baseUrl: string,
+  email: string,
+  password: string,
+  configuredHeaders?: Record<string, string>,
+): Promise<{ cookieHeader: string }> {
   const url = `${baseUrl.replace(/\/$/, "")}/api/auth/sign-in`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), AUTH_FETCH_TIMEOUT_MS);
@@ -31,6 +54,7 @@ export async function loginWithPassword(baseUrl: string, email: string, password
       headers: {
         "Content-Type": "application/json",
         "x-affine-version": AFFINE_CLIENT_VERSION,
+        ...sanitizeSignInHeaders(configuredHeaders),
       },
       body: JSON.stringify({ email, password }),
       signal: controller.signal,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,7 @@
 import { fetch } from "undici";
 
+import { AFFINE_CLIENT_VERSION } from "./config.js";
+
 const AUTH_FETCH_TIMEOUT_MS = 30_000;
 
 function extractCookiePairs(setCookies: string[]): string {
@@ -26,7 +28,10 @@ export async function loginWithPassword(baseUrl: string, email: string, password
   try {
     res = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-affine-version": AFFINE_CLIENT_VERSION,
+      },
       body: JSON.stringify({ email, password }),
       signal: controller.signal,
     });

--- a/src/authSession.ts
+++ b/src/authSession.ts
@@ -15,6 +15,8 @@ type AuthSessionOptions = {
   cookie?: string;
   email?: string;
   password?: string;
+  /** Extra headers (e.g. from AFFINE_HEADERS_JSON) forwarded to email/password sign-in. */
+  headers?: Record<string, string>;
   login?: LoginFunction;
 };
 
@@ -29,6 +31,7 @@ export function parseLoginMode(raw: string | undefined): LoginMode {
 export class AuthSession {
   private readonly baseUrl: string;
   private readonly login: LoginFunction;
+  private readonly headers?: Record<string, string>;
   private email?: string;
   private password?: string;
   private immediate: AuthSnapshot;
@@ -42,6 +45,7 @@ export class AuthSession {
 
     this.baseUrl = options.baseUrl;
     this.login = options.login || loginWithPassword;
+    this.headers = options.headers;
     this.email = hasImmediateAuth ? undefined : options.email;
     this.password = hasImmediateAuth ? undefined : options.password;
 
@@ -89,7 +93,7 @@ export class AuthSession {
     console.error("[affine-mcp] Authenticating with email/password...");
 
     this.pending = Promise.resolve()
-      .then(() => this.login(this.baseUrl, email, password))
+      .then(() => this.login(this.baseUrl, email, password, this.headers))
       .then(({ cookieHeader }) => {
         this.immediate = { kind: "cookie", cookie: cookieHeader };
         console.error("[affine-mcp] Email/password authentication succeeded");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as readline from "readline";
 
 import {
+  AFFINE_CLIENT_VERSION,
   buildGraphqlEndpoint,
   CONFIG_FILE,
   loadConfig,
@@ -115,6 +116,7 @@ async function gql(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
+    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(auth.headers || {}),
   };
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -205,6 +205,15 @@ function getConfigValueSource(name: string, file: Record<string, string>, fallba
   return "unset";
 }
 
+function getEffectiveAuthValueSource(
+  name: string,
+  value: string | undefined,
+  file: Record<string, string>,
+): "env" | "config" | "unset" {
+  if (!value) return "unset";
+  return process.env[name] ? "env" : file[name] ? "config" : "unset";
+}
+
 function buildEffectiveConfigSummary(effective: ServerConfig = loadConfig()) {
   const stored = loadConfigFile();
   const authKind = effective.apiToken
@@ -245,10 +254,10 @@ function buildEffectiveConfigSummary(effective: ServerConfig = loadConfig()) {
       baseUrl: getConfigValueSource("AFFINE_BASE_URL", stored, "http://localhost:3010"),
       graphqlPath: getConfigValueSource("AFFINE_GRAPHQL_PATH", stored, "/graphql"),
       additionalHeaders: getConfigValueSource("AFFINE_HEADERS_JSON", stored),
-      apiToken: getConfigValueSource("AFFINE_API_TOKEN", stored),
-      cookie: getConfigValueSource("AFFINE_COOKIE", stored),
-      email: getConfigValueSource("AFFINE_EMAIL", stored),
-      password: getConfigValueSource("AFFINE_PASSWORD", stored),
+      apiToken: getEffectiveAuthValueSource("AFFINE_API_TOKEN", effective.apiToken, stored),
+      cookie: getEffectiveAuthValueSource("AFFINE_COOKIE", effective.cookie, stored),
+      email: getEffectiveAuthValueSource("AFFINE_EMAIL", effective.email, stored),
+      password: getEffectiveAuthValueSource("AFFINE_PASSWORD", effective.password, stored),
       workspaceId: getConfigValueSource("AFFINE_WORKSPACE_ID", stored),
       authMode: getConfigValueSource("AFFINE_MCP_AUTH_MODE", stored, "bearer"),
       publicBaseUrl: getConfigValueSource("AFFINE_MCP_PUBLIC_BASE_URL", stored),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,9 +116,11 @@ async function gql(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
-    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(auth.headers || {}),
   };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
   if (auth.cookie) headers.Cookie = auth.cookie;
   const body: any = { query };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -280,7 +280,7 @@ async function resolveCliAuth(effective: ServerConfig): Promise<{ auth: CliAuth;
     };
   }
   if (effective.email && effective.password) {
-    const { cookieHeader } = await loginWithPassword(effective.baseUrl, effective.email, effective.password);
+    const { cookieHeader } = await loginWithPassword(effective.baseUrl, effective.email, effective.password, effective.headers);
     return {
       auth: { cookie: cookieHeader, headers: effective.headers },
       authKind: "email-password",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,17 @@ const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 export const VERSION: string = pkg.version;
 
+/**
+ * AFFiNE gates GraphQL/REST requests behind a minimum web-client version,
+ * advertised via the `x-affine-version` request header. Newer / self-hosted
+ * servers reject sign-in with `403 ACTION_FORBIDDEN`
+ * (`UNSUPPORTED_CLIENT_VERSION`) when the header is missing. This is the
+ * HTTP counterpart to `AFFINE_WS_CLIENT_VERSION` (used for the realtime
+ * socket); override it if your deployment pins a different minimum.
+ */
+export const AFFINE_CLIENT_VERSION: string =
+  process.env.AFFINE_CLIENT_VERSION || "0.26.0";
+
 export type TransportMode = "stdio" | "http";
 export type LoginAtStartMode = "async" | "sync";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -245,6 +245,20 @@ function resolveAuthenticationConfig(file: Record<string, string>) {
   const environmentProvidesAuthentication = AUTH_CREDENTIAL_VARIABLES.some(
     (name) => Boolean(process.env[name]),
   ) || (headersSource === "env" && hasAuthenticationHeader(headers));
+
+  const environmentHasEmail = Boolean(process.env.AFFINE_EMAIL);
+  const environmentHasPassword = Boolean(process.env.AFFINE_PASSWORD);
+  if (
+    environmentProvidesAuthentication &&
+    environmentHasEmail !== environmentHasPassword &&
+    Boolean(file.AFFINE_EMAIL || file.AFFINE_PASSWORD)
+  ) {
+    console.warn(
+      "[affine-mcp] WARNING: Environment provides only one of AFFINE_EMAIL or AFFINE_PASSWORD. " +
+        "Saved email/password credentials are ignored; set both environment variables to use email/password authentication.",
+    );
+  }
+
   const credentials = environmentProvidesAuthentication ? process.env : file;
 
   const apiToken = credentials.AFFINE_API_TOKEN || undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -213,6 +213,60 @@ function removeHeadersCaseInsensitive(
   return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
+const AUTH_CREDENTIAL_VARIABLES = [
+  "AFFINE_API_TOKEN",
+  "AFFINE_COOKIE",
+  "AFFINE_EMAIL",
+  "AFFINE_PASSWORD",
+] as const;
+
+function hasAuthenticationHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers || {}).some((name) => /^(authorization|cookie)$/i.test(name));
+}
+
+/**
+ * Resolve authentication as one source-scoped group.
+ *
+ * Mixing individual keys first and choosing an auth method afterwards lets a
+ * saved token or cookie outrank environment email/password credentials. Once
+ * the environment provides any authentication value, all saved authentication
+ * values are ignored while unrelated saved headers remain available.
+ */
+function resolveAuthenticationConfig(file: Record<string, string>) {
+  const environmentHeadersJson = process.env.AFFINE_HEADERS_JSON;
+  const savedHeadersJson = file.AFFINE_HEADERS_JSON;
+  const headersSource = environmentHeadersJson
+    ? "env"
+    : savedHeadersJson
+      ? "config"
+      : "unset";
+  let headers = parseHeadersJson(environmentHeadersJson || savedHeadersJson);
+
+  const environmentProvidesAuthentication = AUTH_CREDENTIAL_VARIABLES.some(
+    (name) => Boolean(process.env[name]),
+  ) || (headersSource === "env" && hasAuthenticationHeader(headers));
+  const credentials = environmentProvidesAuthentication ? process.env : file;
+
+  const apiToken = credentials.AFFINE_API_TOKEN || undefined;
+  const cookie = credentials.AFFINE_COOKIE || undefined;
+  const email = credentials.AFFINE_EMAIL || undefined;
+  const password = credentials.AFFINE_PASSWORD || undefined;
+
+  if (environmentProvidesAuthentication && headersSource === "config") {
+    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
+  }
+  if (apiToken) {
+    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
+  } else if (cookie) {
+    headers = {
+      ...(removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]) || {}),
+      Cookie: cookie,
+    };
+  }
+
+  return { apiToken, cookie, email, password, headers };
+}
+
 function parseAuthMode(raw: string | undefined): "bearer" | "oauth" {
   if (!raw) return "bearer";
   const normalized = raw.trim().toLowerCase();
@@ -323,19 +377,7 @@ export function loadConfig(): ServerConfig {
     },
   );
   const authMode = parseAuthMode(env("AFFINE_MCP_AUTH_MODE", file, "bearer"));
-  const apiToken = env("AFFINE_API_TOKEN", file);
-  const cookie = env("AFFINE_COOKIE", file);
-  const email = env("AFFINE_EMAIL", file);
-  const password = env("AFFINE_PASSWORD", file);
-  let headers: Record<string, string> | undefined = parseHeadersJson(env("AFFINE_HEADERS_JSON", file));
-  if (apiToken) {
-    headers = removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]);
-  } else if (cookie) {
-    headers = {
-      ...(removeHeadersCaseInsensitive(headers, ["authorization", "cookie"]) || {}),
-      Cookie: cookie,
-    };
-  }
+  const { apiToken, cookie, email, password, headers } = resolveAuthenticationConfig(file);
   const graphqlPath = validateGraphqlPath(env("AFFINE_GRAPHQL_PATH", file, "/graphql")!);
   const graphqlEndpoint = `${baseUrl}${graphqlPath}`;
   const defaultWorkspaceId = env("AFFINE_WORKSPACE_ID", file);

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -109,10 +109,24 @@ export class GraphQLClient {
     return this.opts.endpoint;
   }
 
+  /**
+   * Build the outgoing header set for a snapshot. `x-affine-version` goes first
+   * so an explicit override in `baseHeaders` (from `AFFINE_HEADERS_JSON`) wins,
+   * and auth headers last so they are never shadowed. Shared by the `headers`
+   * getter and `getConnectionAuth()` so every request path stays consistent.
+   */
+  private composeHeaders(snapshot: AuthSnapshot): Record<string, string> {
+    return {
+      "x-affine-version": AFFINE_CLIENT_VERSION,
+      ...this.baseHeaders,
+      ...authHeaders(snapshot),
+    };
+  }
+
   /** Synchronous snapshot for compatibility. Async consumers must use getConnectionAuth(). */
   get headers(): Record<string, string> {
     const snapshot = this.authOverride || this.resolvedAuth;
-    return { ...this.baseHeaders, ...authHeaders(snapshot) };
+    return this.composeHeaders(snapshot);
   }
 
   get cookie(): string {
@@ -169,14 +183,9 @@ export class GraphQLClient {
   /** Await authentication and return one normalized credential set for HTTP or WebSocket consumers. */
   async getConnectionAuth(): Promise<ConnectionAuth> {
     const snapshot = this.authOverride || await this.resolveAuth();
-    // `x-affine-version` first so an explicit AFFINE_HEADERS_JSON override (in
-    // baseHeaders) still wins. Injecting it here covers every consumer —
-    // request() below and the direct multipart/blob uploads in tools/.
-    const headers = {
-      "x-affine-version": AFFINE_CLIENT_VERSION,
-      ...this.baseHeaders,
-      ...authHeaders(snapshot),
-    };
+    // Injected here (not only in request()) so it also covers the direct
+    // multipart/blob uploads in tools/ that build their own fetch from this.
+    const headers = this.composeHeaders(snapshot);
     return {
       bearer: snapshot.kind === "bearer" ? snapshot.token : "",
       cookie: snapshot.kind === "cookie" ? snapshot.cookie : "",

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -1,7 +1,7 @@
 import { fetch } from "undici";
 
 import type { AuthSnapshot } from "./authSession.js";
-import { VERSION } from "./config.js";
+import { VERSION, AFFINE_CLIENT_VERSION } from "./config.js";
 
 const GQL_FETCH_TIMEOUT_MS = 30_000;
 
@@ -169,7 +169,14 @@ export class GraphQLClient {
   /** Await authentication and return one normalized credential set for HTTP or WebSocket consumers. */
   async getConnectionAuth(): Promise<ConnectionAuth> {
     const snapshot = this.authOverride || await this.resolveAuth();
-    const headers = { ...this.baseHeaders, ...authHeaders(snapshot) };
+    // `x-affine-version` first so an explicit AFFINE_HEADERS_JSON override (in
+    // baseHeaders) still wins. Injecting it here covers every consumer —
+    // request() below and the direct multipart/blob uploads in tools/.
+    const headers = {
+      "x-affine-version": AFFINE_CLIENT_VERSION,
+      ...this.baseHeaders,
+      ...authHeaders(snapshot),
+    };
     return {
       bearer: snapshot.kind === "bearer" ? snapshot.token : "",
       cookie: snapshot.kind === "cookie" ? snapshot.cookie : "",

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -116,11 +116,14 @@ export class GraphQLClient {
    * getter and `getConnectionAuth()` so every request path stays consistent.
    */
   private composeHeaders(snapshot: AuthSnapshot): Record<string, string> {
-    return {
-      "x-affine-version": AFFINE_CLIENT_VERSION,
-      ...this.baseHeaders,
-      ...authHeaders(snapshot),
-    };
+    const headers: Record<string, string> = { ...this.baseHeaders };
+    // Only supply the default when baseHeaders (AFFINE_HEADERS_JSON) has no
+    // `x-affine-version` in any casing, so Fetch can't coalesce two casings
+    // into one comma-joined value.
+    if (findHeader(headers, "x-affine-version") === undefined) {
+      headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+    }
+    return { ...headers, ...authHeaders(snapshot) };
   }
 
   /** Synchronous snapshot for compatibility. Async consumers must use getConnectionAuth(). */

--- a/src/httpDiagnostics.ts
+++ b/src/httpDiagnostics.ts
@@ -2,7 +2,7 @@ import type express from "express";
 import type { NextFunction, Request, Response } from "express";
 import { fetch } from "undici";
 
-import { VERSION, type ServerConfig } from "./config.js";
+import { VERSION, AFFINE_CLIENT_VERSION, type ServerConfig } from "./config.js";
 import type { HttpAuthState } from "./httpAuth.js";
 import { getOAuthResourceUrl, probeOAuthReadiness } from "./oauth.js";
 
@@ -12,6 +12,7 @@ async function probeAffineGraphql(config: ServerConfig): Promise<void> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
+    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(config.headers || {}),
   };
   if (config.apiToken) headers.Authorization = `Bearer ${config.apiToken}`;

--- a/src/httpDiagnostics.ts
+++ b/src/httpDiagnostics.ts
@@ -12,9 +12,11 @@ async function probeAffineGraphql(config: ServerConfig): Promise<void> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
-    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(config.headers || {}),
   };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   if (config.apiToken) headers.Authorization = `Bearer ${config.apiToken}`;
 
   const controller = new AbortController();

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ const authSession = new AuthSession({
   cookie: sessionCookie,
   email: sessionBearer || sessionCookie ? undefined : config.email,
   password: sessionBearer || sessionCookie ? undefined : config.password,
+  headers: config.headers,
 });
 
 if (config.authMode === "oauth" && !authSession.hasConfiguredAuth) {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -650,8 +650,70 @@ export async function deleteDocFromWorkspace(
   }
 }
 
+type AcknowledgedDeletedDocTrackerOptions = {
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+};
+
+export function createAcknowledgedDeletedDocTracker({
+  ttlMs = 10 * 60_000,
+  maxEntries = 10_000,
+  now = Date.now,
+}: AcknowledgedDeletedDocTrackerOptions = {}) {
+  const entries = new Map<string, Map<string, number>>();
+
+  const forget = (workspaceId: string, docId: string) => {
+    const workspaceEntries = entries.get(workspaceId);
+    workspaceEntries?.delete(docId);
+    if (workspaceEntries?.size === 0) {
+      entries.delete(workspaceId);
+    }
+  };
+
+  const prune = (currentTime: number) => {
+    const retained: Array<{ workspaceId: string; docId: string; acknowledgedAt: number }> = [];
+    for (const [workspaceId, workspaceEntries] of entries) {
+      for (const [docId, acknowledgedAt] of workspaceEntries) {
+        if (currentTime - acknowledgedAt >= ttlMs) {
+          workspaceEntries.delete(docId);
+        } else {
+          retained.push({ workspaceId, docId, acknowledgedAt });
+        }
+      }
+      if (workspaceEntries.size === 0) {
+        entries.delete(workspaceId);
+      }
+    }
+
+    const overflow = retained.length - maxEntries;
+    if (overflow > 0) {
+      retained.sort((left, right) => left.acknowledgedAt - right.acknowledgedAt);
+      for (const entry of retained.slice(0, overflow)) {
+        forget(entry.workspaceId, entry.docId);
+      }
+    }
+  };
+
+  return {
+    remember(workspaceId: string, docId: string) {
+      const currentTime = now();
+      prune(currentTime);
+      const workspaceEntries = entries.get(workspaceId) || new Map<string, number>();
+      workspaceEntries.set(docId, currentTime);
+      entries.set(workspaceId, workspaceEntries);
+      prune(currentTime);
+    },
+    forget,
+    idsFor(workspaceId: string): Set<string> {
+      prune(now());
+      return new Set(entries.get(workspaceId)?.keys() || []);
+    },
+  };
+}
+
 export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults: { workspaceId?: string }) {
-  const acknowledgedDeletedDocIds = new Map<string, Set<string>>();
+  const acknowledgedDeletedDocs = createAcknowledgedDeletedDocTracker();
 
   // helpers
   function generateId(): string {
@@ -4184,7 +4246,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const inTrashByDocId = new Map<string, boolean>();
       let workspacePageCount: number | null = null;
       let workspacePageIds: Set<string> | null = null;
-      const deletedDocIds = new Set(acknowledgedDeletedDocIds.get(workspaceId) || []);
+      const deletedDocIds = acknowledgedDeletedDocs.idsFor(workspaceId);
       try {
         const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -4202,7 +4264,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             for (const docId of deletedDocIds) {
               if (workspacePageIds.has(docId)) {
                 deletedDocIds.delete(docId);
-                acknowledgedDeletedDocIds.get(workspaceId)?.delete(docId);
+                acknowledgedDeletedDocs.forget(workspaceId, docId);
               }
             }
             const { byId } = getWorkspaceTagOptionMaps(meta);
@@ -6341,9 +6403,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const result = await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
       const deletion = result.structuredContent as { ok?: boolean; status?: string } | undefined;
       if (deletion?.ok === true && (deletion.status === "deleted" || deletion.status === "already_absent")) {
-        const deletedIds = acknowledgedDeletedDocIds.get(workspaceId) || new Set<string>();
-        deletedIds.add(parsed.docId);
-        acknowledgedDeletedDocIds.set(workspaceId, deletedIds);
+        acknowledgedDeletedDocs.remember(workspaceId, parsed.docId);
       }
       return result;
     } finally {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -651,6 +651,8 @@ export async function deleteDocFromWorkspace(
 }
 
 export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults: { workspaceId?: string }) {
+  const acknowledgedDeletedDocIds = new Map<string, Set<string>>();
+
   // helpers
   function generateId(): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
@@ -4182,7 +4184,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const inTrashByDocId = new Map<string, boolean>();
       let workspacePageCount: number | null = null;
       let workspacePageIds: Set<string> | null = null;
-      const deletedDocIds = new Set<string>();
+      const deletedDocIds = new Set(acknowledgedDeletedDocIds.get(workspaceId) || []);
       try {
         const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -4197,6 +4199,12 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             const pages = getWorkspacePageEntries(meta);
             workspacePageCount = pages.length;
             workspacePageIds = new Set(pages.map(page => page.id));
+            for (const docId of deletedDocIds) {
+              if (workspacePageIds.has(docId)) {
+                deletedDocIds.delete(docId);
+                acknowledgedDeletedDocIds.get(workspaceId)?.delete(docId);
+              }
+            }
             const { byId } = getWorkspaceTagOptionMaps(meta);
             for (const page of pages) {
               if (page.title) {
@@ -6330,7 +6338,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
     try {
       await joinWorkspace(socket, workspaceId);
-      return await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
+      const result = await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
+      const deletion = result.structuredContent as { ok?: boolean; status?: string } | undefined;
+      if (deletion?.ok === true && (deletion.status === "deleted" || deletion.status === "already_absent")) {
+        const deletedIds = acknowledgedDeletedDocIds.get(workspaceId) || new Set<string>();
+        deletedIds.add(parsed.docId);
+        acknowledgedDeletedDocIds.set(workspaceId, deletedIds);
+      }
+      return result;
     } finally {
       socket.disconnect();
     }

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -379,7 +379,7 @@ export function registerWorkspaceTools(
         
         const workspace = result.data.createWorkspace;
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
-        const baseUrl = process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '');
+        const baseUrl = affineBaseUrl(endpoint);
 
         try {
           const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -6,8 +6,123 @@ import FormData from "form-data";
 import fetch from "node-fetch";
 import { receipt, text, toolError } from "../util/mcp.js";
 import { secureRandomString } from "../util/random.js";
-import { connectWorkspaceSocket, joinWorkspace, pushDocUpdate, wsUrlFromGraphQLEndpoint } from "../ws.js";
+import {
+  connectWorkspaceSocket,
+  joinWorkspace,
+  loadDoc,
+  pushDocUpdate,
+  wsUrlFromGraphQLEndpoint,
+  type WorkspaceSocket,
+} from "../ws.js";
 import { requireMatchingConfirmation } from "../util/inputSchemas.js";
+
+type WorkspaceRecord = Record<string, unknown> & { id: string };
+type WorkspaceProfileStatus = "available" | "unavailable" | "skipped";
+
+type WorkspaceSummary = WorkspaceRecord & {
+  name: string | null;
+  avatar: string | null;
+  url: string;
+  profileStatus: WorkspaceProfileStatus;
+};
+
+type WorkspaceToolDependencies = {
+  connectWorkspaceSocket: typeof connectWorkspaceSocket;
+  joinWorkspace: typeof joinWorkspace;
+  loadDoc: typeof loadDoc;
+};
+
+const DEFAULT_WORKSPACE_TOOL_DEPENDENCIES: WorkspaceToolDependencies = {
+  connectWorkspaceSocket,
+  joinWorkspace,
+  loadDoc,
+};
+
+function affineBaseUrl(endpoint: string): string {
+  const configuredBaseUrl = process.env.AFFINE_BASE_URL?.trim();
+  return (configuredBaseUrl || new URL(endpoint).origin).replace(/\/+$/, "");
+}
+
+function summarizeWorkspace(
+  workspace: WorkspaceRecord,
+  endpoint: string,
+  profileStatus: WorkspaceProfileStatus,
+  profile?: { name: string | null; avatar: string | null },
+): WorkspaceSummary {
+  const existingName = typeof workspace.name === "string" ? workspace.name : null;
+  const existingAvatar = typeof workspace.avatar === "string" ? workspace.avatar : null;
+  return {
+    ...workspace,
+    name: profile?.name ?? existingName,
+    avatar: profile?.avatar ?? existingAvatar,
+    url: `${affineBaseUrl(endpoint)}/workspace/${encodeURIComponent(workspace.id)}`,
+    profileStatus,
+  };
+}
+
+async function readWorkspaceProfile(
+  socket: WorkspaceSocket,
+  workspaceId: string,
+  dependencies: WorkspaceToolDependencies,
+): Promise<{ name: string | null; avatar: string | null }> {
+  await dependencies.joinWorkspace(socket, workspaceId);
+  const snapshot = await dependencies.loadDoc(socket, workspaceId, workspaceId);
+  if (!snapshot.missing) {
+    throw new Error(`Workspace profile metadata is unavailable for ${workspaceId}.`);
+  }
+
+  const workspaceDoc = new Y.Doc();
+  Y.applyUpdate(workspaceDoc, Buffer.from(snapshot.missing, "base64"));
+  const meta = workspaceDoc.getMap("meta");
+  const name = meta.get("name");
+  const avatar = meta.get("avatar");
+  return {
+    name: typeof name === "string" ? name : null,
+    avatar: typeof avatar === "string" ? avatar : null,
+  };
+}
+
+async function enrichWorkspaceProfiles(
+  gql: GraphQLClient,
+  workspaces: WorkspaceRecord[],
+  includeProfile: boolean,
+  dependencies: WorkspaceToolDependencies,
+): Promise<WorkspaceSummary[]> {
+  const endpoint = gql.endpoint;
+  if (!includeProfile) {
+    return workspaces.map(workspace => summarizeWorkspace(workspace, endpoint, "skipped"));
+  }
+  if (workspaces.length === 0) {
+    return [];
+  }
+
+  let socket: WorkspaceSocket;
+  try {
+    const { endpoint: connectionEndpoint, cookie, bearer } = await gql.getConnectionAuth();
+    socket = await dependencies.connectWorkspaceSocket(
+      wsUrlFromGraphQLEndpoint(connectionEndpoint),
+      cookie,
+      bearer,
+    );
+  } catch {
+    return workspaces.map(workspace => summarizeWorkspace(workspace, endpoint, "unavailable"));
+  }
+
+  try {
+    const enriched: WorkspaceSummary[] = [];
+    for (const workspace of workspaces) {
+      try {
+        const profile = await readWorkspaceProfile(socket, workspace.id, dependencies);
+        enriched.push(summarizeWorkspace(workspace, endpoint, "available", profile));
+      } catch {
+        enriched.push(summarizeWorkspace(workspace, endpoint, "unavailable"));
+      }
+    }
+    return enriched;
+  } finally {
+    socket.disconnect();
+  }
+}
 
 // Generate AFFiNE-style document ID
 function generateDocId(): string {
@@ -129,13 +244,28 @@ function createInitialWorkspaceData(workspaceName: string = 'New Workspace', ava
   };
 }
 
-export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
+export function registerWorkspaceTools(
+  server: McpServer,
+  gql: GraphQLClient,
+  dependencyOverrides: Partial<WorkspaceToolDependencies> = {},
+) {
+  const dependencies = {
+    ...DEFAULT_WORKSPACE_TOOL_DEPENDENCIES,
+    ...dependencyOverrides,
+  };
+
   // LIST WORKSPACES
-  const listWorkspacesHandler = async () => {
+  const listWorkspacesHandler = async ({ includeProfile = true }: { includeProfile?: boolean } = {}) => {
     try {
       const query = `query { workspaces { id public enableAi createdAt } }`;
-      const data = await gql.request<{ workspaces: any[] }>(query);
-      return text(data.workspaces || []);
+      const data = await gql.request<{ workspaces: WorkspaceRecord[] }>(query);
+      const workspaces = await enrichWorkspaceProfiles(
+        gql,
+        data.workspaces || [],
+        includeProfile,
+        dependencies,
+      );
+      return text(workspaces);
     } catch (error: any) {
       return toolError(error, { code: "workspace_list_failed" });
     }
@@ -145,7 +275,12 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
     "list_workspaces",
     {
       title: "List Workspaces",
-      description: "List all available AFFiNE workspaces"
+      description: "List available AFFiNE workspaces with best-effort profile metadata and direct URLs",
+      inputSchema: {
+        includeProfile: z.boolean().optional().default(true).describe(
+          "Load workspace names and avatar references from realtime metadata. Set false for a faster GraphQL-only response.",
+        ),
+      },
     },
     listWorkspacesHandler as any
   );
@@ -165,8 +300,12 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
           } 
         } 
       }`;
-      const data = await gql.request<{ workspace: any }>(query, { id });
-      return text(data.workspace);
+      const data = await gql.request<{ workspace: WorkspaceRecord }>(query, { id });
+      if (!data.workspace || typeof data.workspace !== "object") {
+        return text(data.workspace);
+      }
+      const [workspace] = await enrichWorkspaceProfiles(gql, [data.workspace], true, dependencies);
+      return text(workspace);
     } catch (error: any) {
       return toolError(error, { code: "workspace_get_failed" });
     }
@@ -176,7 +315,7 @@ export function registerWorkspaceTools(server: McpServer, gql: GraphQLClient) {
     "get_workspace",
     {
       title: "Get Workspace",
-      description: "Get details of a specific workspace",
+      description: "Get workspace details with best-effort profile metadata and a direct URL",
       inputSchema: { 
         id: z.string().describe("Workspace ID") 
       }

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,7 +1,7 @@
 import { io, Socket } from "socket.io-client";
 
 export type WorkspaceSocket = Socket<any, any>;
-const DEFAULT_WS_CLIENT_VERSION = process.env.AFFINE_WS_CLIENT_VERSION || '0.26.0';
+const DEFAULT_WS_CLIENT_VERSION = process.env.AFFINE_WS_CLIENT_VERSION || process.env.AFFINE_CLIENT_VERSION || '0.26.0';
 const WS_CONNECT_TIMEOUT_MS = Number(process.env.AFFINE_WS_CONNECT_TIMEOUT_MS || 10000);
 const WS_ACK_TIMEOUT_MS = Number(process.env.AFFINE_WS_ACK_TIMEOUT_MS || 10000);
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -14,15 +14,19 @@ function ackErrorMessage(ack: any, fallback: string): string | null {
 function deleteAcknowledged(ack: any): boolean {
   return ack === true
     || ack?.deleted === true
+    || ack?.success === true
     || ack?.data === true
-    || ack?.data?.deleted === true;
+    || ack?.data?.deleted === true
+    || ack?.data?.success === true;
 }
 
 function deleteRejected(ack: any): boolean {
   return ack === false
     || ack?.deleted === false
+    || ack?.success === false
     || ack?.data === false
-    || ack?.data?.deleted === false;
+    || ack?.data?.deleted === false
+    || ack?.data?.success === false;
 }
 
 function emitWithAck<T>(
@@ -164,11 +168,10 @@ export type DeleteDocOptions = {
 /**
  * Delete a document and wait for a trustworthy completion signal.
  *
- * AFFiNE 0.26 returns an error acknowledgement, but its successful
- * `space:delete-doc` handler returns void. NestJS filters that void response and
- * therefore sends no success acknowledgement. To remain compatible, this
- * helper accepts a future success acknowledgement and otherwise verifies that
- * `space:load-doc` returns DOC_NOT_FOUND before resolving.
+ * AFFiNE versions may return no successful acknowledgement, `{ deleted: true }`,
+ * or `{ data: { success: true } }`. AFFiNE 0.27.3 also retains the underlying
+ * snapshot for garbage collection, so a successful acknowledgement must be
+ * recognized instead of relying exclusively on a follow-up DOC_NOT_FOUND.
  */
 export function deleteDoc(
   socket: WorkspaceSocket,

--- a/tests/playwright/sign-in.ts
+++ b/tests/playwright/sign-in.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+
+const EMAIL_INPUT_SELECTOR = 'input[type="email"], input[name="email"], input[placeholder*="email"]';
+const PASSWORD_INPUT_SELECTOR = 'input[type="password"], input[name="password"]';
+const CONTINUE_BUTTON_SELECTOR =
+  'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]';
+const SIGN_IN_BUTTON_SELECTOR =
+  'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]';
+
+type SignInOptions = {
+  baseUrl: string;
+  email: string;
+  password: string;
+};
+
+export async function signInToAffine(
+  page: Page,
+  { baseUrl, email, password }: SignInOptions,
+): Promise<void> {
+  const signInUrl = `${baseUrl}/sign-in`;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 24; attempt++) {
+    await page.goto(signInUrl, { waitUntil: 'domcontentloaded' });
+
+    const emailInput = page.locator(EMAIL_INPUT_SELECTOR);
+    const passwordInput = page.locator(PASSWORD_INPUT_SELECTOR);
+    await emailInput.waitFor({ timeout: 30_000 });
+    await page.waitForTimeout(1_000);
+    await emailInput.fill(email);
+    await page.locator(CONTINUE_BUTTON_SELECTOR).first().click();
+
+    try {
+      await passwordInput.waitFor({ timeout: 4_000 });
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+
+    await passwordInput.fill(password);
+    await page.waitForTimeout(1_000);
+    await page.locator(SIGN_IN_BUTTON_SELECTOR).first().click();
+    try {
+      await page.waitForURL(
+        (url) => !url.toString().includes('/sign-in'),
+        { timeout: 4_000, waitUntil: 'commit' },
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}

--- a/tests/playwright/verify-data-view.pw.ts
+++ b/tests/playwright/verify-data-view.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,28 +43,8 @@ if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
 
 test.describe.serial('AFFiNE Data View Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     for (let i = 0; i < 5; i++) {
       await page.waitForTimeout(1_000);

--- a/tests/playwright/verify-database.pw.ts
+++ b/tests/playwright/verify-database.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,36 +45,10 @@ if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
 
 test.describe.serial('AFFiNE Database Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
+    test.setTimeout(180_000);
     const baseUrl = state.baseUrl;
 
-    // Navigate directly to the sign-in page
-    await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    // Fill email — the placeholder is "Enter your email address"
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    // Click "Continue with email"
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    // Fill password
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    // Click sign in / submit
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    // Wait for redirect away from sign-in page
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    await signInToAffine(page, { baseUrl, email: state.email, password });
 
     // Dismiss any onboarding modals/dialogs that may appear
     for (let i = 0; i < 5; i++) {

--- a/tests/playwright/verify-edgeless-canvas.pw.ts
+++ b/tests/playwright/verify-edgeless-canvas.pw.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -82,28 +83,8 @@ async function openDocInEdgelessMode(page: Page) {
 
 test.describe.serial('AFFiNE Edgeless Canvas Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     for (let i = 0; i < 5; i++) {
       await page.waitForTimeout(1_000);

--- a/tests/playwright/verify-tag-visibility.pw.ts
+++ b/tests/playwright/verify-tag-visibility.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -59,30 +60,10 @@ async function dismissModals(page: any, rounds: number) {
 
 test.describe.serial('Tag Visibility Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
+    test.setTimeout(180_000);
     const baseUrl = state.baseUrl;
 
-    await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    await signInToAffine(page, { baseUrl, email: state.email, password });
     await dismissModals(page, 5);
 
     expect(page.url()).not.toContain('/sign-in');

--- a/tests/playwright/verify-theme-adaptation.pw.ts
+++ b/tests/playwright/verify-theme-adaptation.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -65,28 +66,8 @@ async function readTokens(page, names: string[]): Promise<Record<string, string>
 
 test.describe.serial('AFFiNE theme-adaptation invariants', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     const storageStatePath = path.resolve(__dirname, '..', 'playwright-auth-state.json');
     await context.storageState({ path: storageStatePath });

--- a/tests/test-auth-session.mjs
+++ b/tests/test-auth-session.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
@@ -106,6 +107,7 @@ async function startMockAffine(options = {}) {
         state.graphqlHeaders.push({
           authorization: req.headers.authorization || "",
           cookie: req.headers.cookie || "",
+          tenant: req.headers["x-tenant"] || "",
           receivedAt: Date.now(),
         });
         await readRequestBody(req);
@@ -156,7 +158,7 @@ async function startMockAffine(options = {}) {
   };
 }
 
-function cleanServerEnvironment(port, baseUrl) {
+function cleanServerEnvironment(port, baseUrl, configHome) {
   const env = { ...process.env };
   for (const key of [
     "AFFINE_API_TOKEN",
@@ -179,7 +181,7 @@ function cleanServerEnvironment(port, baseUrl) {
     AFFINE_LOGIN_AT_START: "async",
     AFFINE_MCP_AUTH_MODE: "bearer",
     AFFINE_MCP_HTTP_HOST: "127.0.0.1",
-    XDG_CONFIG_HOME: `/tmp/affine-mcp-auth-session-${process.pid}-${port}`,
+    XDG_CONFIG_HOME: configHome || `/tmp/affine-mcp-auth-session-${process.pid}-${port}`,
   };
 }
 
@@ -204,11 +206,11 @@ async function waitForHealth(child, url, logs, timeoutMs = 8_000) {
   throw new Error(`Timed out waiting for ${url}: ${JSON.stringify(logs())}`);
 }
 
-async function startMcpServer(baseUrl) {
+async function startMcpServer(baseUrl, options = {}) {
   const port = await findFreePort();
   const child = spawn("node", [MCP_SERVER_PATH], {
     cwd: PROJECT_DIR,
-    env: cleanServerEnvironment(port, baseUrl),
+    env: cleanServerEnvironment(port, baseUrl, options.configHome),
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stdout = "";
@@ -235,6 +237,15 @@ async function startMcpServer(baseUrl) {
       }
     },
   };
+}
+
+function writeSavedConfig(configHome, values) {
+  const directory = path.join(configHome, "affine-mcp");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    path.join(directory, "config"),
+    `${Object.entries(values).map(([key, value]) => `${key}=${value}`).join("\n")}\n`,
+  );
 }
 
 async function createMcpClient(mcpUrl, name) {
@@ -359,6 +370,68 @@ async function testFailureNeverFallsBack() {
   }
 }
 
+async function testEnvironmentCredentialsOverrideSavedAuthentication() {
+  const scenarios = [
+    {
+      label: "saved API token",
+      values: { AFFINE_API_TOKEN: "stale-saved-token" },
+    },
+    {
+      label: "saved cookie",
+      values: { AFFINE_COOKIE: "affine_session=stale-saved-cookie" },
+    },
+    {
+      label: "saved authentication headers",
+      values: {
+        AFFINE_HEADERS_JSON: JSON.stringify({
+          Authorization: "Bearer stale-saved-header-token",
+          Cookie: "affine_session=stale-saved-header-cookie",
+        }),
+      },
+    },
+  ];
+
+  for (const [index, scenario] of scenarios.entries()) {
+    const configHome = mkdtempSync(path.join(os.tmpdir(), "affine-mcp-env-auth-"));
+    const tenant = `saved-tenant-${index}`;
+    const existingHeaders = scenario.values.AFFINE_HEADERS_JSON
+      ? JSON.parse(scenario.values.AFFINE_HEADERS_JSON)
+      : {};
+    writeSavedConfig(configHome, {
+      ...scenario.values,
+      AFFINE_HEADERS_JSON: JSON.stringify({ ...existingHeaders, "X-Tenant": tenant }),
+    });
+
+    const mock = await startMockAffine();
+    const mcp = await startMcpServer(mock.baseUrl, { configHome });
+    let client;
+    try {
+      client = await createMcpClient(mcp.mcpUrl, `environment-auth-${index}`);
+      const result = await client.client.callTool({ name: "current_user", arguments: {} });
+
+      assertEqual(parseToolContent(result)?.email, EMAIL, `${scenario.label} current_user email`);
+      assertEqual(mock.state.signInCalls, 1, `${scenario.label} did not trigger environment login`);
+      assertEqual(mock.state.graphqlCalls, 1, `${scenario.label} GraphQL request count`);
+      assertEqual(
+        mock.state.unauthenticatedGraphqlCalls,
+        0,
+        `${scenario.label} reached AFFiNE with stale authentication`,
+      );
+      assertEqual(mock.state.graphqlHeaders[0]?.cookie, COOKIE, `${scenario.label} session cookie`);
+      assertEqual(mock.state.graphqlHeaders[0]?.authorization, "", `${scenario.label} bearer header`);
+      assertEqual(mock.state.graphqlHeaders[0]?.tenant, tenant, `${scenario.label} non-auth header`);
+    } finally {
+      if (client) {
+        try { await client.client.close(); } catch {}
+        try { await client.transport.close(); } catch {}
+      }
+      await mcp.close();
+      await mock.close();
+      rmSync(configHome, { recursive: true, force: true });
+    }
+  }
+}
+
 async function testConcurrentHttpSessionsAndDirectMultipart() {
   const mock = await startMockAffine({ blockLogin: true });
   const mcp = await startMcpServer(mock.baseUrl);
@@ -425,6 +498,7 @@ async function main() {
   await testSingleFlightPrimitive();
   await testExclusiveAuthState();
   await testFailureNeverFallsBack();
+  await testEnvironmentCredentialsOverrideSavedAuthentication();
   await testConcurrentHttpSessionsAndDirectMultipart();
   console.log("Authentication session regression tests passed.");
 }

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -209,6 +209,8 @@ try {
     AFFINE_BASE_URL: baseUrl,
     AFFINE_API_TOKEN: "stale-saved-token",
     AFFINE_COOKIE: "affine_session=stale-saved-cookie",
+    AFFINE_EMAIL: "saved@example.test",
+    AFFINE_PASSWORD: "saved-password",
     AFFINE_HEADERS_JSON: JSON.stringify({
       Authorization: "Bearer stale-saved-header-token",
       Cookie: "affine_session=stale-saved-header-cookie",
@@ -254,6 +256,57 @@ try {
   expect(
     environmentAuthSummary.sources.password === "env",
     "environment password source was not reported",
+  );
+
+  const partialCredentialWarning =
+    "Environment provides only one of AFFINE_EMAIL or AFFINE_PASSWORD";
+  expect(
+    !environmentAuthConfig.stderr.includes(partialCredentialWarning),
+    "complete environment email/password credentials produced a partial-credential warning",
+  );
+
+  const environmentEmailOnlyConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_EMAIL: "environment@example.test",
+    }),
+  );
+  expect(
+    environmentEmailOnlyConfig.code === 0,
+    `partial environment email config failed: ${environmentEmailOnlyConfig.stderr}`,
+  );
+  expect(
+    environmentEmailOnlyConfig.stderr.includes(partialCredentialWarning),
+    "environment email without a password did not warn that saved credentials were ignored",
+  );
+  const environmentEmailOnlySummary = JSON.parse(environmentEmailOnlyConfig.stdout);
+  expect(
+    environmentEmailOnlySummary.sources.email === "env" &&
+      environmentEmailOnlySummary.sources.password === "unset",
+    "environment email was combined with the saved password",
+  );
+
+  const environmentPasswordOnlyConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_PASSWORD: "environment-password",
+    }),
+  );
+  expect(
+    environmentPasswordOnlyConfig.code === 0,
+    `partial environment password config failed: ${environmentPasswordOnlyConfig.stderr}`,
+  );
+  expect(
+    environmentPasswordOnlyConfig.stderr.includes(partialCredentialWarning),
+    "environment password without an email did not warn that saved credentials were ignored",
+  );
+  const environmentPasswordOnlySummary = JSON.parse(environmentPasswordOnlyConfig.stdout);
+  expect(
+    environmentPasswordOnlySummary.sources.email === "unset" &&
+      environmentPasswordOnlySummary.sources.password === "env",
+    "environment password was combined with the saved email",
   );
 
   const nonAuthEnvironmentHeaders = await runNode(

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -141,6 +141,7 @@ const upstream = createServer(async (request, response) => {
     authorization: request.headers.authorization || null,
     cookie: request.headers.cookie || null,
     tenant: request.headers["x-tenant"] || null,
+    affineVersion: request.headers["x-affine-version"] || null,
     query: body.query,
     url: request.url,
   });
@@ -187,6 +188,7 @@ try {
     AFFINE_BASE_URL: baseUrl,
     AFFINE_GRAPHQL_PATH: "/custom/graphql",
     AFFINE_API_TOKEN: "env-token",
+    AFFINE_HEADERS_JSON: JSON.stringify({ "X-Affine-Version": "cli-override-version" }),
     AFFINE_WORKSPACE_ID: "workspace-env",
     MCP_TRANSPORT: "streamable",
     PORT: "4321",
@@ -337,8 +339,11 @@ try {
   expect(statusPayload.authKind === "api-token", "status did not use effective token auth");
   expect(statusPayload.userEmail === "config@example.test", "status did not inspect the fake upstream");
   expect(
-    graphqlRequests.some((entry) => entry.authorization === "Bearer env-token"),
-    "status did not send the environment API token",
+    graphqlRequests.some(
+      (entry) => entry.authorization === "Bearer env-token"
+        && entry.affineVersion === "cli-override-version",
+    ),
+    "status did not send the environment API token and exact client-version override",
   );
 
   const noConfigHome = path.join(TEMP_ROOT, "no-config");
@@ -507,6 +512,7 @@ try {
       "X-Tenant": "saved-tenant",
       Authorization: "Basic stale",
       Cookie: "stale-header-cookie",
+      "X-Affine-Version": "readyz-override-version",
     }),
     MCP_TRANSPORT: "http",
     PORT: String(httpPort),
@@ -538,9 +544,10 @@ try {
       (entry) => entry.query.includes("AffineMcpReadiness")
         && entry.authorization === "Bearer runtime-token"
         && entry.cookie === null
-        && entry.tenant === "saved-tenant",
+        && entry.tenant === "saved-tenant"
+        && entry.affineVersion === "readyz-override-version",
     ),
-    "readyz did not use the configured endpoint, custom headers, and service token",
+    "readyz did not use the configured endpoint, exact client-version override, custom headers, and service token",
   );
 
   upstreamReady = false;
@@ -566,6 +573,7 @@ try {
       "strict transport validation",
       "saved HTTP runtime flags",
       "upstream-aware readiness",
+      "case-insensitive client-version overrides",
     ],
   }, null, 2));
 } finally {

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -204,6 +204,79 @@ try {
   expect(summary.sources.graphqlPath === "env", "GraphQL path source should be env");
   expect(summary.apiToken !== "env-token", "show-config exposed the API token");
 
+  const staleSavedAuthHome = path.join(TEMP_ROOT, "stale-saved-auth");
+  writeConfig(staleSavedAuthHome, {
+    AFFINE_BASE_URL: baseUrl,
+    AFFINE_API_TOKEN: "stale-saved-token",
+    AFFINE_COOKIE: "affine_session=stale-saved-cookie",
+    AFFINE_HEADERS_JSON: JSON.stringify({
+      Authorization: "Bearer stale-saved-header-token",
+      Cookie: "affine_session=stale-saved-header-cookie",
+      "X-Tenant": "saved-tenant",
+    }),
+  });
+  const environmentCredentials = cleanEnvironment({
+    XDG_CONFIG_HOME: staleSavedAuthHome,
+    AFFINE_EMAIL: "environment@example.test",
+    AFFINE_PASSWORD: "environment-password",
+  });
+  const environmentAuthConfig = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    environmentCredentials,
+  );
+  expect(
+    environmentAuthConfig.code === 0,
+    `environment auth config failed: ${environmentAuthConfig.stderr}`,
+  );
+  const environmentAuthSummary = JSON.parse(environmentAuthConfig.stdout);
+  expect(
+    environmentAuthSummary.authKind === "email-password",
+    "saved token or cookie overrode environment email/password credentials",
+  );
+  expect(environmentAuthSummary.apiToken === null, "ignored saved API token remained effective");
+  expect(environmentAuthSummary.cookie === null, "ignored saved cookie remained effective");
+  expect(
+    environmentAuthSummary.email === "environment@example.test",
+    "environment email was not selected",
+  );
+  expect(
+    environmentAuthSummary.sources.apiToken === "unset",
+    "ignored saved API token source remained active",
+  );
+  expect(
+    environmentAuthSummary.sources.cookie === "unset",
+    "ignored saved cookie source remained active",
+  );
+  expect(
+    environmentAuthSummary.sources.email === "env",
+    "environment email source was not reported",
+  );
+  expect(
+    environmentAuthSummary.sources.password === "env",
+    "environment password source was not reported",
+  );
+
+  const nonAuthEnvironmentHeaders = await runNode(
+    [DIST_ENTRY, "show-config", "--json"],
+    cleanEnvironment({
+      XDG_CONFIG_HOME: staleSavedAuthHome,
+      AFFINE_HEADERS_JSON: JSON.stringify({ "X-Tenant": "environment-tenant" }),
+    }),
+  );
+  expect(
+    nonAuthEnvironmentHeaders.code === 0,
+    `non-auth environment headers config failed: ${nonAuthEnvironmentHeaders.stderr}`,
+  );
+  const savedAuthSummary = JSON.parse(nonAuthEnvironmentHeaders.stdout);
+  expect(
+    savedAuthSummary.authKind === "api-token",
+    "non-auth environment headers incorrectly disabled saved authentication",
+  );
+  expect(
+    savedAuthSummary.sources.apiToken === "config",
+    "saved API token source was not reported after non-auth environment headers",
+  );
+
   const status = await runNode([DIST_ENTRY, "status", "--json"], effectiveEnv);
   expect(status.code === 0, `status failed: ${status.stderr}`);
   const statusPayload = JSON.parse(status.stdout);
@@ -427,6 +500,7 @@ try {
     ok: true,
     cases: [
       "environment precedence",
+      "authentication source precedence",
       "custom GraphQL path",
       "custom-path workspace socket origin",
       "effective status auth",

--- a/tests/test-destructive-mutation-ack.mjs
+++ b/tests/test-destructive-mutation-ack.mjs
@@ -8,7 +8,10 @@ import * as Y from "yjs";
 import { deleteDoc } from "../dist/ws.js";
 import { registerBlobTools } from "../dist/tools/blobStorage.js";
 import { registerCommentTools } from "../dist/tools/comments.js";
-import { deleteDocFromWorkspace } from "../dist/tools/docs.js";
+import {
+  createAcknowledgedDeletedDocTracker,
+  deleteDocFromWorkspace,
+} from "../dist/tools/docs.js";
 import { registerNotificationTools } from "../dist/tools/notifications.js";
 import { registerWorkspaceTools } from "../dist/tools/workspaces.js";
 
@@ -162,6 +165,32 @@ class ToolRegistry {
   registerTool(name, _definition, handler) {
     this.tools.set(name, handler);
   }
+}
+
+function testAcknowledgedDeleteTrackerBounds() {
+  let currentTime = 0;
+  const tracker = createAcknowledgedDeletedDocTracker({
+    ttlMs: 100,
+    maxEntries: 2,
+    now: () => currentTime,
+  });
+
+  tracker.remember("workspace-1", "doc-1");
+  currentTime = 50;
+  tracker.remember("workspace-1", "doc-2");
+  assert.deepEqual([...tracker.idsFor("workspace-1")], ["doc-1", "doc-2"]);
+
+  currentTime = 75;
+  tracker.remember("workspace-2", "doc-3");
+  assert.deepEqual([...tracker.idsFor("workspace-1")], ["doc-2"]);
+  assert.deepEqual([...tracker.idsFor("workspace-2")], ["doc-3"]);
+
+  currentTime = 151;
+  assert.deepEqual([...tracker.idsFor("workspace-1")], []);
+  assert.deepEqual([...tracker.idsFor("workspace-2")], ["doc-3"]);
+
+  tracker.forget("workspace-2", "doc-3");
+  assert.deepEqual([...tracker.idsFor("workspace-2")], []);
 }
 
 async function testDeleteDocProtocol() {
@@ -484,6 +513,7 @@ async function testAdditionalMutationReceipts() {
   assert.equal(parseToolResult(await updateWorkspace({ id: "workspace-1", public: true })).ok, true);
 }
 
+testAcknowledgedDeleteTrackerBounds();
 await testDeleteDocProtocol();
 await testDocumentReceipts();
 await testWorkspaceReceipts();

--- a/tests/test-destructive-mutation-ack.mjs
+++ b/tests/test-destructive-mutation-ack.mjs
@@ -115,6 +115,14 @@ class FakeWorkspaceSocket {
           ack?.({ data: { deleted: false } });
           return;
         }
+        if (this.deleteMode === "server-success-ack") {
+          ack?.({ data: { success: true } });
+          return;
+        }
+        if (this.deleteMode === "server-negative-ack") {
+          ack?.({ data: { success: false } });
+          return;
+        }
         if (this.deleteMode === "empty-ack-still-present") {
           ack?.({});
           return;
@@ -164,6 +172,13 @@ async function testDeleteDocProtocol() {
   });
   assert.deepEqual(acknowledged, { acknowledged: true, verifiedAbsent: false });
 
+  const serverAcknowledgedSocket = new FakeWorkspaceSocket({ deleteMode: "server-success-ack" });
+  const serverAcknowledged = await deleteDoc(serverAcknowledgedSocket, "workspace-1", "doc-1", {
+    timeoutMs: 100,
+    verificationIntervalMs: 5,
+  });
+  assert.deepEqual(serverAcknowledged, { acknowledged: true, verifiedAbsent: false });
+
   const voidSuccessSocket = new FakeWorkspaceSocket({ deleteMode: "void-success" });
   const verified = await deleteDoc(voidSuccessSocket, "workspace-1", "doc-1", {
     timeoutMs: 100,
@@ -185,6 +200,15 @@ async function testDeleteDocProtocol() {
   const negativeAcknowledgementSocket = new FakeWorkspaceSocket({ deleteMode: "negative-ack" });
   await assert.rejects(
     deleteDoc(negativeAcknowledgementSocket, "workspace-1", "doc-1", {
+      timeoutMs: 100,
+      verificationIntervalMs: 5,
+    }),
+    /did not confirm document deletion/,
+  );
+
+  const serverNegativeAcknowledgementSocket = new FakeWorkspaceSocket({ deleteMode: "server-negative-ack" });
+  await assert.rejects(
+    deleteDoc(serverNegativeAcknowledgementSocket, "workspace-1", "doc-1", {
       timeoutMs: 100,
       verificationIntervalMs: 5,
     }),

--- a/tests/test-http-email-password.mjs
+++ b/tests/test-http-email-password.mjs
@@ -6,11 +6,14 @@ import { testTempPath } from './require-destructive-test-safety.mjs';
  *
  * Reproduces the multi-session flow where buildServer() is invoked for each
  * Streamable HTTP session. Credentials must remain available so each new
- * session can authenticate successfully.
+ * session can authenticate successfully. The saved config deliberately holds
+ * stale token, cookie, and authentication-header credentials to verify that
+ * environment email/password credentials select the active auth source.
  */
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -74,10 +77,31 @@ async function waitForSuccessfulFetch(url, timeoutMs = 15000) {
 async function startEmailPasswordHttpServer() {
   const port = await findFreePort();
   const publicBaseUrl = `http://127.0.0.1:${port}`;
+  const configHome = testTempPath("http-email-password-server-config");
+  const configDirectory = path.join(configHome, "affine-mcp");
+  mkdirSync(configDirectory, { recursive: true });
+  writeFileSync(
+    path.join(configDirectory, "config"),
+    [
+      "AFFINE_API_TOKEN=stale-saved-token",
+      "AFFINE_COOKIE=affine_session=stale-saved-cookie",
+      `AFFINE_HEADERS_JSON=${JSON.stringify({
+        Authorization: "Bearer stale-saved-header-token",
+        Cookie: "affine_session=stale-saved-header-cookie",
+        "X-Affine-Mcp-Test": "saved-non-auth-header",
+      })}`,
+      "",
+    ].join("\n"),
+  );
+
+  const childEnvironment = { ...process.env };
+  delete childEnvironment.AFFINE_API_TOKEN;
+  delete childEnvironment.AFFINE_COOKIE;
+  delete childEnvironment.AFFINE_HEADERS_JSON;
   const child = spawn("node", [MCP_SERVER_PATH], {
     cwd: PROJECT_DIR,
     env: {
-      ...process.env,
+      ...childEnvironment,
       MCP_TRANSPORT: "http",
       PORT: String(port),
       AFFINE_BASE_URL: BASE_URL,
@@ -85,7 +109,7 @@ async function startEmailPasswordHttpServer() {
       AFFINE_PASSWORD: PASSWORD,
       AFFINE_LOGIN_AT_START: "sync",
       AFFINE_MCP_HTTP_HOST: "127.0.0.1",
-      XDG_CONFIG_HOME: testTempPath('http-email-password-server-config'),
+      XDG_CONFIG_HOME: configHome,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/tests/test-suites.json
+++ b/tests/test-suites.json
@@ -59,7 +59,8 @@
     "test-test-suite-verifier.mjs": "fast",
     "test-theme-defaults-setup.mjs": "integration",
     "test-tool-filtering.mjs": "fast",
-    "test-url-safety.mjs": "fast"
+    "test-url-safety.mjs": "fast",
+    "test-workspace-discovery.mjs": "fast"
   },
   "suites": {
     "fast": [
@@ -87,7 +88,8 @@
       "test-secure-random.mjs",
       "test-test-suite-verifier.mjs",
       "test-tool-filtering.mjs",
-      "test-url-safety.mjs"
+      "test-url-safety.mjs",
+      "test-workspace-discovery.mjs"
     ],
     "e2e": [
       "test-database-creation.mjs",

--- a/tests/test-supporting-tools.mjs
+++ b/tests/test-supporting-tools.mjs
@@ -127,12 +127,19 @@ async function main() {
 
     const listedWorkspacesAfter = await call('list_workspaces');
     expectArray(listedWorkspacesAfter, 'list_workspaces after create');
-    if (!listedWorkspacesAfter.some(entry => entry?.id === workspaceId)) {
+    const listedWorkspace = listedWorkspacesAfter.find(entry => entry?.id === workspaceId);
+    if (!listedWorkspace) {
       throw new Error('list_workspaces did not include created workspace');
     }
+    expectEqual(listedWorkspace.name, workspaceName, 'list_workspaces workspace name');
+    expectEqual(listedWorkspace.profileStatus, 'available', 'list_workspaces profileStatus');
+    expectTruthy(listedWorkspace.url, 'list_workspaces workspace URL');
 
     const fetchedWorkspace = await call('get_workspace', { id: workspaceId });
     expectEqual(fetchedWorkspace?.id, workspaceId, 'get_workspace id');
+    expectEqual(fetchedWorkspace?.name, workspaceName, 'get_workspace workspace name');
+    expectEqual(fetchedWorkspace?.profileStatus, 'available', 'get_workspace profileStatus');
+    expectTruthy(fetchedWorkspace?.url, 'get_workspace workspace URL');
 
     const updatedWorkspace = await call('update_workspace', {
       id: workspaceId,

--- a/tests/test-workspace-discovery.mjs
+++ b/tests/test-workspace-discovery.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import * as Y from "yjs";
+
+import { registerWorkspaceTools } from "../dist/tools/workspaces.js";
+
+class ToolRegistry {
+  tools = new Map();
+
+  registerTool(name, definition, handler) {
+    this.tools.set(name, { definition, handler });
+  }
+}
+
+function parseTextContent(result) {
+  const raw = result?.content?.[0]?.text;
+  return raw ? JSON.parse(raw) : null;
+}
+
+function parseToolResult(result) {
+  return result?.structuredContent ?? parseTextContent(result);
+}
+
+function encodedWorkspaceProfile(name, avatar) {
+  const doc = new Y.Doc();
+  const meta = doc.getMap("meta");
+  if (name !== undefined) meta.set("name", name);
+  if (avatar !== undefined) meta.set("avatar", avatar);
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+}
+
+function makeSocket() {
+  return {
+    disconnected: false,
+    disconnect() {
+      this.disconnected = true;
+    },
+  };
+}
+
+async function testListEnrichesProfilesBestEffort() {
+  const originalBaseUrl = process.env.AFFINE_BASE_URL;
+  process.env.AFFINE_BASE_URL = "https://affine.example/";
+  try {
+    const registry = new ToolRegistry();
+    const socket = makeSocket();
+    const joins = [];
+    const loads = [];
+    let connectionAuthCalls = 0;
+    let connectCalls = 0;
+
+    const gql = {
+      endpoint: "https://api.example/graphql",
+      async request(query) {
+        assert.match(query, /workspaces \{ id public enableAi createdAt \}/);
+        return {
+          workspaces: [
+            { id: "workspace-1", public: false, enableAi: true, createdAt: "2026-07-27T00:00:00.000Z" },
+            { id: "workspace-2", public: true, enableAi: false, createdAt: "2026-07-26T00:00:00.000Z" },
+          ],
+        };
+      },
+      async getConnectionAuth() {
+        connectionAuthCalls += 1;
+        return {
+          endpoint: "https://api.example/graphql",
+          cookie: "session=value",
+          bearer: "",
+          headers: {},
+        };
+      },
+    };
+
+    registerWorkspaceTools(registry, gql, {
+      async connectWorkspaceSocket(url, cookie, bearer) {
+        connectCalls += 1;
+        assert.equal(url, "wss://api.example");
+        assert.equal(cookie, "session=value");
+        assert.equal(bearer, "");
+        return socket;
+      },
+      async joinWorkspace(_socket, workspaceId) {
+        joins.push(workspaceId);
+        if (workspaceId === "workspace-2") throw new Error("profile denied");
+      },
+      async loadDoc(_socket, workspaceId, docId) {
+        loads.push({ workspaceId, docId });
+        return { missing: encodedWorkspaceProfile("Product", "blob-avatar") };
+      },
+    });
+
+    const listTool = registry.tools.get("list_workspaces");
+    assert.ok(listTool, "list_workspaces must be registered");
+    assert.ok(listTool.definition.inputSchema.includeProfile, "includeProfile input must be declared");
+
+    const result = await listTool.handler({});
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(parseTextContent(result), [
+      {
+        id: "workspace-1",
+        public: false,
+        enableAi: true,
+        createdAt: "2026-07-27T00:00:00.000Z",
+        name: "Product",
+        avatar: "blob-avatar",
+        url: "https://affine.example/workspace/workspace-1",
+        profileStatus: "available",
+      },
+      {
+        id: "workspace-2",
+        public: true,
+        enableAi: false,
+        createdAt: "2026-07-26T00:00:00.000Z",
+        name: null,
+        avatar: null,
+        url: "https://affine.example/workspace/workspace-2",
+        profileStatus: "unavailable",
+      },
+    ]);
+    assert.equal(connectionAuthCalls, 1);
+    assert.equal(connectCalls, 1, "one socket must be reused for the full list");
+    assert.deepEqual(joins, ["workspace-1", "workspace-2"]);
+    assert.deepEqual(loads, [{ workspaceId: "workspace-1", docId: "workspace-1" }]);
+    assert.equal(socket.disconnected, true, "the shared socket must always disconnect");
+  } finally {
+    if (originalBaseUrl === undefined) delete process.env.AFFINE_BASE_URL;
+    else process.env.AFFINE_BASE_URL = originalBaseUrl;
+  }
+}
+
+async function testListCanSkipProfileLoading() {
+  const registry = new ToolRegistry();
+  let connectionAuthCalls = 0;
+  const gql = {
+    endpoint: "https://affine.example/custom-graphql",
+    async request() {
+      return { workspaces: [{ id: "workspace-fast", public: false, enableAi: false, createdAt: "now" }] };
+    },
+    async getConnectionAuth() {
+      connectionAuthCalls += 1;
+      throw new Error("profile loading must be skipped");
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      throw new Error("profile loading must be skipped");
+    },
+  });
+
+  const result = parseTextContent(await registry.tools.get("list_workspaces").handler({ includeProfile: false }));
+  assert.deepEqual(result, [{
+    id: "workspace-fast",
+    public: false,
+    enableAi: false,
+    createdAt: "now",
+    name: null,
+    avatar: null,
+    url: "https://affine.example/workspace/workspace-fast",
+    profileStatus: "skipped",
+  }]);
+  assert.equal(connectionAuthCalls, 0);
+}
+
+async function testGetWorkspaceUsesTheSameProfileContract() {
+  const registry = new ToolRegistry();
+  const socket = makeSocket();
+  const requests = [];
+  const gql = {
+    endpoint: "https://affine.example/graphql",
+    async request(query, variables) {
+      requests.push({ query, variables });
+      return {
+        workspace: {
+          id: "workspace-detail",
+          public: false,
+          enableAi: true,
+          createdAt: "2026-07-27T00:00:00.000Z",
+          permissions: { Workspace_Read: true, Workspace_CreateDoc: true },
+        },
+      };
+    },
+    async getConnectionAuth() {
+      return { endpoint: this.endpoint, cookie: "", bearer: "token", headers: {} };
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      return socket;
+    },
+    async joinWorkspace(_socket, workspaceId) {
+      assert.equal(workspaceId, "workspace-detail");
+    },
+    async loadDoc(_socket, workspaceId, docId) {
+      assert.equal(workspaceId, "workspace-detail");
+      assert.equal(docId, "workspace-detail");
+      return { missing: encodedWorkspaceProfile("Detailed Workspace", "") };
+    },
+  });
+
+  const result = await registry.tools.get("get_workspace").handler({ id: "workspace-detail" });
+  assert.deepEqual(result.structuredContent, {
+    id: "workspace-detail",
+    public: false,
+    enableAi: true,
+    createdAt: "2026-07-27T00:00:00.000Z",
+    permissions: { Workspace_Read: true, Workspace_CreateDoc: true },
+    name: "Detailed Workspace",
+    avatar: "",
+    url: "https://affine.example/workspace/workspace-detail",
+    profileStatus: "available",
+  });
+  assert.deepEqual(requests[0].variables, { id: "workspace-detail" });
+  assert.equal(socket.disconnected, true);
+}
+
+async function testProfileFailuresDoNotHideGraphqlResults() {
+  const registry = new ToolRegistry();
+  let requestMode = "success";
+  const gql = {
+    endpoint: "https://affine.example/graphql",
+    async request() {
+      if (requestMode === "failure") throw new Error("GraphQL unavailable");
+      return { workspaces: [{ id: "workspace-1", public: false, enableAi: true, createdAt: "now" }] };
+    },
+    async getConnectionAuth() {
+      return { endpoint: this.endpoint, cookie: "", bearer: "", headers: {} };
+    },
+  };
+  registerWorkspaceTools(registry, gql, {
+    async connectWorkspaceSocket() {
+      throw new Error("WebSocket unavailable");
+    },
+  });
+
+  const degraded = await registry.tools.get("list_workspaces").handler({});
+  assert.equal(degraded.isError, undefined);
+  assert.equal(parseTextContent(degraded)[0].profileStatus, "unavailable");
+
+  requestMode = "failure";
+  const failed = await registry.tools.get("list_workspaces").handler({});
+  assert.equal(failed.isError, true);
+  assert.equal(failed.structuredContent.code, "workspace_list_failed");
+  assert.match(failed.structuredContent.error, /GraphQL unavailable/);
+}
+
+await testListEnrichesProfilesBestEffort();
+await testListCanSkipProfileLoading();
+await testGetWorkspaceUsesTheSameProfileContract();
+await testProfileFailuresDoNotHideGraphqlResults();
+console.log("Workspace discovery tests passed");

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.1.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- prepare the `3.1.0` release from the current `develop` line
- publish the authentication, client-version compatibility, delete acknowledgement, and workspace-discovery improvements accumulated since `3.0.1`
- refresh transitive package-lock entries to remove the high-severity `fast-uri` advisory

## Changes

- bump `package.json`, `package-lock.json`, and `tool-manifest.json` to `3.1.0`
- add the `3.1.0` changelog and release notes
- update the README version badge and release highlights
- include workspace profile metadata and an `includeProfile: false` fast path
- prioritize environment authentication sources and preserve partial-credential warnings
- send `x-affine-version` consistently across sign-in, GraphQL, REST, and WebSocket paths
- accept AFFiNE 0.27.3 delete acknowledgements and hide acknowledged stale document listings
- update `jose` to 6.2.4 and refresh safe transitive lockfile versions

## Validation

- `npm run ci` — passed
- `npm audit --audit-level=high` — passed; 0 high vulnerabilities
- `npm run test:comprehensive` — passed (15 focused integration tests, 107/107 regression checks)
- `AFFINE_REVISION=0.27.3 npm run test:e2e` — passed (21 release integration tests, 14 Playwright tests)
- packed tarball smoke test — passed (install, CLI, version, and 92-tool MCP surface)
- `npm publish --dry-run --access public --ignore-scripts` — passed
- `git diff --check` — passed
- repository Hangul scan — clean

## Notes\n\n- Two moderate `@hono/node-server` advisories remain through `@modelcontextprotocol/sdk@1.29.0`; the current SDK release still constrains the affected 1.x adapter line.\n- Review follow-up now bounds acknowledged-delete tombstones, preserves case-insensitive client-version overrides without duplicate headers, and canonicalizes created-workspace URLs.\n- The Playwright sign-in helper now retries interactions that can occur before self-hosted AFFiNE finishes hydrating; the clean API/MCP and UI reruns passed after this hardening.\n\n## Checklist

- [x] Release metadata is consistent at `3.1.0`
- [x] Release notes cover all user-facing changes since `3.0.1`
- [x] High-severity audit gate passes
- [x] Packaged artifact and publish dry-run pass
- [x] AFFiNE 0.27.3 API and UI gates pass

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace listings and workspace details now include best-effort profile name, avatar, direct URL, and availability status, with an option to skip profile enrichment for faster discovery.
  * Improved sign-in request compatibility via configurable client version headers.
* **Bug Fixes**
  * Authentication now prioritizes environment credentials over saved values more reliably.
  * Document deletion acknowledgements are handled across more server response shapes, including safer acknowledgement tracking.
* **Documentation**
  * Updated setup and configuration guides, including MCP Inspector instructions.
* **Tests**
  * Added/expanded coverage for workspace discovery, auth precedence, client-version overrides, and deletion acknowledgement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->