### PR TITLE
fix: probe IPv4 loopback in the container healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The container `HEALTHCHECK` now probes `127.0.0.1` instead of `localhost`, which can resolve to `::1` while the server listens on IPv4 only.
+
 ## [3.2.1] - 2026-08-06
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ ENV MCP_TRANSPORT=http \
     PORT=3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO- http://localhost:${PORT}/healthz || exit 1
+    CMD wget -qO- http://127.0.0.1:${PORT}/healthz || exit 1
 
 ENTRYPOINT ["node", "bin/affine-mcp"]


### PR DESCRIPTION
Summary
The container HEALTHCHECK probes http://localhost:${PORT}/healthz. On hosts where localhost resolves to ::1 first, the probe never reaches the server, which binds IPv4 0.0.0.0 by default — so a fully working container is reported unhealthy and platforms that gate on health (Dokploy, Swarm, Compose depends_on: service_healthy) refuse to route to it or restart it in a loop. Switching the probe to 127.0.0.1 removes the resolution ambiguity.

Changes
Dockerfile: HEALTHCHECK now requests http://127.0.0.1:${PORT}/healthz instead of http://localhost:${PORT}/healthz.
Validation

npm run build                # pass
npm run test:tool-manifest   # pass
npm run test:docs            # pass
npm run test:pr-route-policy # pass
Built the image and ran it with the HTTP transport: docker inspect --format '{{.State.Health.Status}}' reports healthy, and /healthz answers HTTP 200 from outside the container.

Backward compatibility
None affected. The probe is internal to the container and the endpoint is unchanged; 127.0.0.1 is reachable in every network mode where localhost was, including host and bridge networking. Only a deployment that overrode AFFINE_MCP_HTTP_HOST to an IPv6-only bind would be affected, and that configuration fails the current healthcheck as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container health checks for IPv4-only servers by probing `127.0.0.1` instead of `localhost`.

* **Documentation**
  * Added an unreleased changelog entry describing the health check correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->