### PR TITLE
fix: return 404 for unknown MCP sessions

### DIFF
--- a/src/sse.ts
+++ b/src/sse.ts
@@ -387,6 +387,9 @@ export async function startHttpMcpServer(
 
         const mcpServer = await createMcpServer();
         await mcpServer.connect(transport);
+      } else if (sessionId && !existing) {
+        sendJsonRpcError(res, 404, -32001, "Session not found");
+        return;
       } else {
         sendJsonRpcError(
           res,

--- a/tests/test-http-runtime-safety.mjs
+++ b/tests/test-http-runtime-safety.mjs
@@ -266,6 +266,42 @@ async function testBodyLimitErrors() {
   }
 }
 
+async function testUnknownSessionReturnsNotFound() {
+  const server = await startHealthyServer();
+  try {
+    const unknownSessionId = "00000000-0000-0000-0000-000000000000";
+    const toolsList = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+
+    const unknownPost = await postMcp(server.baseUrl, toolsList, unknownSessionId);
+    assertEqual(unknownPost.status, 404, "unknown-session POST status");
+    const unknownPostBody = await readJson(unknownPost);
+    assertEqual(unknownPostBody.error?.code, -32001, "unknown-session POST error code");
+    assertEqual(
+      unknownPostBody.error?.message,
+      "Session not found",
+      "unknown-session POST error",
+    );
+
+    for (const method of ["GET", "DELETE"]) {
+      const response = await fetch(`${server.baseUrl}/mcp`, {
+        method,
+        headers: {
+          Accept: "application/json, text/event-stream",
+          "mcp-session-id": unknownSessionId,
+        },
+      });
+      assertEqual(response.status, 404, `unknown-session ${method} status`);
+      await response.body?.cancel();
+    }
+
+    const missingSession = await postMcp(server.baseUrl, toolsList);
+    assertEqual(missingSession.status, 400, "missing-session non-initialize status");
+    await missingSession.body?.cancel();
+  } finally {
+    await server.close();
+  }
+}
+
 async function testSessionCapacityActivityAndIdleCleanup() {
   const server = await startHealthyServer({
     AFFINE_MCP_HTTP_MAX_SESSIONS: "1",
@@ -434,6 +470,7 @@ async function main() {
   await testRuntimeConfig();
   await testStartupErrors();
   await testBodyLimitErrors();
+  await testUnknownSessionReturnsNotFound();
   await testSessionCapacityActivityAndIdleCleanup();
   await testShutdownWithActiveSession();
   await testForcedConnectionDeadline();


### PR DESCRIPTION
## Summary\n\nReturn the Streamable HTTP status required by the MCP protocol when a client sends an unknown session ID, allowing clients to initialize a replacement session automatically.\n\nCloses #301\n\n## Changes\n\n- Return HTTP 404 with JSON-RPC code -32001 for unknown Mcp-Session-Id values.\n- Preserve HTTP 400 for non-initialize requests that omit the session header.\n- Cover POST, GET, and DELETE unknown-session requests plus the missing-session control case.\n\n## Validation\n\nCommands executed:\n\n- npx -y -p node@24 -- npm run ci\n- npm run test:comprehensive (15/15 focused tests; 109/109 tool checks)\n- AFFINE_REVISION=0.27.4 npm run test:e2e (22/22 integration tests; 15/15 Chromium tests)\n\n## Compatibility\n\nThis is a protocol-compliance correction. Existing valid sessions are unchanged; clients can now recover from expired or server-forgotten sessions.\n\n## Checklist\n\n- [x] Head branch is a dedicated branch, not main, develop, dev, or master\n- [x] Base branch is develop\n- [x] Tool names remain unique and snake_case; the tool surface is unchanged\n- [x] tool-manifest.json is unchanged because the tool list did not change\n- [x] No README change is needed for this standards-compliant status correction\n- [x] Backward compatibility impact is described above