### PR TITLE
chore: sync v3.2.2 release metadata to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-08-18
+
 ### Fixed
 - The container `HEALTHCHECK` now probes `127.0.0.1` instead of `localhost`, which can resolve to `::1` while the server listens on IPv4 only.
 - Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
+
+### Dependencies
+- Raised `undici` from `^6.28.0` to `^7.29.0` and refreshed the locked `jose` and `yjs` releases.
+- Refreshed the locked Node.js types, `tsx`, Playwright, and Docker login action releases.
 
 ## [3.2.1] - 2026-08-06
 
@@ -662,6 +668,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.2.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.2
 [3.2.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.1
 [3.2.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.0
 [3.1.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.1.0
@@ -694,4 +701,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.1...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.2.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool schemas are no longer advertised with the draft-07 JSON Schema dialect. The MCP SDK stamps `"$schema": "http://json-schema.org/draft-07/schema#"` onto every schema converted from Zod v3, which made clients that support JSON Schema 2020-12 only (Claude) reject every tool with `Tool has an invalid outputSchema`.
 
 ### Dependencies
-- Raised `undici` from `^6.28.0` to `^7.29.0` and refreshed the locked `jose` and `yjs` releases.
+- Raised `undici` from `^6.28.0` to `^7.29.0`, raised the supported Node.js floor to 20.18.1, and refreshed the locked `jose` and `yjs` releases.
 - Refreshed the locked Node.js types, `tsx`, Playwright, and Docker login action releases.
 
 ## [3.2.1] - 2026-08-06

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.2.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.2.2-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If you want to expose the server remotely over HTTP instead of stdio, start with
 
 ## Compatibility Matrix
 
-Node.js 20 is the minimum supported runtime. CI validates the minimum runtime and the current Node.js release used by the npm publish workflow.
+Node.js 20.18.1 is the minimum supported runtime. CI validates the Node.js 20 and 24 release lines.
 
 | Target | Transport | Recommended auth | Recommended path |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Node.js 20.18.1 is the minimum supported runtime. CI validates the Node.js 20 an
 
 Every canonical tool also declares an MCP `outputSchema` for its `structuredContent`. Object results retain their existing top-level fields, while array and scalar results use stable `{ items }`, `{ text }`, or `{ value }` envelopes. The existing text `content` remains unchanged for compatibility with clients that do not consume structured results.
 
-Advertised input and output schemas carry no `$schema` keyword, so they are read as JSON Schema 2020-12. Clients that validate 2020-12 only reject any schema that declares an older dialect.
+Advertised input and output schemas omit the SDK-generated draft-07 `$schema` marker. Schema interpretation follows the client context, allowing clients that reject an explicit draft-07 declaration to consume the tool surface.
 
 Domains:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## Version 3.2.2 (2026-08-18)
+
+### Highlights
+- Tool discovery now works with clients that accept JSON Schema 2020-12 but reject schemas declaring the draft-07 dialect.
+- Container health checks now use IPv4 loopback, avoiding false unhealthy states when `localhost` resolves to IPv6.
+- Runtime, development, browser-test, and container-publish dependencies were refreshed.
+
+### What Changed
+- MCP schema compatibility
+  - Removes the SDK-injected draft-07 `$schema` marker from advertised input and output schemas.
+  - Preserves the existing tool names, parameters, output structures, and 92-tool canonical surface.
+  - Fails closed at startup if an incompatible MCP SDK change prevents schema normalization.
+- Container reliability
+  - Probes `127.0.0.1` in the Docker `HEALTHCHECK`, matching the server's IPv4 listener.
+- Dependencies
+  - Raised `undici` from `^6.28.0` to `^7.29.0`.
+  - Refreshed locked `jose`, `yjs`, Node.js types, `tsx`, and Playwright releases.
+  - Updated the Docker login action from `4.5.2` to `4.6.0`.
+
+### Compatibility
+- No tools were added or removed, and no existing input or output contract changed.
+- Node.js 20 or newer remains required.
+- Docker deployments keep the same HTTP port and health endpoint.
+
+### Validation Evidence
+- Node.js 20.20.2 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
+- `npm audit --audit-level=low` (zero vulnerabilities)
+- Node.js 20.20.2: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
+- Packed-tarball install, CLI, and 92-tool discovery smoke
+- `npm publish --dry-run --access public --ignore-scripts`
+- Linux/amd64 Docker build, version check, non-root UID check, and IPv4 healthcheck smoke
+
 ## Version 3.2.1 (2026-08-06)
 
 ### Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,13 +21,13 @@
 
 ### Compatibility
 - No tools were added or removed, and no existing input or output contract changed.
-- Node.js 20 or newer remains required.
+- Node.js 20.18.1 or newer is required.
 - Docker deployments keep the same HTTP port and health endpoint.
 
 ### Validation Evidence
-- Node.js 20.20.2 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
+- Node.js 20.18.1 and 24.19.0: clean `npm ci && npm run ci` (27/27 fast tests on each runtime)
 - `npm audit --audit-level=low` (zero vulnerabilities)
-- Node.js 20.20.2: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
+- Node.js 20.18.1: `npm run test:e2e` (21/21 integration tests; 14/14 Playwright tests)
 - Packed-tarball install, CLI, and 92-tool discovery smoke
 - `npm publish --dry-run --access public --ignore-scripts`
 - Linux/amd64 Docker build, version check, non-root UID check, and IPv4 healthcheck smoke

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/util/mcp.ts
+++ b/src/util/mcp.ts
@@ -38,8 +38,8 @@ export function text(data: unknown) {
 /**
  * The MCP SDK converts Zod v3 schemas with zod-to-json-schema, which stamps every
  * advertised tool schema with `"$schema": "http://json-schema.org/draft-07/schema#"`.
- * Clients that validate 2020-12 only (Claude) reject those tools outright. Without a
- * `$schema` the dialect defaults to 2020-12, which these object schemas already satisfy.
+ * Clients that reject an explicitly declared draft-07 dialect cannot discover those tools.
+ * Removing the marker leaves schema interpretation to the client context.
  */
 export function stripSchemaDialect(server: { server?: unknown }): void {
   const handlers = (server.server as { _requestHandlers?: Map<string, Function> } | undefined)?._requestHandlers;

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.1",
+  "version": "3.2.2",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- Synchronize the v3.2.2 release metadata from `main` back to `develop`.
- Carry forward the Node.js 20.18.1 support floor and the clarified schema dialect documentation finalized in release PR #295.
- Keep `develop` aligned with the published npm package, GHCR image, tag, and GitHub Release.

## Validation

- Reuses the successful v3.2.2 release gate on the identical source tree.
- `git diff --check origin/develop...HEAD`
- Published npm version: `3.2.2`
- Release: https://github.com/DAWNCR0W/affine-mcp-server/releases/tag/v3.2.2