### PR TITLE
chore: sync v3.2.1 release to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.1] - 2026-08-06
+
 ### Security
 - Replaced the `affine-mcp login --cookie <value>` process-argument path with `--cookie-stdin` so browser session cookies do not appear in shell history or process listings.
 
@@ -656,6 +658,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.2.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.1
 [3.2.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.0
 [3.1.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.1.0
 [3.0.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.0.1
@@ -687,4 +690,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.1...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.2.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)
@@ -49,7 +49,7 @@ Scope boundaries:
 - AFFiNE 0.27+ removed the legacy personal-access-token GraphQL API; this server no longer exposes token-management tools
 - AFFiNE Cloud requires browser-session authentication for this external GraphQL integration; programmatic email/password sign-in is blocked by Cloudflare
 
-> New in v3.2.0: All 92 tools now declare MCP output schemas for structured-result validation and safer follow-up calls, with refreshed security dependencies and deterministic release validation.
+> New in v3.2.1: Scripted cookie login now keeps session secrets out of process arguments, validates workspace access before saving credentials, and restores document pagination for ordinary workspace members.
 
 ## Choose Your Path
 | Goal | Start here |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,42 @@
 # Release Notes
 
+## Version 3.2.1 (2026-08-06)
+
+### Highlights
+- Scripted session-cookie login now reads secrets from stdin instead of exposing them in shell history or process listings.
+- Explicit workspace selections are verified against the authenticated account before the CLI saves them.
+- Ordinary workspace members can paginate documents even when AFFiNE denies access to the primary GraphQL document connection.
+
+### Security Migration
+- `affine-mcp login --cookie <value>` is no longer accepted. Automation must pass the cookie through `--cookie-stdin` instead.
+- Existing saved cookie configurations and interactive login remain compatible; only command-line cookie ingestion changed.
+- Piped cookie input requires `--force` when it replaces existing credentials, preventing an overwrite prompt from consuming the secret.
+
+### What Changed
+- CLI authentication
+  - Added `--cookie-stdin` for hidden or piped session-cookie input.
+  - Rejects legacy `--cookie` and `--cookie=<value>` arguments without echoing their values.
+  - Validates `--workspace-id` for cookie, compatible-token, and email/password login paths.
+- Document discovery
+  - Falls back to bounded workspace metadata pagination when ordinary members cannot query the primary document connection.
+  - Preserves workspace-scoped cursors, pagination bounds, and acknowledged-deletion filtering in fallback results.
+- Regression coverage
+  - Covers legacy-cookie redaction, non-TTY stdin isolation, overwrite protection, inaccessible workspace rejection, and deletion-aware fallback pagination.
+
+### Compatibility
+- The canonical MCP tool surface remains at 92 tools with no input or output contract removals.
+- Scripts that passed a cookie in `--cookie` must migrate to `--cookie-stdin`.
+- Existing saved credentials, interactive login, and Node.js 20-or-newer support remain unchanged.
+
+### Validation Evidence
+- Node.js 20 and 24: clean `npm ci && npm run ci`
+- `npm audit --audit-level=low` (zero vulnerabilities)
+- `AFFINE_REVISION=0.27.3 npm run test:comprehensive` (15/15 focused tests; 107/107 regression checks)
+- `AFFINE_REVISION=0.27.3 npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
+- Packed-tarball smoke on Node.js 20 and 24
+- `npm publish --dry-run --access public --ignore-scripts`
+- Linux/amd64 Docker build and non-root runtime smoke
+
 ## Version 3.2.0 (2026-08-04)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -4426,7 +4426,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             id: page.id,
             title: page.title,
             createdAt: page.createDate,
-            updatedAt: page.updatedDate,
+            updatedAt: page.updatedDate ?? page.createDate,
             tags: tagsByDocId.get(page.id) || [],
             inTrash: inTrashByDocId.get(page.id) ?? page.inTrash,
           })),
@@ -4492,7 +4492,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "list_docs",
     {
       title: "List Documents",
-      description: "List documents in a workspace (GraphQL), falling back to bounded workspace metadata when GraphQL document access is denied. Each doc includes an inTrash flag; fallback summary, public, and defaultRole values are null.",
+      description: "List documents in a workspace (GraphQL), falling back to bounded workspace metadata when GraphQL document access is denied. Each doc includes an inTrash flag; fallback summary, public, and defaultRole values are null. GraphQL and fallback cursors are not interchangeable; restart pagination without after if a cursor is rejected.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         first: PageSize.optional(),

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0",
+  "version": "3.2.1",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- Sync the published v3.2.1 release commit from `main` back to `develop`.
- Carry the release metadata and the reviewed `list_docs` fallback consistency fix.
- Keep the development line aligned with the annotated v3.2.1 tag.

## Published release

- Release PR: #281
- Main merge: `16c745c36af839fc0c81576c6b871df24a503f9e`
- Annotated tag: `v3.2.1`
- GitHub Release: https://github.com/DAWNCR0W/affine-mcp-server/releases/tag/v3.2.1
- npm: `affine-mcp-server@3.2.1` (`latest`)
- Publish workflow: https://github.com/DAWNCR0W/affine-mcp-server/actions/runs/31067307578

## Scope

The diff against `develop` is limited to seven files: six release metadata files plus `src/tools/docs.ts`, which contains the release-review fix for fallback timestamps and cursor guidance.

## Validation

- Node.js 20.20.2: clean `npm ci && npm run ci`
- Node.js 24.18.0: clean `npm ci && npm run ci`
- `npm audit --audit-level=low` (zero vulnerabilities)
- `AFFINE_REVISION=0.27.3 npm run test:comprehensive` (15/15 focused; 107/107 regression)
- `AFFINE_REVISION=0.27.3 npm run test:e2e` (21/21 integration; 14/14 Playwright)
- Packed-tarball smoke on Node.js 20 and 24
- `npm publish --dry-run --access public --ignore-scripts`
- Linux/amd64 Docker build and non-root runtime smoke