### PR TITLE
fix: preserve database rich-text delta attributes

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -129,11 +129,11 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | --- | --- | --- |
 | `compose_database_from_intent` | Create or enrich a database block from a high-level schema intent | Useful for project boards and structured tables |
 | `add_database_column` | Add a column to a database block | Supports `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date` |
-| `add_database_row` | Add a row to a database block | Can set the built-in title field |
+| `add_database_row` | Add a row to a database block | Rich-text and title values accept strings or delta arrays |
 | `delete_database_row` | Delete a row by row block id | Destructive |
 | `read_database_columns` | Read schema metadata, types, options, and view mappings | Useful before edits |
-| `read_database_cells` | Read row titles and decoded cell values | Supports row and column filters |
-| `update_database_row` | Update multiple cells on a row at once | `createOption` defaults to `true` |
+| `read_database_cells` | Read row titles and decoded cell values | Rich-text titles and cells include plain values and formatting-preserving deltas |
+| `update_database_row` | Update multiple cells on a row at once | Rich-text deltas are preserved; `createOption` defaults to `true` |
 
 ## Edgeless canvas and surface elements
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -7353,8 +7353,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   }
 
   function normalizeDatabaseRichTextValue(value: unknown): string | TextDelta[] {
+    if (typeof value === "string") {
+      return value;
+    }
     if (!Array.isArray(value)) {
-      return String(value ?? "");
+      throw new Error("Rich-text values must be strings or delta arrays with string insert values");
     }
     const deltas = richTextValueToDeltas(value) ?? [];
     if (deltas.length !== value.length) {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -7352,24 +7352,31 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return childIdsFrom(dbBlock.get("sys:children"));
   }
 
-  function readDatabaseRowTitle(rowBlock: Y.Map<any>): string {
-    return asText(rowBlock.get("prop:text"));
+  function normalizeDatabaseRichTextValue(value: unknown): string | TextDelta[] {
+    if (!Array.isArray(value)) {
+      return String(value ?? "");
+    }
+    const deltas = richTextValueToDeltas(value) ?? [];
+    if (deltas.length !== value.length) {
+      throw new Error("Rich-text values must be strings or delta arrays with string insert values");
+    }
+    return deltas;
   }
 
   function resolveDatabaseTitleValue(
     cells: Record<string, unknown>,
     lookup: DatabaseColumnLookup,
-  ): string {
+  ): string | TextDelta[] {
     if (lookup.titleCol) {
       const value = cells[lookup.titleCol.name] ?? cells[lookup.titleCol.id];
       if (value !== undefined) {
-        return String(value ?? "");
+        return normalizeDatabaseRichTextValue(value);
       }
     }
 
     for (const [key, value] of Object.entries(cells)) {
       if (isTitleAliasKey(key)) {
-        return String(value ?? "");
+        return normalizeDatabaseRichTextValue(value);
       }
     }
 
@@ -7377,7 +7384,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     if (namedTitleColumn) {
       const value = cells[namedTitleColumn.name] ?? cells[namedTitleColumn.id];
       if (value !== undefined) {
-        return String(value ?? "");
+        return normalizeDatabaseRichTextValue(value);
       }
     }
 
@@ -7413,7 +7420,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       rowBlock.set("prop:text", makeLinkedDocText(parsed.linkedDocId));
     } else {
       const titleValue = resolveDatabaseTitleValue(parsed.cells, parsed.lookup);
-      rowBlock.set("prop:text", makeText(String(titleValue)));
+      rowBlock.set("prop:text", makeText(titleValue));
     }
     parsed.blocks.set(rowBlockId, rowBlock);
 
@@ -7522,7 +7529,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     switch (col.type) {
       case "rich-text":
       case "title":
-        return { ...base, value: richTextValueToString(rawValue) || null };
+        return {
+          ...base,
+          value: richTextValueToString(rawValue) || null,
+          deltas: richTextValueToDeltas(rawValue) ?? [],
+        };
       case "select": {
         const optionId = asStringOrNull(rawValue);
         const option = col.options.find(entry => entry.id === optionId) || null;
@@ -7580,7 +7591,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     switch (col.type) {
       case "rich-text":
       case "title":
-        cellValue.set("value", makeText(String(value ?? "")));
+        cellValue.set("value", makeText(normalizeDatabaseRichTextValue(value)));
         break;
       case "number": {
         const num = Number(value);
@@ -7708,7 +7719,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         rowBlock.set("prop:text", makeLinkedDocText(parsed.linkedDocId));
       } else {
         const titleValue = resolveDatabaseTitleValue(parsed.cells, ctx);
-        rowBlock.set("prop:text", makeText(String(titleValue)));
+        rowBlock.set("prop:text", makeText(titleValue));
       }
       ctx.blocks.set(rowBlockId, rowBlock);
 
@@ -7753,7 +7764,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)"),
         docId: DocId.describe("Document ID containing the database"),
         databaseBlockId: z.string().min(1).describe("Block ID of the affine:database block"),
-        cells: z.record(z.unknown()).describe("Map of column name (or column ID) to cell value. For select columns, pass the display label (option auto-created if new)."),
+        cells: z.record(z.unknown()).describe("Map of column name (or column ID) to cell value. Rich-text and title values accept strings or delta arrays with optional attributes. For select columns, pass the display label (option auto-created if new)."),
         linkedDocId: z.string().optional().describe("Link this row to an existing doc by ID. The row will open the linked doc in center peek when clicked."),
       },
     },
@@ -7839,7 +7850,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
 
       const rows = requestedRows.map(rowBlockId => {
         const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, rowBlockId);
-        const title = readDatabaseRowTitle(rowBlock) || null;
+        const titleValue = rowBlock.get("prop:text");
+        const title = richTextValueToString(titleValue) || null;
         const rowCells = ctx.cellsMap.get(rowBlockId);
         const cells: Record<string, Record<string, unknown>> = {};
 
@@ -7862,6 +7874,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         return {
           rowBlockId,
           title,
+          titleDeltas: richTextValueToDeltas(titleValue) ?? [],
           linkedDocId: readLinkedDocId(rowBlock),
           cells,
         };
@@ -7876,7 +7889,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "read_database_cells",
     {
       title: "Read Database Cells",
-      description: "Read row titles and database cell values from an AFFiNE database block.",
+      description: "Read row titles and database cell values from an AFFiNE database block. Rich-text titles and cells include both plain values and formatting-preserving deltas.",
       inputSchema: {
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)"),
         docId: DocId.describe("Document ID containing the database"),
@@ -7946,13 +7959,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     try {
       const rowBlock = getDatabaseRowBlock(ctx.blocks, ctx.dbBlock, parsed.databaseBlockId, parsed.rowBlockId);
       const rowCells = ensureDatabaseRowCells(ctx.cellsMap, parsed.rowBlockId);
-      let titleValue: string | null = null;
+      let titleValue: string | TextDelta[] | null = null;
 
       for (const [key, value] of Object.entries(parsed.cells)) {
         const col = findDatabaseColumn(key, ctx);
         if (!col) {
           if (isTitleAliasKey(key)) {
-            titleValue = String(value ?? "");
+            titleValue = normalizeDatabaseRichTextValue(value);
             continue;
           }
           throw new Error(`Column '${key}' not found. Available columns: ${availableDatabaseColumns(ctx)}`);
@@ -7960,7 +7973,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
 
         writeDatabaseCellValue(rowCells, col, value, parsed.createOption ?? true);
         if (col.type === "title" || isTitleAliasKey(col.name)) {
-          titleValue = String(value ?? "");
+          titleValue = normalizeDatabaseRichTextValue(value);
         }
       }
 
@@ -7992,7 +8005,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         docId: DocId.describe("Document ID containing the database"),
         databaseBlockId: z.string().min(1).describe("Block ID of the affine:database block"),
         rowBlockId: z.string().min(1).describe("Row paragraph block ID"),
-        cells: z.record(z.unknown()).describe("Map of column name (or column ID) to new cell value. Use `title` for the built-in row title."),
+        cells: z.record(z.unknown()).describe("Map of column name (or column ID) to new cell value. Rich-text and title values accept strings or delta arrays with optional attributes. Use `title` for the built-in row title."),
         createOption: z.boolean().optional().describe("For select and multi-select columns, create the option label if it does not exist (default true)"),
         linkedDocId: z.string().optional().describe("Link this row to an existing doc by ID. The row will open the linked doc in center peek when clicked."),
       },

--- a/tests/playwright/verify-database.pw.ts
+++ b/tests/playwright/verify-database.pw.ts
@@ -20,9 +20,21 @@ interface TestState {
   error?: string;
 }
 
+interface CellTestState {
+  baseUrl: string;
+  email: string;
+  workspaceId: string;
+  docId: string;
+  databaseBlockId: string;
+  richTextLinks: Array<{ text: string; href: string }>;
+  error?: string;
+}
+
 const STATE_PATH = path.resolve(__dirname, '..', 'test-database-state.json');
+const CELL_STATE_PATH = path.resolve(__dirname, '..', 'test-database-cells-state.json');
 
 let state: TestState;
+let cellState: CellTestState;
 
 test.beforeAll(() => {
   if (!fs.existsSync(STATE_PATH)) {
@@ -37,6 +49,20 @@ test.beforeAll(() => {
   }
   if (!state.workspaceId || !state.docId) {
     throw new Error('State file missing workspaceId or docId');
+  }
+
+  if (!fs.existsSync(CELL_STATE_PATH)) {
+    throw new Error(
+      `State file not found: ${CELL_STATE_PATH}\n` +
+      'Run "npm run test:db-cells" first to create rich-text database test data.',
+    );
+  }
+  cellState = JSON.parse(fs.readFileSync(CELL_STATE_PATH, 'utf8'));
+  if (cellState.error) {
+    throw new Error(`State file contains error from database cell test: ${cellState.error}`);
+  }
+  if (!cellState.workspaceId || !cellState.docId || !cellState.databaseBlockId || !cellState.richTextLinks?.length) {
+    throw new Error('Database cell state is missing IDs or rich-text links');
   }
 });
 
@@ -136,6 +162,36 @@ test.describe.serial('AFFiNE Database Verification', () => {
       // Verify a select value is present
       const selectValue = page.getByText('Active', { exact: true });
       await expect(selectValue.first()).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('verify rich-text database links in the AFFiNE editor', async ({ browser }) => {
+    const storageStatePath = path.resolve(__dirname, '..', 'playwright-auth-state.json');
+    const context = await browser.newContext({ storageState: storageStatePath });
+    const page = await context.newPage();
+
+    try {
+      await page.goto(`${cellState.baseUrl}/workspace/${cellState.workspaceId}/${cellState.docId}`);
+      await page.waitForLoadState('domcontentloaded');
+
+      if (page.url().includes('/sign-in')) {
+        throw new Error('Redirected to sign-in — login test did not persist auth state');
+      }
+
+      await page.waitForTimeout(5_000);
+      const databaseBlock = page.locator(
+        'affine-database, [data-block-flavour="affine:database"], ' +
+        '.affine-database-block-container, [class*="database"]',
+      );
+      await expect(databaseBlock.first()).toBeVisible({ timeout: 30_000 });
+
+      for (const expectedLink of cellState.richTextLinks) {
+        const link = page.locator(`a[href="${expectedLink.href}"]`).filter({ hasText: expectedLink.text }).first();
+        await expect(link).toBeVisible({ timeout: 15_000 });
+        await expect(link).toHaveAttribute('href', expectedLink.href);
+      }
     } finally {
       await context.close();
     }

--- a/tests/test-database-cells.mjs
+++ b/tests/test-database-cells.mjs
@@ -244,6 +244,13 @@ async function main() {
       await settle();
     }
 
+    await expectToolFailure('add_database_row', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.databaseBlockId,
+      cells: { Title: { insert: 'Invalid object input' } },
+    }, 'Rich-text values must be strings or delta arrays');
+
     const rowInputs = [
       {
         Title: richTextCases.initialTitle,

--- a/tests/test-database-cells.mjs
+++ b/tests/test-database-cells.mjs
@@ -2,7 +2,7 @@
 import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
 
 /**
- * Comprehensive live integration test for issue #50.
+ * Comprehensive live integration test for issues #50 and #304.
  *
  * Covers:
  * - `Title`-based row creation writing the built-in Kanban title
@@ -12,6 +12,7 @@ import { testResourceName, testTempPath } from './require-destructive-test-safet
  * - `update_database_row` batch updates
  * - `delete_database_row` removes rows cleanly from the database block
  * - select / multi-select option auto-create behavior and strict failure mode
+ * - rich-text delta attributes survive add, update, read, and row-title writes
  *
  * Outputs tests/test-database-cells-state.json for UI verification.
  */
@@ -143,6 +144,7 @@ async function main() {
     rowBlockIds: [],
     columnIds: {},
     finalRows: [],
+    richTextLinks: [],
   };
 
   const initialDates = {
@@ -154,6 +156,32 @@ async function main() {
     row1: Date.UTC(2026, 2, 12, 10, 15, 0),
     row2: Date.UTC(2026, 2, 13, 11, 45, 0),
   };
+
+  const richTextCases = {
+    initialTitle: [
+      { insert: 'Card ' },
+      { insert: 'Alpha', attributes: { link: 'https://example.com/cards/alpha' } },
+    ],
+    initialNotes: [
+      { insert: 'README', attributes: { link: 'https://example.com/readme' } },
+      { insert: ' is required', attributes: { italic: true } },
+    ],
+    updatedRow1Title: [
+      { insert: 'Card Alpha ' },
+      { insert: 'Prime', attributes: { bold: true } },
+    ],
+    updatedRow1Notes: [
+      { insert: 'Migration guide', attributes: { link: 'https://example.com/migration' } },
+    ],
+    finalTitle: [
+      { insert: 'Card Beta ' },
+      { insert: 'Final', attributes: { link: 'https://example.com/cards/beta-final' } },
+    ],
+    finalNotes: [
+      { insert: 'Release runbook', attributes: { bold: true, link: 'https://example.com/release-runbook' } },
+    ],
+  };
+  const rowTitles = ['Card Alpha', 'Card Beta'];
 
   await client.connect(transport);
 
@@ -193,6 +221,7 @@ async function main() {
 
     const columns = [
       { key: 'Title', name: 'Title', type: 'rich-text' },
+      { key: 'Notes', name: 'Notes', type: 'rich-text' },
       { key: 'Owner', name: 'Owner', type: 'rich-text' },
       { key: 'Stage', name: 'Stage', type: 'select', options: ['Todo', 'In Progress', 'Done'] },
       { key: 'Labels', name: 'Labels', type: 'multi-select', options: ['Backend', 'Frontend', 'Urgent'] },
@@ -217,7 +246,8 @@ async function main() {
 
     const rowInputs = [
       {
-        Title: 'Card Alpha',
+        Title: richTextCases.initialTitle,
+        Notes: richTextCases.initialNotes,
         Owner: 'Alice',
         Stage: 'In Progress',
         Labels: ['Backend'],
@@ -228,6 +258,7 @@ async function main() {
       },
       {
         Title: 'Card Beta',
+        Notes: 'Draft',
         Owner: 'Bob',
         Stage: 'Todo',
         Labels: ['Frontend', 'Urgent'],
@@ -255,9 +286,8 @@ async function main() {
     });
     for (let i = 0; i < state.rowBlockIds.length; i++) {
       const rowBlock = readAfterAdd?.blocks?.find(block => block.id === state.rowBlockIds[i]);
-      expectEqual(rowBlock?.text, rowInputs[i].Title, `row title after add_database_row for row ${i + 1}`);
+      expectEqual(rowBlock?.text, rowTitles[i], `row title after add_database_row for row ${i + 1}`);
     }
-
     const readAllRows = await call('read_database_cells', {
       workspaceId: state.workspaceId,
       docId: state.docId,
@@ -267,7 +297,11 @@ async function main() {
 
     const [row1, row2] = readAllRows.rows;
     expectEqual(row1.title, 'Card Alpha', 'row1 title after create');
+    expectArrayEqual(row1.titleDeltas, richTextCases.initialTitle, 'row1 title deltas after create');
     expectEqual(row1.cells.Title.value, 'Card Alpha', 'row1 custom Title cell');
+    expectArrayEqual(row1.cells.Title.deltas, richTextCases.initialTitle, 'row1 custom Title deltas after create');
+    expectEqual(row1.cells.Notes.value, 'README is required', 'row1 Notes');
+    expectArrayEqual(row1.cells.Notes.deltas, richTextCases.initialNotes, 'row1 Notes deltas after create');
     expectEqual(row1.cells.Owner.value, 'Alice', 'row1 Owner');
     expectEqual(row1.cells.Stage.value, 'In Progress', 'row1 Stage');
     expectTruthy(row1.cells.Stage.optionId, 'row1 Stage optionId');
@@ -279,7 +313,10 @@ async function main() {
     expectEqual(row1.cells.Link.value, 'https://example.com/alpha', 'row1 Link');
 
     expectEqual(row2.title, 'Card Beta', 'row2 title after create');
+    expectArrayEqual(row2.titleDeltas, [{ insert: 'Card Beta' }], 'row2 plain title deltas after create');
     expectEqual(row2.cells.Title.value, 'Card Beta', 'row2 custom Title cell');
+    expectArrayEqual(row2.cells.Title.deltas, [{ insert: 'Card Beta' }], 'row2 plain Title deltas after create');
+    expectArrayEqual(row2.cells.Notes.deltas, [{ insert: 'Draft' }], 'row2 plain Notes deltas after create');
     expectEqual(row2.cells.Owner.value, 'Bob', 'row2 Owner');
     expectEqual(row2.cells.Stage.value, 'Todo', 'row2 Stage');
     expectArrayEqual(row2.cells.Labels.value, ['Frontend', 'Urgent'], 'row2 Labels');
@@ -316,7 +353,8 @@ async function main() {
       databaseBlockId: state.databaseBlockId,
       rowBlockId: state.rowBlockIds[0],
       cells: {
-        Title: 'Card Alpha Prime',
+        Title: richTextCases.updatedRow1Title,
+        Notes: richTextCases.updatedRow1Notes,
         [state.columnIds.Owner]: 'Carol',
         Stage: 'Blocked',
         [state.columnIds.Labels]: ['Backend', 'Urgent', 'Release'],
@@ -336,7 +374,10 @@ async function main() {
     });
     const updatedRow1 = row1AfterSingleUpdates.rows[0];
     expectEqual(updatedRow1.title, 'Card Alpha Prime', 'row1 title after single-cell updates');
+    expectArrayEqual(updatedRow1.titleDeltas, richTextCases.updatedRow1Title, 'row1 title deltas after update_database_row');
     expectEqual(updatedRow1.cells.Title.value, 'Card Alpha Prime', 'row1 custom Title after update_database_row');
+    expectArrayEqual(updatedRow1.cells.Title.deltas, richTextCases.updatedRow1Title, 'row1 custom Title deltas after update_database_row');
+    expectArrayEqual(updatedRow1.cells.Notes.deltas, richTextCases.updatedRow1Notes, 'row1 Notes deltas after update_database_row');
     expectEqual(updatedRow1.cells.Owner.value, 'Carol', 'row1 Owner after update_database_row');
     expectEqual(updatedRow1.cells.Stage.value, 'Blocked', 'row1 Stage after auto-created option');
     expectArrayEqual(updatedRow1.cells.Labels.value, ['Backend', 'Urgent', 'Release'], 'row1 Labels after update_database_row');
@@ -373,7 +414,8 @@ async function main() {
       databaseBlockId: state.databaseBlockId,
       rowBlockId: state.rowBlockIds[1],
       cells: {
-        title: 'Card Beta Final',
+        title: richTextCases.finalTitle,
+        Notes: richTextCases.finalNotes,
         Owner: 'Dana',
         Stage: 'Done',
         [state.columnIds.Labels]: ['Frontend', 'QA'],
@@ -400,7 +442,11 @@ async function main() {
 
     expectEqual(finalRow1.title, 'Card Alpha Prime', 'final row1 title');
     expectEqual(finalRow2.title, 'Card Beta Final', 'final row2 title');
+    expectArrayEqual(finalRow2.titleDeltas, richTextCases.finalTitle, 'final row2 title deltas');
     expectEqual(finalRow2.cells.Title.value, 'Card Beta Final', 'final row2 custom Title cell');
+    expectArrayEqual(finalRow2.cells.Title.deltas, richTextCases.finalTitle, 'final row2 custom Title deltas');
+    expectEqual(finalRow2.cells.Notes.value, 'Release runbook', 'final row2 Notes');
+    expectArrayEqual(finalRow2.cells.Notes.deltas, richTextCases.finalNotes, 'final row2 Notes deltas');
     expectEqual(finalRow2.cells.Owner.value, 'Dana', 'final row2 Owner');
     expectEqual(finalRow2.cells.Stage.value, 'Done', 'final row2 Stage');
     expectArrayEqual(finalRow2.cells.Labels.value, ['Frontend', 'QA'], 'final row2 Labels');
@@ -441,6 +487,10 @@ async function main() {
     }
 
     state.finalRows = afterDelete.rows;
+    state.richTextLinks = [
+      { text: 'Final', href: 'https://example.com/cards/beta-final' },
+      { text: 'Release runbook', href: 'https://example.com/release-runbook' },
+    ];
 
     fs.writeFileSync(STATE_OUTPUT_PATH, JSON.stringify(state, null, 2));
     console.log();

--- a/tests/test-suites.json
+++ b/tests/test-suites.json
@@ -95,6 +95,7 @@
     ],
     "e2e": [
       "test-database-creation.mjs",
+      "test-database-cells.mjs",
       "test-database-linked-doc.mjs",
       "test-http-email-password.mjs",
       "test-http-bearer.mjs",


### PR DESCRIPTION
## Summary

- accept rich-text delta arrays for database titles and cells without coercing them to strings
- return formatting-preserving deltas alongside plain-text database values
- cover create, update, read, and rendered AFFiNE editor links

## Regression evidence

Before the fix, the issue reproduction failed with `expected "Card Alpha", got "[object Object],[object Object]"`. The same scenario now preserves link, bold, and italic attributes through AFFiNE CRDT storage and rendering.

## Validation

- `npx --yes --package=node@24 --call "npm run ci"`
- `npx --yes --package=node@24 --call "npm run test:comprehensive"`
- `AFFINE_REVISION=0.27.4 npm run test:e2e` (22 integration tests and 15 Playwright tests)

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Database titles and rich-text cells now preserve formatting, including links.
  - Rows support rich-text delta values when adding or updating data.
  - Reading database cells exposes both plain text and preserved formatting.

- **Bug Fixes**
  - Improved consistency of rich-text formatting across row creation, updates, and reads.
  - Invalid rich-text values now return clear validation errors.

- **Documentation**
  - Updated database tool documentation to describe rich-text and delta-array support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->