### PR TITLE
fix: harden CLI login credential handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Replaced the `affine-mcp login --cookie <value>` process-argument path with `--cookie-stdin` so browser session cookies do not appear in shell history or process listings.
+
+### Fixed
+- `affine-mcp login --workspace-id` now verifies that the requested workspace is available to the authenticated account before saving the configuration.
+
+### Tests
+- Added CLI regressions for stdin cookie authentication, legacy cookie redaction, inaccessible workspace rejection, and live workspace validation.
+
 ## [3.2.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ This stores credentials in `$XDG_CONFIG_HOME/affine-mcp/config` when `XDG_CONFIG
 - For self-hosted AFFiNE, use email/password (recommended) or a signed-in session cookie
 - `AFFINE_API_TOKEN` remains available only for deployments that still accept a compatible GraphQL bearer token
 
+For scripted session-cookie setup, keep the cookie out of process arguments:
+
+```bash
+affine-mcp login --url https://app.affine.pro --cookie-stdin --workspace-id your-workspace-id --force
+```
+
+Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The CLI verifies `--workspace-id` against the authenticated account before saving it.
+
 ### 4. Register the server with your client
 
 Claude Code project config:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For scripted session-cookie setup, keep the cookie out of process arguments:
 affine-mcp login --url https://app.affine.pro --cookie-stdin --workspace-id your-workspace-id --force
 ```
 
-Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The CLI verifies `--workspace-id` against the authenticated account before saving it.
+Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The CLI verifies `--workspace-id` against the authenticated account before saving it. Piped input requires `--force` when existing credentials would be replaced.
 
 ### 4. Register the server with your client
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,14 @@ What happens:
 - For self-hosted AFFiNE, it signs in with email/password and saves the resulting session cookie
 - The effective config is stored at `$XDG_CONFIG_HOME/affine-mcp/config` when `XDG_CONFIG_HOME` is set, otherwise at `~/.config/affine-mcp/config`
 
+For automation, pass browser-session cookies through stdin instead of process arguments:
+
+```bash
+affine-mcp login --url https://app.affine.pro --cookie-stdin --workspace-id your-workspace-id --force
+```
+
+Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The requested workspace must be available to the authenticated account.
+
 ### 3. Verify the saved config
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ For automation, pass browser-session cookies through stdin instead of process ar
 affine-mcp login --url https://app.affine.pro --cookie-stdin --workspace-id your-workspace-id --force
 ```
 
-Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The requested workspace must be available to the authenticated account.
+Paste the cookie at the hidden prompt, or pipe it from a trusted secret source. The requested workspace must be available to the authenticated account. Piped input requires `--force` when existing credentials would be replaced.
 
 ### 3. Verify the saved config
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -513,16 +513,25 @@ async function login(args: string[]) {
   if (providedToken && useCookieStdin) {
     throw new CliError("Use either --token or --cookie-stdin, not both.");
   }
+  const nonInteractiveCookieStdin = useCookieStdin && process.stdin.isTTY !== true;
 
   console.error("Affine MCP Server — Login\n");
 
   const existing = loadConfigFile();
-  if (existing.AFFINE_API_TOKEN || existing.AFFINE_COOKIE || (existing.AFFINE_EMAIL && existing.AFFINE_PASSWORD)) {
+  const hasExistingAuth = Boolean(
+    existing.AFFINE_API_TOKEN ||
+    existing.AFFINE_COOKIE ||
+    (existing.AFFINE_EMAIL && existing.AFFINE_PASSWORD),
+  );
+  if (hasExistingAuth) {
     console.error(`Existing config: ${CONFIG_FILE}`);
     console.error(`  URL:       ${existing.AFFINE_BASE_URL || "(default)"}`);
     console.error("  Auth:      (set)");
     console.error(`  Workspace: ${existing.AFFINE_WORKSPACE_ID || "(none)"}\n`);
     if (!force) {
+      if (nonInteractiveCookieStdin) {
+        throw new CliError("--force is required when --cookie-stdin would overwrite existing credentials.");
+      }
       const overwrite = await ask("Overwrite? [y/N] ");
       if (!/^[yY]$/.test(overwrite)) {
         console.error("Keeping existing config.");
@@ -534,8 +543,14 @@ async function login(args: string[]) {
     }
   }
 
+  const pipedCookie = nonInteractiveCookieStdin ? await ask("", true) : undefined;
   const defaultUrl = "https://app.affine.pro";
-  const rawUrl = providedUrl ?? ((await ask(`Affine URL [${defaultUrl}]: `)) || defaultUrl);
+  const configuredUrl = process.env.AFFINE_BASE_URL || existing.AFFINE_BASE_URL || defaultUrl;
+  const rawUrl = providedUrl ?? (
+    nonInteractiveCookieStdin
+      ? configuredUrl
+      : (await ask(`Affine URL [${defaultUrl}]: `)) || defaultUrl
+  );
   const baseUrl = validateBaseUrl(rawUrl, {
     allowInsecureHttp: parseBooleanFlag(
       "AFFINE_ALLOW_INSECURE_HTTP",
@@ -548,9 +563,11 @@ async function login(args: string[]) {
     providedGraphqlPath || process.env.AFFINE_GRAPHQL_PATH || existing.AFFINE_GRAPHQL_PATH || "/graphql",
   );
   const graphqlEndpoint = buildGraphqlEndpoint(baseUrl, graphqlPath);
-  const providedCookie = useCookieStdin
-    ? await ask(process.stdin.isTTY ? "Session cookie: " : "", true)
-    : undefined;
+  const providedCookie = nonInteractiveCookieStdin
+    ? pipedCookie
+    : useCookieStdin
+      ? await ask("Session cookie: ", true)
+      : undefined;
   if (useCookieStdin && !providedCookie) {
     throw new CliError("No session cookie received on stdin.");
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -353,19 +353,34 @@ async function detectWorkspace(
   auth: CliAuth,
   preferredWorkspaceId?: string,
 ): Promise<string> {
-  if (preferredWorkspaceId) {
-    console.error(`Using workspace override: ${preferredWorkspaceId}`);
-    return preferredWorkspaceId;
-  }
-  console.error("Detecting workspaces...");
+  console.error(preferredWorkspaceId ? "Validating workspace override..." : "Detecting workspaces...");
+  let data: any;
   try {
-    const data = await gql(graphqlEndpoint, auth, `query {
+    data = await gql(graphqlEndpoint, auth, `query {
       workspaces {
         id createdAt memberCount
         owner { name }
       }
     }`);
-    const workspaces: any[] = data.workspaces;
+  } catch (err: any) {
+    if (preferredWorkspaceId) {
+      throw new CliError(`Could not validate workspace '${preferredWorkspaceId}': ${err.message}`);
+    }
+    console.error(`  Could not list workspaces: ${err.message}`);
+    return "";
+  }
+
+  const workspaces: any[] = Array.isArray(data?.workspaces) ? data.workspaces : [];
+  if (preferredWorkspaceId) {
+    const preferredWorkspace = workspaces.find((workspace) => workspace?.id === preferredWorkspaceId);
+    if (!preferredWorkspace) {
+      throw new CliError(`Workspace '${preferredWorkspaceId}' is not available to the authenticated account.`);
+    }
+    console.error(`  Verified workspace: ${preferredWorkspaceId}`);
+    return preferredWorkspaceId;
+  }
+
+  try {
     if (workspaces.length === 0) {
       console.error("  No workspaces found.");
       return "";
@@ -400,6 +415,7 @@ async function detectWorkspace(
 async function loginWithEmail(
   baseUrl: string,
   graphqlEndpoint: string,
+  preferredWorkspaceId?: string,
 ): Promise<LoginResult> {
   const email = await ask("Email: ");
   const password = await ask("Password: ", true);
@@ -423,12 +439,13 @@ async function loginWithEmail(
     throw new CliError(`Session verification failed: ${err.message}`);
   }
 
-  const workspaceId = await detectWorkspace(graphqlEndpoint, auth);
+  const workspaceId = await detectWorkspace(graphqlEndpoint, auth, preferredWorkspaceId);
   return { cookie: cookieHeader, workspaceId };
 }
 
 async function loginWithToken(
   graphqlEndpoint: string,
+  preferredWorkspaceId?: string,
 ): Promise<LoginResult> {
   console.error(
     "\nAFFiNE 0.27+ no longer provides legacy personal access tokens. " +
@@ -448,13 +465,14 @@ async function loginWithToken(
     throw new CliError(`Authentication failed: ${err.message}`);
   }
 
-  const workspaceId = await detectWorkspace(graphqlEndpoint, { token });
+  const workspaceId = await detectWorkspace(graphqlEndpoint, { token }, preferredWorkspaceId);
   return { token, workspaceId };
 }
 
 async function loginWithCookie(
   baseUrl: string,
   graphqlEndpoint: string,
+  preferredWorkspaceId?: string,
 ): Promise<LoginResult> {
   console.error("\nTo use an existing browser session:");
   console.error(`  1. Sign in to ${baseUrl}`);
@@ -474,21 +492,26 @@ async function loginWithCookie(
     throw new CliError(`Authentication failed: ${err.message}`);
   }
 
-  const workspaceId = await detectWorkspace(graphqlEndpoint, { cookie });
+  const workspaceId = await detectWorkspace(graphqlEndpoint, { cookie }, preferredWorkspaceId);
   return { cookie, workspaceId };
 }
 
 async function login(args: string[]) {
+  if (args.some((arg) => arg === "--cookie" || arg.startsWith("--cookie="))) {
+    throw new CliError(
+      "The --cookie option is not accepted because command-line arguments may be visible to other processes. Use --cookie-stdin instead.",
+    );
+  }
   const parsedArgs = [...args];
   const providedUrl = consumeOption(parsedArgs, "--url");
   const providedGraphqlPath = consumeOption(parsedArgs, "--graphql-path");
   const providedToken = consumeOption(parsedArgs, "--token");
-  const providedCookie = consumeOption(parsedArgs, "--cookie");
+  const useCookieStdin = consumeFlags(parsedArgs, "--cookie-stdin");
   const providedWorkspaceId = consumeOption(parsedArgs, "--workspace-id");
   const force = consumeFlags(parsedArgs, "--force", "-f");
   ensureNoUnexpectedArgs(parsedArgs, "login");
-  if (providedToken && providedCookie) {
-    throw new CliError("Use either --token or --cookie, not both.");
+  if (providedToken && useCookieStdin) {
+    throw new CliError("Use either --token or --cookie-stdin, not both.");
   }
 
   console.error("Affine MCP Server — Login\n");
@@ -525,6 +548,12 @@ async function login(args: string[]) {
     providedGraphqlPath || process.env.AFFINE_GRAPHQL_PATH || existing.AFFINE_GRAPHQL_PATH || "/graphql",
   );
   const graphqlEndpoint = buildGraphqlEndpoint(baseUrl, graphqlPath);
+  const providedCookie = useCookieStdin
+    ? await ask(process.stdin.isTTY ? "Session cookie: " : "", true)
+    : undefined;
+  if (useCookieStdin && !providedCookie) {
+    throw new CliError("No session cookie received on stdin.");
+  }
 
   let result: LoginResult;
 
@@ -559,25 +588,19 @@ async function login(args: string[]) {
         "\nAuth method — [1] Email/password (recommended)  [2] Paste session cookie  [3] Compatible API token: ",
       );
       const loginResult = method === "2"
-        ? await loginWithCookie(baseUrl, graphqlEndpoint)
+        ? await loginWithCookie(baseUrl, graphqlEndpoint, providedWorkspaceId)
         : method === "3"
-          ? await loginWithToken(graphqlEndpoint)
-          : await loginWithEmail(baseUrl, graphqlEndpoint);
-      result = {
-        ...loginResult,
-        workspaceId: providedWorkspaceId || loginResult.workspaceId,
-      };
+          ? await loginWithToken(graphqlEndpoint, providedWorkspaceId)
+          : await loginWithEmail(baseUrl, graphqlEndpoint, providedWorkspaceId);
+      result = loginResult;
     } else {
       const method = await ask(
         "\nAuth method — [1] Paste session cookie (recommended)  [2] Compatible API token: ",
       );
       const loginResult = method === "2"
-        ? await loginWithToken(graphqlEndpoint)
-        : await loginWithCookie(baseUrl, graphqlEndpoint);
-      result = {
-        ...loginResult,
-        workspaceId: providedWorkspaceId || loginResult.workspaceId,
-      };
+        ? await loginWithToken(graphqlEndpoint, providedWorkspaceId)
+        : await loginWithCookie(baseUrl, graphqlEndpoint, providedWorkspaceId);
+      result = loginResult;
     }
   }
 
@@ -998,7 +1021,7 @@ const COMMANDS: Record<string, CliCommandDefinition> = {
   },
   login: {
     summary: "Interactive login and config bootstrap",
-    usage: "affine-mcp login [--url <url>] [--graphql-path <path>] [--token <token> | --cookie <cookie>] [--workspace-id <id>] [--force]",
+    usage: "affine-mcp login [--url <url>] [--graphql-path <path>] [--token <token> | --cookie-stdin] [--workspace-id <id>] [--force]",
     handler: login,
   },
   status: {

--- a/tests/test-cli-live.mjs
+++ b/tests/test-cli-live.mjs
@@ -5,7 +5,7 @@ import { testResourceName, testTempPath } from './require-destructive-test-safet
  * Live CLI integration test against a running AFFiNE instance.
  *
  * Covers:
- * - login --url --cookie --workspace-id --force
+ * - login --url --cookie-stdin --workspace-id --force
  * - status --json
  * - doctor --json
  * - snippet all --env
@@ -34,10 +34,11 @@ function expect(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function runCli(label, args, xdgConfigHome) {
+function runCli(label, args, xdgConfigHome, input) {
   const result = spawnSync("node", [BIN_ENTRY, ...args], {
     cwd: ROOT,
     encoding: "utf8",
+    input,
     env: {
       ...process.env,
       XDG_CONFIG_HOME: xdgConfigHome,
@@ -119,10 +120,10 @@ try {
   const login = runCli("login", [
     "login",
     "--url", BASE_URL,
-    "--cookie", cookie,
+    "--cookie-stdin",
     "--workspace-id", workspaceId,
     "--force",
-  ], xdgConfigHome);
+  ], xdgConfigHome, `${cookie}\n`);
   expect(login.status === 0, `login failed: ${login.stderr || login.stdout}`);
 
   const configPath = path.join(xdgConfigHome, "affine-mcp", "config");
@@ -150,7 +151,7 @@ try {
   console.log(JSON.stringify({
     ok: true,
     cases: [
-      "login --url --cookie --workspace-id --force",
+      "login --url --cookie-stdin --workspace-id --force",
       "status --json",
       "doctor --json",
       "snippet all --env",

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -457,6 +457,42 @@ try {
     "stdin cookie was not used to authenticate and validate the workspace",
   );
 
+  const configuredUrlHome = path.join(TEMP_ROOT, "configured-url-cookie");
+  writeConfig(configuredUrlHome, {
+    AFFINE_BASE_URL: baseUrl,
+    AFFINE_GRAPHQL_PATH: "/custom/graphql",
+    MCP_TRANSPORT: "stdio",
+  });
+  const configuredUrlLogin = await runNode([
+    DIST_ENTRY,
+    "login",
+    "--cookie-stdin",
+    "--workspace-id",
+    "workspace-env",
+    "--force",
+  ], cleanEnvironment({ XDG_CONFIG_HOME: configuredUrlHome }), {
+    input: `${cookieFromStdin}\n`,
+  });
+  expect(
+    configuredUrlLogin.code === 0,
+    `piped cookie was consumed by a URL prompt: ${configuredUrlLogin.stderr}`,
+  );
+  expect(
+    configuredUrlLogin.stderr.includes("Verified workspace: workspace-env"),
+    "non-TTY cookie login did not use the configured URL before validating the workspace",
+  );
+
+  const missingForce = await runNode([
+    DIST_ENTRY,
+    "login",
+    "--cookie-stdin",
+  ], savedOnlyEnv);
+  expect(missingForce.code !== 0, "piped cookie login prompted before requiring overwrite confirmation");
+  expect(
+    missingForce.stderr.includes("--force is required"),
+    `non-TTY overwrite failure was unclear: ${missingForce.stderr}`,
+  );
+
   const rejectedWorkspaceHome = path.join(TEMP_ROOT, "rejected-workspace");
   const rejectedWorkspace = await runNode([
     DIST_ENTRY,
@@ -615,6 +651,7 @@ try {
       "POSIX-safe Codex snippet quoting",
       "login and logout setting preservation",
       "stdin cookie authentication",
+      "non-TTY cookie prompt isolation",
       "workspace override validation",
       "legacy cookie argument redaction",
       "header-only credential logout",

--- a/tests/test-config-cli-consistency.mjs
+++ b/tests/test-config-cli-consistency.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -26,13 +26,15 @@ function cleanEnvironment(extra = {}) {
   return { ...environment, ...extra };
 }
 
-function runNode(args, env, timeoutMs = 10_000) {
+function runNode(args, env, options = {}) {
+  const { input = "", timeoutMs = 10_000 } = options;
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, args, {
       cwd: ROOT,
       env,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
+    child.stdin.end(input);
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (chunk) => { stdout += chunk; });
@@ -430,6 +432,7 @@ try {
   );
 
   const savedOnlyEnv = cleanEnvironment({ XDG_CONFIG_HOME: savedConfigHome });
+  const cookieFromStdin = "affine_session=stdin-cookie-value";
   const login = await runNode([
     DIST_ENTRY,
     "login",
@@ -437,22 +440,64 @@ try {
     baseUrl,
     "--graphql-path",
     "/custom/graphql",
-    "--token",
-    "replacement-token",
+    "--cookie-stdin",
     "--workspace-id",
-    "workspace-login",
+    "workspace-env",
     "--force",
-  ], savedOnlyEnv);
+  ], savedOnlyEnv, { input: `${cookieFromStdin}\n` });
   expect(login.code === 0, `non-interactive login failed: ${login.stderr}`);
   const configAfterLogin = readFileSync(path.join(savedConfigHome, "affine-mcp", "config"), "utf8");
   expect(configAfterLogin.includes("MCP_TRANSPORT=stdio"), "login erased a saved runtime setting");
   expect(configAfterLogin.includes("PORT=3001"), "login erased the saved HTTP port");
   expect(configAfterLogin.includes("AFFINE_GRAPHQL_PATH=/custom/graphql"), "login did not save the GraphQL path");
+  expect(configAfterLogin.includes(`AFFINE_COOKIE=${cookieFromStdin}`), "login did not save the stdin cookie");
+  expect(configAfterLogin.includes("AFFINE_WORKSPACE_ID=workspace-env"), "login did not save the validated workspace");
+  expect(
+    graphqlRequests.some((entry) => entry.cookie === cookieFromStdin),
+    "stdin cookie was not used to authenticate and validate the workspace",
+  );
+
+  const rejectedWorkspaceHome = path.join(TEMP_ROOT, "rejected-workspace");
+  const rejectedWorkspace = await runNode([
+    DIST_ENTRY,
+    "login",
+    "--url",
+    baseUrl,
+    "--graphql-path",
+    "/custom/graphql",
+    "--cookie-stdin",
+    "--workspace-id",
+    "workspace-unavailable",
+    "--force",
+  ], cleanEnvironment({ XDG_CONFIG_HOME: rejectedWorkspaceHome }), {
+    input: `${cookieFromStdin}\n`,
+  });
+  expect(rejectedWorkspace.code !== 0, "login accepted a workspace outside the authenticated account");
+  expect(
+    rejectedWorkspace.stderr.includes("Workspace 'workspace-unavailable' is not available"),
+    `invalid workspace failure was unclear: ${rejectedWorkspace.stderr}`,
+  );
+  expect(
+    !existsSync(path.join(rejectedWorkspaceHome, "affine-mcp", "config")),
+    "login saved config after workspace validation failed",
+  );
+
+  const legacyCookieSecret = "affine_session=must-not-appear-in-errors";
+  const legacyCookie = await runNode([
+    DIST_ENTRY,
+    "login",
+    "--cookie",
+    legacyCookieSecret,
+  ], cleanEnvironment({ XDG_CONFIG_HOME: path.join(TEMP_ROOT, "legacy-cookie") }));
+  expect(legacyCookie.code !== 0, "login accepted a cookie in process arguments");
+  expect(legacyCookie.stderr.includes("--cookie-stdin"), "legacy cookie error did not explain the safe replacement");
+  expect(!legacyCookie.stderr.includes(legacyCookieSecret), "legacy cookie secret leaked to stderr");
+  expect(!legacyCookie.stdout.includes(legacyCookieSecret), "legacy cookie secret leaked to stdout");
 
   const logout = await runNode([DIST_ENTRY, "logout"], savedOnlyEnv);
   expect(logout.code === 0, `logout failed: ${logout.stderr}`);
   const configAfterLogout = readFileSync(path.join(savedConfigHome, "affine-mcp", "config"), "utf8");
-  expect(!configAfterLogout.includes("AFFINE_API_TOKEN="), "logout left the saved API token behind");
+  expect(!configAfterLogout.includes("AFFINE_COOKIE="), "logout left the saved session cookie behind");
   expect(configAfterLogout.includes("MCP_TRANSPORT=stdio"), "logout erased a saved runtime setting");
 
   const headerOnlyConfigHome = path.join(TEMP_ROOT, "header-only-auth");
@@ -569,6 +614,9 @@ try {
       "snippet propagation",
       "POSIX-safe Codex snippet quoting",
       "login and logout setting preservation",
+      "stdin cookie authentication",
+      "workspace override validation",
+      "legacy cookie argument redaction",
       "header-only credential logout",
       "strict transport validation",
       "saved HTTP runtime flags",


### PR DESCRIPTION
## Summary

- replace `affine-mcp login --cookie <value>` with `--cookie-stdin` so browser session cookies do not appear in process arguments or shell history
- reject the legacy cookie argument before unexpected-argument reporting can echo its value
- validate every explicit `--workspace-id` against the authenticated account before saving configuration
- apply the same workspace validation to token, cookie, and email/password login paths
- document the safe stdin workflow and update live CLI coverage

## Context

The session-cookie login capability proposed in #252 is already present on `develop`. This focused follow-up preserves credit to @oersted for identifying the remaining safety gaps while avoiding changes to the contributor's `develop` branch. It supersedes #252 for the still-relevant credential-input and workspace-validation fixes.

## Validation

Validated with the supported Node.js 24 runtime:

- `npm run ci` (27/27 fast tests plus metadata, documentation, and package checks)
- `npm audit --audit-level=high` (0 vulnerabilities)
- actual tarball install, CLI/version/help, and 92-tool MCP surface smoke test
- Docker build, runtime version, and non-root UID smoke test
- `npm run test:comprehensive` (15/15 integration scenarios and 107/107 MCP regression checks)
- `npm run test:e2e` (21/21 integration tests, including live stdin-cookie login, and 14/14 Playwright tests)
- `git diff --check`
- repository-wide Hangul scan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added secure cookie-based login through hidden standard input, preventing cookies from appearing in command history or process arguments.
  * Legacy command-line cookie arguments are rejected.

* **Bug Fixes**
  * Workspace selection now verifies access before saving configuration.
  * Improved fallback behavior when workspace listing is unavailable.

* **Documentation**
  * Added setup guidance for scripted login, workspace selection, secure secret input, and configuration options.

* **Tests**
  * Expanded CLI coverage for secure login, workspace validation, rejected legacy options, and logout cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->