### PR TITLE
Fix/json schema 2020 12 dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
+
 ## [3.2.1] - 2026-08-06
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Node.js 20 is the minimum supported runtime. CI validates the minimum runtime an
 
 Every canonical tool also declares an MCP `outputSchema` for its `structuredContent`. Object results retain their existing top-level fields, while array and scalar results use stable `{ items }`, `{ text }`, or `{ value }` envelopes. The existing text `content` remains unchanged for compatibility with clients that do not consume structured results.
 
+Advertised input and output schemas carry no `$schema` keyword, so they are read as JSON Schema 2020-12. Clients that validate 2020-12 only reject any schema that declares an older dialect.
+
 Domains:
 
 - Workspace: create, inspect, update, delete, and traverse workspaces

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { startHttpMcpServer } from "./sse.js";
 import { existsSync } from "fs";
 import { createToolFilter, toolAnnotationsFor } from "./toolSurface.js";
 import { toolOutputSchemaFor } from "./toolOutputSchemas.js";
+import { stripSchemaDialect } from "./util/mcp.js";
 import {
   assertOAuthServiceWritePolicy,
   createToolFilterEnvironment,
@@ -210,6 +211,7 @@ async function buildServer() {
   }
   registerBlobTools(server, gql);
   registerNotificationTools(server, gql);
+  stripSchemaDialect(server);
   return server;
 }
 

--- a/src/util/mcp.ts
+++ b/src/util/mcp.ts
@@ -35,6 +35,34 @@ export function text(data: unknown) {
   };
 }
 
+/**
+ * The MCP SDK converts Zod v3 schemas with zod-to-json-schema, which stamps every
+ * advertised tool schema with `"$schema": "http://json-schema.org/draft-07/schema#"`.
+ * Clients that validate 2020-12 only (Claude) reject those tools outright. Without a
+ * `$schema` the dialect defaults to 2020-12, which these object schemas already satisfy.
+ */
+export function stripSchemaDialect(server: { server?: unknown }): void {
+  const handlers = (server.server as { _requestHandlers?: Map<string, Function> } | undefined)?._requestHandlers;
+  if (!(handlers instanceof Map)) {
+    throw new Error(
+      "[affine-mcp] Server request handlers not found - the advertised JSON Schema dialect cannot be " +
+      "normalized. The MCP SDK API may have changed. Refusing to start because clients that support " +
+      "JSON Schema 2020-12 only would reject every tool.",
+    );
+  }
+  // No handler until the first tool is registered; a fully filtered surface has nothing to fix.
+  const listTools = handlers.get("tools/list");
+  if (!listTools) return;
+  handlers.set("tools/list", async (...args: unknown[]) => {
+    const result = await listTools(...args);
+    for (const tool of (result as { tools?: Array<Record<string, any>> })?.tools ?? []) {
+      delete tool.inputSchema?.$schema;
+      delete tool.outputSchema?.$schema;
+    }
+    return result;
+  });
+}
+
 export type ToolErrorOptions = {
   code?: string;
   retryable?: boolean;

--- a/tests/test-output-schemas.mjs
+++ b/tests/test-output-schemas.mjs
@@ -8,7 +8,7 @@ import { ALL_TOOLS } from "../src/toolSurface.ts";
 import { registerBlobTools } from "../src/tools/blobStorage.ts";
 import { registerDocTools } from "../src/tools/docs.ts";
 import { TOOLS_WITH_ERROR_OUTPUT, toolOutputSchemaFor } from "../src/toolOutputSchemas.ts";
-import { text } from "../src/util/mcp.ts";
+import { stripSchemaDialect, text } from "../src/util/mcp.ts";
 
 function installOutputSchemaRegistration(server) {
   const registerTool = server.registerTool.bind(server);
@@ -140,12 +140,16 @@ const gql = {
   },
 };
 registerBlobTools(server, gql);
+stripSchemaDialect(server);
 
 const client = await connectInMemory(server, "output-schema-test");
 
 const listed = await client.listTools();
 for (const tool of listed.tools) {
   assert.equal(tool.outputSchema?.type, "object", `${tool.name} did not advertise an object output schema`);
+  // Clients that only support JSON Schema 2020-12 reject any declared dialect.
+  assert.equal(tool.inputSchema.$schema, undefined, `${tool.name} advertised a JSON Schema dialect on its input schema`);
+  assert.equal(tool.outputSchema.$schema, undefined, `${tool.name} advertised a JSON Schema dialect on its output schema`);
 }
 const listedByName = Object.fromEntries(listed.tools.map(tool => [tool.name, tool]));
 assert.equal(listedByName.upload_blob.outputSchema.properties.encoding.type, "string");


### PR DESCRIPTION
Summary
MCP clients that implement JSON Schema 2020-12 only — Claude among them — reject every tool in this server with Tool has an invalid outputSchema: JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#"). The SDK converts Zod v3 schemas with zod-to-json-schema, which stamps the draft-07 dialect onto every advertised input and output schema. This strips the keyword at the tools/list boundary so the dialect defaults to 2020-12.

Zod v4 is not an alternative: mcp.js calls toJsonSchemaCompat without a target, so that branch also emits draft-7.

Changes
stripSchemaDialect() in src/util/mcp.ts wraps the SDK's tools/list handler and removes $schema from every advertised input and output schema. The SDK exposes no public wrap point, so the internals access throws if the handler map ever disappears, matching the existing registerTool guard in index.ts rather than silently letting the bug back in.
Called once in buildServer(), covering stdio, streamable HTTP, and SSE.
Regression in tests/test-output-schemas.mjs asserting no tool advertises a dialect.
README note that advertised schemas are read as 2020-12.
Validation

npm run build              # pass
npm run test:tool-manifest # pass
npm run test:docs          # pass
npm run test:pr-route-policy # pass
npm run test:output-schemas  # pass, 92 tools
Also verified end-to-end against a built container image: initialize → tools/list over streamable HTTP returns 92 tools, none carrying $schema.

Backward compatibility
No client regresses. Absent $schema, a 2020-12 validator applies its default dialect and a draft-07 validator falls back to its own — and all 91 registered schemas were audited for keywords whose meaning differs between the two (tuple-form items, additionalItems, dependencies, $ref/definitions, $recursive*); none are used. The declared field contract is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool input and output schemas now omit the `$schema` keyword and are interpreted as JSON Schema 2020-12.
  * Improved compatibility with clients that only support the JSON Schema 2020-12 dialect.

* **Documentation**
  * Updated the changelog and README to describe the schema format and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->