### PR TITLE
Release v3.2.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,7 @@ jobs:
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
+
 ## [3.2.1] - 2026-08-06
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-08-18
+
 ### Fixed
 - The container `HEALTHCHECK` now probes `127.0.0.1` instead of `localhost`, which can resolve to `::1` while the server listens on IPv4 only.
 - Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
+
+### Dependencies
+- Raised `undici` from `^6.28.0` to `^7.29.0` and refreshed the locked `jose` and `yjs` releases.
+- Refreshed the locked Node.js types, `tsx`, Playwright, and Docker login action releases.
 
 ## [3.2.1] - 2026-08-06
 
@@ -662,6 +668,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.2.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.2
 [3.2.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.1
 [3.2.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.0
 [3.1.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.1.0
@@ -694,4 +701,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.1...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
 
 ### Dependencies
-- Raised `undici` from `^6.28.0` to `^7.29.0` and refreshed the locked `jose` and `yjs` releases.
+- Raised `undici` from `^6.28.0` to `^7.29.0`, raised the supported Node.js floor to 20.18.1, and refreshed the locked `jose` and `yjs` releases.
 - Refreshed the locked Node.js types, `tsx`, Playwright, and Docker login action releases.
 
 ## [3.2.1] - 2026-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The container `HEALTHCHECK` now probes `127.0.0.1` instead of `localhost`, which can resolve to `::1` while the server listens on IPv4 only.
+
 ## [3.2.1] - 2026-08-06
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ ENV MCP_TRANSPORT=http \
     PORT=3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO- http://localhost:${PORT}/healthz || exit 1
+    CMD wget -qO- http://127.0.0.1:${PORT}/healthz || exit 1
 
 ENTRYPOINT ["node", "bin/affine-mcp"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.2.2-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If you want to expose the server remotely over HTTP instead of stdio, start with
 
 ## Compatibility Matrix
 
-Node.js 20 is the minimum supported runtime. CI validates the minimum runtime and the current Node.js release used by the npm publish workflow.
+Node.js 20.18.1 is the minimum supported runtime. CI validates the Node.js 20 and 24 release lines.
 
 | Target | Transport | Recommended auth | Recommended path |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Node.js 20 is the minimum supported runtime. CI validates the minimum runtime an
 
 Every canonical tool also declares an MCP `outputSchema` for its `structuredContent`. Object results retain their existing top-level fields, while array and scalar results use stable `{ items }`, `{ text }`, or `{ value }` envelopes. The existing text `content` remains unchanged for compatibility with clients that do not consume structured results.
 
+Advertised input and output schemas carry no `$schema` keyword, so they are read as JSON Schema 2020-12. Clients that validate 2020-12 only reject any schema that declares an older dialect.
+
 Domains:
 
 - Workspace: create, inspect, update, delete, and traverse workspaces

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Node.js 20.18.1 is the minimum supported runtime. CI validates the Node.js 20 an
 
 Every canonical tool also declares an MCP `outputSchema` for its `structuredContent`. Object results retain their existing top-level fields, while array and scalar results use stable `{ items }`, `{ text }`, or `{ value }` envelopes. The existing text `content` remains unchanged for compatibility with clients that do not consume structured results.
 
-Advertised input and output schemas carry no `$schema` keyword, so they are read as JSON Schema 2020-12. Clients that validate 2020-12 only reject any schema that declares an older dialect.
+Advertised input and output schemas omit the SDK-generated draft-07 `$schema` marker. Schema interpretation follows the client context, allowing clients that reject an explicit draft-07 declaration to consume the tool surface.
 
 Domains:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## Version 3.2.2 (2026-08-18)
+
+### Highlights
+- Tool discovery now works with clients that accept JSON Schema 2020-12 but reject schemas declaring the draft-07 dialect.
+- Container health checks now use IPv4 loopback, avoiding false unhealthy states when `localhost` resolves to IPv6.
+- Runtime, development, browser-test, and container-publish dependencies were refreshed.
+
+### What Changed
+- MCP schema compatibility
+  - Removes the SDK-injected draft-07 `$schema` marker from advertised input and output schemas.
+  - Preserves the existing tool names, parameters, output structures, and 92-tool canonical surface.
+  - Fails closed at startup if an incompatible MCP SDK change prevents schema normalization.
+- Container reliability
+  - Probes `127.0.0.1` in the Docker `HEALTHCHECK`, matching the server's IPv4 listener.
+- Dependencies
+  - Raised `undici` from `^6.28.0` to `^7.29.0`.
+  - Refreshed locked `jose`, `yjs`, Node.js types, `tsx`, and Playwright releases.
+  - Updated the Docker login action from `4.5.2` to `4.6.0`.
+
+### Compatibility
+- No tools were added or removed, and no existing input or output contract changed.
+- Node.js 20 or newer remains required.
+- Docker deployments keep the same HTTP port and health endpoint.
+
+### Validation Evidence
+- Node.js 20.20.2 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
+- `npm audit --audit-level=low` (zero vulnerabilities)
+- Node.js 20.20.2: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
+- Packed-tarball install, CLI, and 92-tool discovery smoke
+- `npm publish --dry-run --access public --ignore-scripts`
+- Linux/amd64 Docker build, version check, non-root UID check, and IPv4 healthcheck smoke
+
 ## Version 3.2.1 (2026-08-06)
 
 ### Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,13 +21,13 @@
 
 ### Compatibility
 - No tools were added or removed, and no existing input or output contract changed.
-- Node.js 20 or newer remains required.
+- Node.js 20.18.1 or newer is required.
 - Docker deployments keep the same HTTP port and health endpoint.
 
 ### Validation Evidence
-- Node.js 20.20.2 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
+- Node.js 20.18.1 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
 - `npm audit --audit-level=low` (zero vulnerabilities)
-- Node.js 20.20.2: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
+- Node.js 20.18.1: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
 - Packed-tarball install, CLI, and 92-tool discovery smoke
 - `npm publish --dry-run --access public --ignore-scripts`
 - Linux/amd64 Docker build, version check, non-root UID check, and IPv4 healthcheck smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "markdown-it": "^14.1.0",
         "node-fetch": "^3.3.2",
         "socket.io-client": "^4.8.1",
-        "undici": "^6.28.0",
+        "undici": "^7.29.0",
         "yjs": "^13.6.27",
         "zod": "^3.23.8"
       },
@@ -2581,12 +2581,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,9 +643,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,13 +533,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2161,13 +2161,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2180,9 +2180,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.31",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
-      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "version": "13.6.32",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
+      "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.99"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "markdown-it": "^14.1.0",
     "node-fetch": "^3.3.2",
     "socket.io-client": "^4.8.1",
-    "undici": "^6.28.0",
+    "undici": "^7.29.0",
     "yjs": "^13.6.27",
     "zod": "^3.23.8"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { startHttpMcpServer } from "./sse.js";
 import { existsSync } from "fs";
 import { createToolFilter, toolAnnotationsFor } from "./toolSurface.js";
 import { toolOutputSchemaFor } from "./toolOutputSchemas.js";
+import { stripSchemaDialect } from "./util/mcp.js";
 import {
   assertOAuthServiceWritePolicy,
   createToolFilterEnvironment,
@@ -210,6 +211,7 @@ async function buildServer() {
   }
   registerBlobTools(server, gql);
   registerNotificationTools(server, gql);
+  stripSchemaDialect(server);
   return server;
 }
 

--- a/src/util/mcp.ts
+++ b/src/util/mcp.ts
@@ -35,6 +35,34 @@ export function text(data: unknown) {
   };
 }
 
+/**
+ * The MCP SDK converts Zod v3 schemas with zod-to-json-schema, which stamps every
+ * advertised tool schema with `"$schema": "http://json-schema.org/draft-07/schema#"`.
+ * Clients that validate 2020-12 only (Claude) reject those tools outright. Without a
+ * `$schema` the dialect defaults to 2020-12, which these object schemas already satisfy.
+ */
+export function stripSchemaDialect(server: { server?: unknown }): void {
+  const handlers = (server.server as { _requestHandlers?: Map<string, Function> } | undefined)?._requestHandlers;
+  if (!(handlers instanceof Map)) {
+    throw new Error(
+      "[affine-mcp] Server request handlers not found - the advertised JSON Schema dialect cannot be " +
+      "normalized. The MCP SDK API may have changed. Refusing to start because clients that support " +
+      "JSON Schema 2020-12 only would reject every tool.",
+    );
+  }
+  // No handler until the first tool is registered; a fully filtered surface has nothing to fix.
+  const listTools = handlers.get("tools/list");
+  if (!listTools) return;
+  handlers.set("tools/list", async (...args: unknown[]) => {
+    const result = await listTools(...args);
+    for (const tool of (result as { tools?: Array<Record<string, any>> })?.tools ?? []) {
+      delete tool.inputSchema?.$schema;
+      delete tool.outputSchema?.$schema;
+    }
+    return result;
+  });
+}
+
 export type ToolErrorOptions = {
   code?: string;
   retryable?: boolean;

--- a/src/util/mcp.ts
+++ b/src/util/mcp.ts
@@ -38,8 +38,8 @@ export function text(data: unknown) {
 /**
  * The MCP SDK converts Zod v3 schemas with zod-to-json-schema, which stamps every
  * advertised tool schema with `"$schema": "http://json-schema.org/draft-07/schema#"`.
- * Clients that validate 2020-12 only (Claude) reject those tools outright. Without a
- * `$schema` the dialect defaults to 2020-12, which these object schemas already satisfy.
+ * Clients that reject an explicitly declared draft-07 dialect cannot discover those tools.
+ * Removing the marker leaves schema interpretation to the client context.
  */
 export function stripSchemaDialect(server: { server?: unknown }): void {
   const handlers = (server.server as { _requestHandlers?: Map<string, Function> } | undefined)?._requestHandlers;

--- a/tests/test-output-schemas.mjs
+++ b/tests/test-output-schemas.mjs
@@ -8,7 +8,7 @@ import { ALL_TOOLS } from "../src/toolSurface.ts";
 import { registerBlobTools } from "../src/tools/blobStorage.ts";
 import { registerDocTools } from "../src/tools/docs.ts";
 import { TOOLS_WITH_ERROR_OUTPUT, toolOutputSchemaFor } from "../src/toolOutputSchemas.ts";
-import { text } from "../src/util/mcp.ts";
+import { stripSchemaDialect, text } from "../src/util/mcp.ts";
 
 function installOutputSchemaRegistration(server) {
   const registerTool = server.registerTool.bind(server);
@@ -140,12 +140,16 @@ const gql = {
   },
 };
 registerBlobTools(server, gql);
+stripSchemaDialect(server);
 
 const client = await connectInMemory(server, "output-schema-test");
 
 const listed = await client.listTools();
 for (const tool of listed.tools) {
   assert.equal(tool.outputSchema?.type, "object", `${tool.name} did not advertise an object output schema`);
+  // Clients that only support JSON Schema 2020-12 reject any declared dialect.
+  assert.equal(tool.inputSchema.$schema, undefined, `${tool.name} advertised a JSON Schema dialect on its input schema`);
+  assert.equal(tool.outputSchema.$schema, undefined, `${tool.name} advertised a JSON Schema dialect on its output schema`);
 }
 const listedByName = Object.fromEntries(listed.tools.map(tool => [tool.name, tool]));
 assert.equal(listedByName.upload_blob.outputSchema.properties.encoding.type, "string");

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.1",
+  "version": "3.2.2",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- release MCP schema compatibility fixes for clients that reject an explicit draft-07 declaration
- use IPv4 loopback for the container healthcheck
- refresh runtime, development, browser-test, and container-publish dependencies
- synchronize package, manifest, README, changelog, and release-note metadata for v3.2.2

## Impact

- preserves the 92-tool surface and existing runtime result shapes
- removes SDK-generated draft-07 markers while leaving schema interpretation to the client context
- avoids false unhealthy container states when localhost resolves to IPv6
- raises the minimum supported Node.js version to 20.18.1 to match undici 7.29.0

## Validation

- Node.js 20.18.1 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
- `npm audit --audit-level=low` (zero vulnerabilities)
- Node.js 20.18.1: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
- packed-tarball install, CLI, and 92-tool discovery smoke
- `npm publish --dry-run --access public --ignore-scripts`
- Linux/amd64 Docker build, version check, non-root UID check, and IPv4 healthcheck smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MCP tool schema compatibility by removing unsupported dialect markers from advertised input and output schemas.
  * Preserved the existing tool set and client compatibility.

* **Bug Fixes**
  * Docker health checks now use the IPv4 loopback address for more reliable status detection.

* **Documentation**
  * Added Version 3.2.2 release notes and updated version and schema behavior documentation.

* **Chores**
  * Raised the minimum Node.js version requirement to 20.18.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->