### PR TITLE
chore: sync v3.1.0 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-07-27
+
 ### Added
 - `list_workspaces` and `get_workspace` now include best-effort workspace profile names, avatar references, direct URLs, and an explicit profile status while preserving the existing GraphQL fields and list response shape.
 
 ### Fixed
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
 - Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
+- Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and filters only locally acknowledged deletions from stale `list_docs` edges while upstream indexing converges.
 - Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
 
 ### Tests
 - Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
+- Added deterministic and live integration coverage for workspace profile enrichment, failure isolation, and the GraphQL-only `includeProfile: false` fast path.
+
+### Dependencies
+- Updated `jose` from 6.2.3 to 6.2.4.
+- Refreshed locked HTTP and URI parser dependencies, including `hono`, `body-parser`, `type-is`, and `fast-uri`, clearing the current high-severity audit finding.
 
 ## [3.0.1] - 2026-07-21
 
@@ -620,8 +628,9 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
-[3.0.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.0
+[3.1.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.1.0
 [3.0.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.1
+[3.0.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.0
 [2.5.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.5.0
 [2.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.4.0
 [2.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v2.3.0
@@ -649,4 +658,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Email/password sign-in and all GraphQL/REST requests now send the `x-affine-version` header (configurable via the new `AFFINE_CLIENT_VERSION`, default `0.26.0`). AFFiNE servers that gate on a minimum web-client version previously rejected sign-in with `403 ACTION_FORBIDDEN` (`UNSUPPORTED_CLIENT_VERSION`), leaving the MCP server unable to connect. `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION` so a single variable can govern both the HTTP and realtime-socket client versions.
 - Environment authentication now overrides saved token, cookie, and authentication-header credentials as one source-scoped group, so client-provided email/password credentials cannot be masked by stale local auth state.
 - Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and filters only locally acknowledged deletions from stale `list_docs` edges while upstream indexing converges.
+- Acknowledged deletion tombstones now expire after ten minutes and retain at most 10,000 entries, bounding process memory while preserving the index-convergence window.
+- Case-insensitive `x-affine-version` overrides now replace the default cleanly in CLI and readiness requests instead of producing duplicate header values.
+- Created-workspace URLs now derive from the same canonical AFFiNE origin resolver used by workspace discovery, including custom GraphQL paths.
 - Documented how to launch MCP Inspector with a named Claude Desktop server configuration instead of starting an unauthenticated standalone process.
 
 ### Tests
 - Added CLI, mock-AFFiNE, and live integration regression coverage for environment email/password authentication overriding saved API tokens, cookies, and authentication headers while retaining unrelated saved headers.
 - Added deterministic and live integration coverage for workspace profile enrichment, failure isolation, and the GraphQL-only `includeProfile: false` fast path.
+- Hardened Playwright sign-in setup against clicks that occur before the self-hosted AFFiNE page finishes hydrating.
 
 ### Dependencies
 - Updated `jose` from 6.2.3 to 6.2.4.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.0.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.1.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -49,7 +49,7 @@ Scope boundaries:
 - AFFiNE 0.27+ removed the legacy personal-access-token GraphQL API; this server no longer exposes token-management tools
 - AFFiNE Cloud requires browser-session authentication for this external GraphQL integration; programmatic email/password sign-in is blocked by Cloudflare
 
-> New in v3.0.1: Markdown import/export now preserves AFFiNE inline LinkedPage references for safe round-tripping.
+> New in v3.1.0: Workspace discovery now includes profile metadata and direct links, with improved authentication and document deletion compatibility for AFFiNE 0.27.3.
 
 ## Choose Your Path
 | Goal | Start here |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,12 +14,15 @@
   - Profile lookup failures are isolated per workspace instead of failing the entire result.
 - Authentication and compatibility
   - Added `AFFINE_CLIENT_VERSION` with a default of `0.26.0` and send `x-affine-version` on sign-in, GraphQL, REST, CLI, and readiness requests.
-  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides remain supported.
+  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides replace the default without duplicate values.
   - Environment authentication is resolved as one credential group, preventing saved tokens, cookies, or authentication headers from masking client-provided email/password credentials.
   - MCP Inspector setup guidance now explains how to load a named Claude Desktop server configuration.
 - Document lifecycle
   - `delete_doc` accepts top-level and nested success acknowledgements returned by current AFFiNE servers.
   - Successfully acknowledged deletions are filtered from stale document listings without hiding unrelated orphan documents.
+  - Acknowledged deletion tombstones expire after ten minutes and retain at most 10,000 entries.
+- Workspace URLs
+  - Newly created workspaces use the same canonical AFFiNE origin resolver as workspace discovery, including deployments with custom GraphQL paths.
 - Dependencies and security
   - Updated `jose` from 6.2.3 to 6.2.4.
   - Refreshed locked HTTP and URI parser dependencies and cleared the current high-severity `fast-uri` audit finding.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,41 @@
 # Release Notes
 
+## Version 3.1.0 (2026-07-27)
+
+### Highlights
+- Workspace discovery now returns best-effort profile names, avatar references, direct URLs, and explicit profile status without changing the existing top-level result shape.
+- Self-hosted email/password authentication is more reliable on AFFiNE 0.27.3 because environment credentials override stale saved authentication and every HTTP path sends the required client-version header.
+- Document deletion now recognizes AFFiNE 0.27.3 success acknowledgements and hides only confirmed deletions while upstream indexes converge.
+
+### What Changed
+- Workspace discovery
+  - `list_workspaces` and `get_workspace` enrich GraphQL results with profile metadata when available.
+  - `list_workspaces` accepts `includeProfile: false` for a faster GraphQL-only response.
+  - Profile lookup failures are isolated per workspace instead of failing the entire result.
+- Authentication and compatibility
+  - Added `AFFINE_CLIENT_VERSION` with a default of `0.26.0` and send `x-affine-version` on sign-in, GraphQL, REST, CLI, and readiness requests.
+  - `AFFINE_WS_CLIENT_VERSION` now falls back to `AFFINE_CLIENT_VERSION`, while explicit case-insensitive header overrides remain supported.
+  - Environment authentication is resolved as one credential group, preventing saved tokens, cookies, or authentication headers from masking client-provided email/password credentials.
+  - MCP Inspector setup guidance now explains how to load a named Claude Desktop server configuration.
+- Document lifecycle
+  - `delete_doc` accepts top-level and nested success acknowledgements returned by current AFFiNE servers.
+  - Successfully acknowledged deletions are filtered from stale document listings without hiding unrelated orphan documents.
+- Dependencies and security
+  - Updated `jose` from 6.2.3 to 6.2.4.
+  - Refreshed locked HTTP and URI parser dependencies and cleared the current high-severity `fast-uri` audit finding.
+
+### Compatibility
+- No tools were removed and no existing input is required to change.
+- Node.js 20 or newer remains required.
+- Operators can override `AFFINE_CLIENT_VERSION` when an AFFiNE deployment requires a newer minimum client version.
+
+### Validation Evidence
+- `npm run ci`
+- `npm audit --audit-level=high`
+- `npm run test:comprehensive`
+- `AFFINE_REVISION=0.27.3 npm run test:e2e`
+- package smoke test and `npm publish --dry-run --access public --ignore-scripts`
+
 ## Version 3.0.1 (2026-07-21)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1086,21 +1086,34 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1528,9 +1541,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1776,9 +1789,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2496,17 +2509,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,9 +116,11 @@ async function gql(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
-    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(auth.headers || {}),
   };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   if (auth.token) headers.Authorization = `Bearer ${auth.token}`;
   if (auth.cookie) headers.Cookie = auth.cookie;
   const body: any = { query };

--- a/src/httpDiagnostics.ts
+++ b/src/httpDiagnostics.ts
@@ -12,9 +12,11 @@ async function probeAffineGraphql(config: ServerConfig): Promise<void> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "User-Agent": `affine-mcp-server/${VERSION}`,
-    "x-affine-version": AFFINE_CLIENT_VERSION,
     ...(config.headers || {}),
   };
+  if (!Object.keys(headers).some((name) => name.toLowerCase() === "x-affine-version")) {
+    headers["x-affine-version"] = AFFINE_CLIENT_VERSION;
+  }
   if (config.apiToken) headers.Authorization = `Bearer ${config.apiToken}`;
 
   const controller = new AbortController();

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -650,8 +650,70 @@ export async function deleteDocFromWorkspace(
   }
 }
 
+type AcknowledgedDeletedDocTrackerOptions = {
+  ttlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+};
+
+export function createAcknowledgedDeletedDocTracker({
+  ttlMs = 10 * 60_000,
+  maxEntries = 10_000,
+  now = Date.now,
+}: AcknowledgedDeletedDocTrackerOptions = {}) {
+  const entries = new Map<string, Map<string, number>>();
+
+  const forget = (workspaceId: string, docId: string) => {
+    const workspaceEntries = entries.get(workspaceId);
+    workspaceEntries?.delete(docId);
+    if (workspaceEntries?.size === 0) {
+      entries.delete(workspaceId);
+    }
+  };
+
+  const prune = (currentTime: number) => {
+    const retained: Array<{ workspaceId: string; docId: string; acknowledgedAt: number }> = [];
+    for (const [workspaceId, workspaceEntries] of entries) {
+      for (const [docId, acknowledgedAt] of workspaceEntries) {
+        if (currentTime - acknowledgedAt >= ttlMs) {
+          workspaceEntries.delete(docId);
+        } else {
+          retained.push({ workspaceId, docId, acknowledgedAt });
+        }
+      }
+      if (workspaceEntries.size === 0) {
+        entries.delete(workspaceId);
+      }
+    }
+
+    const overflow = retained.length - maxEntries;
+    if (overflow > 0) {
+      retained.sort((left, right) => left.acknowledgedAt - right.acknowledgedAt);
+      for (const entry of retained.slice(0, overflow)) {
+        forget(entry.workspaceId, entry.docId);
+      }
+    }
+  };
+
+  return {
+    remember(workspaceId: string, docId: string) {
+      const currentTime = now();
+      prune(currentTime);
+      const workspaceEntries = entries.get(workspaceId) || new Map<string, number>();
+      workspaceEntries.set(docId, currentTime);
+      entries.set(workspaceId, workspaceEntries);
+      prune(currentTime);
+    },
+    forget,
+    idsFor(workspaceId: string): Set<string> {
+      prune(now());
+      return new Set(entries.get(workspaceId)?.keys() || []);
+    },
+  };
+}
+
 export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults: { workspaceId?: string }) {
-  const acknowledgedDeletedDocIds = new Map<string, Set<string>>();
+  const acknowledgedDeletedDocs = createAcknowledgedDeletedDocTracker();
 
   // helpers
   function generateId(): string {
@@ -4184,7 +4246,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const inTrashByDocId = new Map<string, boolean>();
       let workspacePageCount: number | null = null;
       let workspacePageIds: Set<string> | null = null;
-      const deletedDocIds = new Set(acknowledgedDeletedDocIds.get(workspaceId) || []);
+      const deletedDocIds = acknowledgedDeletedDocs.idsFor(workspaceId);
       try {
         const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
@@ -4202,7 +4264,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             for (const docId of deletedDocIds) {
               if (workspacePageIds.has(docId)) {
                 deletedDocIds.delete(docId);
-                acknowledgedDeletedDocIds.get(workspaceId)?.delete(docId);
+                acknowledgedDeletedDocs.forget(workspaceId, docId);
               }
             }
             const { byId } = getWorkspaceTagOptionMaps(meta);
@@ -6341,9 +6403,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const result = await deleteDocFromWorkspace(socket, workspaceId, parsed.docId);
       const deletion = result.structuredContent as { ok?: boolean; status?: string } | undefined;
       if (deletion?.ok === true && (deletion.status === "deleted" || deletion.status === "already_absent")) {
-        const deletedIds = acknowledgedDeletedDocIds.get(workspaceId) || new Set<string>();
-        deletedIds.add(parsed.docId);
-        acknowledgedDeletedDocIds.set(workspaceId, deletedIds);
+        acknowledgedDeletedDocs.remember(workspaceId, parsed.docId);
       }
       return result;
     } finally {

--- a/src/tools/workspaces.ts
+++ b/src/tools/workspaces.ts
@@ -379,7 +379,7 @@ export function registerWorkspaceTools(
         
         const workspace = result.data.createWorkspace;
         const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
-        const baseUrl = process.env.AFFINE_BASE_URL || endpoint.replace(/\/graphql\/?$/, '');
+        const baseUrl = affineBaseUrl(endpoint);
 
         try {
           const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);

--- a/tests/playwright/sign-in.ts
+++ b/tests/playwright/sign-in.ts
@@ -21,26 +21,20 @@ export async function signInToAffine(
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= 24; attempt++) {
-    await page.goto(signInUrl, { waitUntil: 'domcontentloaded' });
-
-    const emailInput = page.locator(EMAIL_INPUT_SELECTOR);
-    const passwordInput = page.locator(PASSWORD_INPUT_SELECTOR);
-    await emailInput.waitFor({ timeout: 30_000 });
-    await page.waitForTimeout(1_000);
-    await emailInput.fill(email);
-    await page.locator(CONTINUE_BUTTON_SELECTOR).first().click();
-
     try {
+      await page.goto(signInUrl, { waitUntil: 'domcontentloaded' });
+
+      const emailInput = page.locator(EMAIL_INPUT_SELECTOR);
+      const passwordInput = page.locator(PASSWORD_INPUT_SELECTOR);
+      await emailInput.waitFor({ timeout: 30_000 });
+      await page.waitForTimeout(1_000);
+      await emailInput.fill(email);
+      await page.locator(CONTINUE_BUTTON_SELECTOR).first().click();
+
       await passwordInput.waitFor({ timeout: 4_000 });
-    } catch (error) {
-      lastError = error;
-      continue;
-    }
-
-    await passwordInput.fill(password);
-    await page.waitForTimeout(1_000);
-    await page.locator(SIGN_IN_BUTTON_SELECTOR).first().click();
-    try {
+      await passwordInput.fill(password);
+      await page.waitForTimeout(1_000);
+      await page.locator(SIGN_IN_BUTTON_SELECTOR).first().click();
       await page.waitForURL(
         (url) => !url.toString().includes('/sign-in'),
         { timeout: 4_000, waitUntil: 'commit' },

--- a/tests/playwright/sign-in.ts
+++ b/tests/playwright/sign-in.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+
+const EMAIL_INPUT_SELECTOR = 'input[type="email"], input[name="email"], input[placeholder*="email"]';
+const PASSWORD_INPUT_SELECTOR = 'input[type="password"], input[name="password"]';
+const CONTINUE_BUTTON_SELECTOR =
+  'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]';
+const SIGN_IN_BUTTON_SELECTOR =
+  'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]';
+
+type SignInOptions = {
+  baseUrl: string;
+  email: string;
+  password: string;
+};
+
+export async function signInToAffine(
+  page: Page,
+  { baseUrl, email, password }: SignInOptions,
+): Promise<void> {
+  const signInUrl = `${baseUrl}/sign-in`;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 24; attempt++) {
+    await page.goto(signInUrl, { waitUntil: 'domcontentloaded' });
+
+    const emailInput = page.locator(EMAIL_INPUT_SELECTOR);
+    const passwordInput = page.locator(PASSWORD_INPUT_SELECTOR);
+    await emailInput.waitFor({ timeout: 30_000 });
+    await page.waitForTimeout(1_000);
+    await emailInput.fill(email);
+    await page.locator(CONTINUE_BUTTON_SELECTOR).first().click();
+
+    try {
+      await passwordInput.waitFor({ timeout: 4_000 });
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+
+    await passwordInput.fill(password);
+    await page.waitForTimeout(1_000);
+    await page.locator(SIGN_IN_BUTTON_SELECTOR).first().click();
+    try {
+      await page.waitForURL(
+        (url) => !url.toString().includes('/sign-in'),
+        { timeout: 4_000, waitUntil: 'commit' },
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}

--- a/tests/playwright/verify-data-view.pw.ts
+++ b/tests/playwright/verify-data-view.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,28 +43,8 @@ if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
 
 test.describe.serial('AFFiNE Data View Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     for (let i = 0; i < 5; i++) {
       await page.waitForTimeout(1_000);

--- a/tests/playwright/verify-database.pw.ts
+++ b/tests/playwright/verify-database.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,36 +45,10 @@ if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
 
 test.describe.serial('AFFiNE Database Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
+    test.setTimeout(180_000);
     const baseUrl = state.baseUrl;
 
-    // Navigate directly to the sign-in page
-    await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    // Fill email — the placeholder is "Enter your email address"
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    // Click "Continue with email"
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    // Fill password
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    // Click sign in / submit
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    // Wait for redirect away from sign-in page
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    await signInToAffine(page, { baseUrl, email: state.email, password });
 
     // Dismiss any onboarding modals/dialogs that may appear
     for (let i = 0; i < 5; i++) {

--- a/tests/playwright/verify-edgeless-canvas.pw.ts
+++ b/tests/playwright/verify-edgeless-canvas.pw.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -82,28 +83,8 @@ async function openDocInEdgelessMode(page: Page) {
 
 test.describe.serial('AFFiNE Edgeless Canvas Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     for (let i = 0; i < 5; i++) {
       await page.waitForTimeout(1_000);

--- a/tests/playwright/verify-tag-visibility.pw.ts
+++ b/tests/playwright/verify-tag-visibility.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -59,30 +60,10 @@ async function dismissModals(page: any, rounds: number) {
 
 test.describe.serial('Tag Visibility Verification', () => {
   test('login to AFFiNE', async ({ page, context }) => {
+    test.setTimeout(180_000);
     const baseUrl = state.baseUrl;
 
-    await page.goto(`${baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    await signInToAffine(page, { baseUrl, email: state.email, password });
     await dismissModals(page, 5);
 
     expect(page.url()).not.toContain('/sign-in');

--- a/tests/playwright/verify-theme-adaptation.pw.ts
+++ b/tests/playwright/verify-theme-adaptation.pw.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signInToAffine } from './sign-in.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -65,28 +66,8 @@ async function readTokens(page, names: string[]): Promise<Record<string, string>
 
 test.describe.serial('AFFiNE theme-adaptation invariants', () => {
   test('login to AFFiNE', async ({ page, context }) => {
-    await page.goto(`${state.baseUrl}/sign-in`);
-    await page.waitForLoadState('domcontentloaded');
-
-    const emailInput = page.locator('input[type="email"], input[name="email"], input[placeholder*="email"]');
-    await emailInput.waitFor({ timeout: 30_000 });
-    await emailInput.fill(state.email);
-
-    const continueBtn = page.locator(
-      'button:has-text("Continue with email"), button:has-text("Continue"), button[type="submit"]',
-    );
-    await continueBtn.first().click();
-
-    const passwordInput = page.locator('input[type="password"], input[name="password"]');
-    await passwordInput.waitFor({ timeout: 15_000 });
-    await passwordInput.fill(password);
-
-    const signInBtn = page.locator(
-      'button:has-text("Sign in"), button:has-text("Log in"), button[type="submit"]',
-    );
-    await signInBtn.first().click();
-
-    await page.waitForURL(url => !url.toString().includes('/sign-in'), { timeout: 30_000 });
+    test.setTimeout(180_000);
+    await signInToAffine(page, { baseUrl: state.baseUrl, email: state.email, password });
 
     const storageStatePath = path.resolve(__dirname, '..', 'playwright-auth-state.json');
     await context.storageState({ path: storageStatePath });

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -141,6 +141,7 @@ const upstream = createServer(async (request, response) => {
     authorization: request.headers.authorization || null,
     cookie: request.headers.cookie || null,
     tenant: request.headers["x-tenant"] || null,
+    affineVersion: request.headers["x-affine-version"] || null,
     query: body.query,
     url: request.url,
   });
@@ -187,6 +188,7 @@ try {
     AFFINE_BASE_URL: baseUrl,
     AFFINE_GRAPHQL_PATH: "/custom/graphql",
     AFFINE_API_TOKEN: "env-token",
+    AFFINE_HEADERS_JSON: JSON.stringify({ "X-Affine-Version": "cli-override-version" }),
     AFFINE_WORKSPACE_ID: "workspace-env",
     MCP_TRANSPORT: "streamable",
     PORT: "4321",
@@ -337,8 +339,11 @@ try {
   expect(statusPayload.authKind === "api-token", "status did not use effective token auth");
   expect(statusPayload.userEmail === "config@example.test", "status did not inspect the fake upstream");
   expect(
-    graphqlRequests.some((entry) => entry.authorization === "Bearer env-token"),
-    "status did not send the environment API token",
+    graphqlRequests.some(
+      (entry) => entry.authorization === "Bearer env-token"
+        && entry.affineVersion === "cli-override-version",
+    ),
+    "status did not send the environment API token and exact client-version override",
   );
 
   const noConfigHome = path.join(TEMP_ROOT, "no-config");
@@ -507,6 +512,7 @@ try {
       "X-Tenant": "saved-tenant",
       Authorization: "Basic stale",
       Cookie: "stale-header-cookie",
+      "X-Affine-Version": "readyz-override-version",
     }),
     MCP_TRANSPORT: "http",
     PORT: String(httpPort),
@@ -538,9 +544,10 @@ try {
       (entry) => entry.query.includes("AffineMcpReadiness")
         && entry.authorization === "Bearer runtime-token"
         && entry.cookie === null
-        && entry.tenant === "saved-tenant",
+        && entry.tenant === "saved-tenant"
+        && entry.affineVersion === "readyz-override-version",
     ),
-    "readyz did not use the configured endpoint, custom headers, and service token",
+    "readyz did not use the configured endpoint, exact client-version override, custom headers, and service token",
   );
 
   upstreamReady = false;
@@ -566,6 +573,7 @@ try {
       "strict transport validation",
       "saved HTTP runtime flags",
       "upstream-aware readiness",
+      "case-insensitive client-version overrides",
     ],
   }, null, 2));
 } finally {

--- a/tests/test-destructive-mutation-ack.mjs
+++ b/tests/test-destructive-mutation-ack.mjs
@@ -8,7 +8,10 @@ import * as Y from "yjs";
 import { deleteDoc } from "../dist/ws.js";
 import { registerBlobTools } from "../dist/tools/blobStorage.js";
 import { registerCommentTools } from "../dist/tools/comments.js";
-import { deleteDocFromWorkspace } from "../dist/tools/docs.js";
+import {
+  createAcknowledgedDeletedDocTracker,
+  deleteDocFromWorkspace,
+} from "../dist/tools/docs.js";
 import { registerNotificationTools } from "../dist/tools/notifications.js";
 import { registerWorkspaceTools } from "../dist/tools/workspaces.js";
 
@@ -162,6 +165,32 @@ class ToolRegistry {
   registerTool(name, _definition, handler) {
     this.tools.set(name, handler);
   }
+}
+
+function testAcknowledgedDeleteTrackerBounds() {
+  let currentTime = 0;
+  const tracker = createAcknowledgedDeletedDocTracker({
+    ttlMs: 100,
+    maxEntries: 2,
+    now: () => currentTime,
+  });
+
+  tracker.remember("workspace-1", "doc-1");
+  currentTime = 50;
+  tracker.remember("workspace-1", "doc-2");
+  assert.deepEqual([...tracker.idsFor("workspace-1")], ["doc-1", "doc-2"]);
+
+  currentTime = 75;
+  tracker.remember("workspace-2", "doc-3");
+  assert.deepEqual([...tracker.idsFor("workspace-1")], ["doc-2"]);
+  assert.deepEqual([...tracker.idsFor("workspace-2")], ["doc-3"]);
+
+  currentTime = 151;
+  assert.deepEqual([...tracker.idsFor("workspace-1")], []);
+  assert.deepEqual([...tracker.idsFor("workspace-2")], ["doc-3"]);
+
+  tracker.forget("workspace-2", "doc-3");
+  assert.deepEqual([...tracker.idsFor("workspace-2")], []);
 }
 
 async function testDeleteDocProtocol() {
@@ -484,6 +513,7 @@ async function testAdditionalMutationReceipts() {
   assert.equal(parseToolResult(await updateWorkspace({ id: "workspace-1", public: true })).ok, true);
 }
 
+testAcknowledgedDeleteTrackerBounds();
 await testDeleteDocProtocol();
 await testDocumentReceipts();
 await testWorkspaceReceipts();

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
+  "version": "3.1.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- sync the confirmed `v3.1.0` release commit from `main` back into `develop`
- keep future development based on the published source plus one test-only review hardening follow-up

## Included

- v3.1.0 release metadata and documentation
- release-review fixes for client-version headers, deletion tombstone bounds, and workspace URL resolution
- deterministic Playwright sign-in setup used by the validated release E2E suite\n- CodeRabbit follow-up that retries the complete sign-in attempt after any transient navigation, locator, fill, or click failure

## Validation

- release PR #268 merged with all CI, E2E, Docker smoke, security, branch-route, and CodeRabbit checks passing
- annotated tag `v3.1.0` resolves to merge commit `c56e00a3dc3c2cdecde2820030cece36e9269469`
- npm publish and GHCR release workflows completed successfully
- npm `latest` resolves to `3.1.0`

## Notes

- source: confirmed `origin/main` release commit
- target: `develop`
- one post-release test-only hardening commit is included; published runtime artifacts are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace discovery now includes profile names, avatars, direct URLs, and profile status.
  * Document deletion results are handled more reliably while changes synchronize.
  * Workspace creation now returns canonical direct URLs across deployment configurations.

* **Bug Fixes**
  * Improved authentication and client-version header handling, including custom overrides.
  * Prevented saved credentials from masking explicitly provided login credentials.
  * Improved compatibility with self-hosted deployments and MCP Inspector setup.

* **Documentation**
  * Added Version 3.1.0 release notes and updated version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->