### PR TITLE
chore: refresh security dependencies and release validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added declared MCP `outputSchema` metadata for all 92 canonical tools so ChatGPT and other clients can validate structured results and reason about follow-up calls.
 
+### Security
+- Raised the minimum MCP SDK and `undici` versions and refreshed transitive dependency locks to remediate current `@hono/node-server`, `fast-uri`, `hono`, `ip-address`, `socket.io-parser`, and `undici` advisories.
+
 ### Tests
 - Added output-schema coverage and MCP round-trip validation, and included it in the default test and CI gates.
+- Configured isolated comprehensive-test instances to disable AFFiNE's new-account share delay so document publish and revoke coverage runs deterministically.
 
 ## [3.1.0] - 2026-07-27
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.2",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "form-data": "^4.0.4",
@@ -18,7 +18,7 @@
         "markdown-it": "^14.1.0",
         "node-fetch": "^3.3.2",
         "socket.io-client": "^4.8.1",
-        "undici": "^6.27.0",
+        "undici": "^6.28.0",
         "yjs": "^13.6.27",
         "zod": "^3.23.8"
       },
@@ -481,12 +481,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1541,9 +1541,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1789,9 +1789,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1840,9 +1840,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -2581,9 +2581,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "form-data": "^4.0.4",
@@ -132,7 +132,7 @@
     "markdown-it": "^14.1.0",
     "node-fetch": "^3.3.2",
     "socket.io-client": "^4.8.1",
-    "undici": "^6.27.0",
+    "undici": "^6.28.0",
     "yjs": "^13.6.27",
     "zod": "^3.23.8"
   },

--- a/tests/acquire-credentials.mjs
+++ b/tests/acquire-credentials.mjs
@@ -72,12 +72,13 @@ export async function ensureAdminUser(baseUrl, email, password) {
  * Sign in to AFFiNE and return session cookie.
  * Pattern matches src/auth.ts (getSetCookie / fallback).
  */
-export async function acquireCredentials(baseUrl, email, password) {
+export async function acquireCredentials(baseUrl, email, password, { signal } = {}) {
   const url = `${baseUrl.replace(/\/$/, '')}/api/auth/sign-in`;
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
+    signal,
   });
 
   if (!res.ok) {

--- a/tests/configure-comprehensive-instance.mjs
+++ b/tests/configure-comprehensive-instance.mjs
@@ -12,7 +12,9 @@ if (!baseUrl || !email || !password) {
   );
 }
 
-const { cookie } = await acquireCredentials(baseUrl, email, password);
+const { cookie } = await acquireCredentials(baseUrl, email, password, {
+  signal: AbortSignal.timeout(30_000),
+});
 const response = await fetch(`${baseUrl.replace(/\/$/, '')}/graphql`, {
   method: 'POST',
   headers: {
@@ -34,6 +36,7 @@ const response = await fetch(`${baseUrl.replace(/\/$/, '')}/graphql`, {
       }
     `,
   }),
+  signal: AbortSignal.timeout(30_000),
 });
 
 const body = await response.json().catch(() => null);

--- a/tests/configure-comprehensive-instance.mjs
+++ b/tests/configure-comprehensive-instance.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { acquireCredentials } from './acquire-credentials.mjs';
+
+const baseUrl = process.env.AFFINE_BASE_URL;
+const email = process.env.AFFINE_ADMIN_EMAIL;
+const password = process.env.AFFINE_ADMIN_PASSWORD;
+
+if (!baseUrl || !email || !password) {
+  throw new Error(
+    'AFFINE_BASE_URL, AFFINE_ADMIN_EMAIL, and AFFINE_ADMIN_PASSWORD are required'
+  );
+}
+
+const { cookie } = await acquireCredentials(baseUrl, email, password);
+const response = await fetch(`${baseUrl.replace(/\/$/, '')}/graphql`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    Cookie: cookie,
+  },
+  body: JSON.stringify({
+    query: `
+      mutation ConfigureComprehensiveInstance {
+        updateAppConfig(
+          updates: [
+            {
+              module: "auth"
+              key: "newAccountShareActionDelay"
+              value: 0
+            }
+          ]
+        )
+      }
+    `,
+  }),
+});
+
+const body = await response.json().catch(() => null);
+if (!response.ok || body?.errors?.length) {
+  const message = body?.errors?.map(error => error.message).join('; ')
+    || `${response.status} ${response.statusText}`;
+  throw new Error(`Failed to configure the comprehensive test instance: ${message}`);
+}
+
+if (body?.data?.updateAppConfig?.auth?.newAccountShareActionDelay !== 0) {
+  throw new Error('AFFiNE did not confirm the comprehensive test configuration');
+}
+
+console.log('[comprehensive] New-account share delay disabled for the isolated test instance');

--- a/tests/run-comprehensive.sh
+++ b/tests/run-comprehensive.sh
@@ -168,6 +168,10 @@ echo "=== Re-checking AFFiNE auth readiness ==="
 wait_for_auth_ready
 
 echo ""
+echo "=== Configuring isolated AFFiNE test instance ==="
+node "$SCRIPT_DIR/configure-comprehensive-instance.mjs"
+
+echo ""
 echo "=== Running focused comprehensive suite ==="
 node "$PROJECT_DIR/scripts/run-test-suite.mjs" comprehensive
 


### PR DESCRIPTION
## Summary

- Raise the minimum MCP SDK and `undici` versions and refresh transitive locks to clear the current dependency advisories.
- Configure only the isolated comprehensive-test AFFiNE instance to bypass the upstream 24-hour new-account sharing delay, keeping `publish_doc` and `revoke_doc` coverage deterministic.
- Keep this change independent of #270; no commits from #270 are included.

## Validation

- Node.js 20: `npm ci && npm run ci`
- Node.js 24: `npm ci && npm run ci`
- `npm audit --audit-level=low`: 0 vulnerabilities
- AFFiNE 0.27.3 comprehensive suite: 15/15 focused tests and 107/107 regression checks
- AFFiNE 0.27.3 E2E: 21/21 integration tests and 14/14 Playwright tests
- Packed-tarball smoke: Node.js 20 and Node.js 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the MCP SDK and HTTP client versions to include the latest security improvements.

* **Tests**
  * Improved comprehensive test setup for reliable document publishing and revocation coverage.
  * Added validation of test-instance configuration and authentication before regression tests run.

* **Documentation**
  * Updated the unreleased changelog with dependency and test-configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->