### PR TITLE
Fix Markdown sentence punctuation escaping

### DIFF
--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -220,7 +220,11 @@ function renderTextDelta(
     }
   }
 
-  let rendered = renderAsCode ? inlineCodeFence(content) : escapeMarkdownPlainText(content);
+  let rendered = renderAsCode
+    ? inlineCodeFence(content)
+    : options.tableCell
+      ? escapeMarkdownTableCell(content)
+      : escapeMarkdownPlainText(content);
   if (attributes.bold) rendered = `**${rendered}**`;
   if (attributes.italic) rendered = `*${rendered}*`;
   if (attributes.strike) rendered = `~~${rendered}~~`;

--- a/src/markdown/safety.ts
+++ b/src/markdown/safety.ts
@@ -1,6 +1,7 @@
 const UNSAFE_LINK_SCHEMES = new Set(["data", "file", "javascript", "vbscript"]);
 const ENTITY_LIKE_AMPERSAND = /&(?=(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);)/gi;
-const INLINE_MARKDOWN_SYNTAX = new Set(["\\", "`", "*", "_", "[", "]", "<", "&", "~"]);
+const ENTITY_AFTER_AMPERSAND = /^(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);/i;
+const INLINE_MARKDOWN_SYNTAX = new Set(["\\", "`", "*", "_", "[", "]", "<", "~"]);
 
 export type MarkdownFrontmatterInput = {
   docId: string;
@@ -104,7 +105,14 @@ function escapeMarkdownCharacter(character: string): string {
 
 /** Escape untrusted text while leaving generated Markdown structure untouched. */
 export function escapeMarkdownPlainText(value: string): string {
-  return Array.from(value, escapeMarkdownCharacter)
+  let offset = 0;
+  return Array.from(value, character => {
+    const currentOffset = offset;
+    offset += character.length;
+    return character === "&" && ENTITY_AFTER_AMPERSAND.test(value.slice(currentOffset + 1))
+      ? "\\&"
+      : escapeMarkdownCharacter(character);
+  })
     .join("")
     .replace(/(\\<[^<>]*?)>/g, "$1\\>")
     .replace(/(\\\])\(/g, "$1\\(")

--- a/src/markdown/safety.ts
+++ b/src/markdown/safety.ts
@@ -1,7 +1,10 @@
+import MarkdownIt from "markdown-it";
+
 const UNSAFE_LINK_SCHEMES = new Set(["data", "file", "javascript", "vbscript"]);
 const ENTITY_LIKE_AMPERSAND = /&(?=(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);)/gi;
-const ENTITY_AFTER_AMPERSAND = /^(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);/i;
+const MARKDOWN_ENTITY = /^&(?:#(?:x[a-f0-9]{1,6}|[0-9]{1,7})|[a-z][a-z0-9]{1,31});/i;
 const INLINE_MARKDOWN_SYNTAX = new Set(["\\", "`", "*", "_", "[", "]", "<", "~"]);
+const markdownUtils = new MarkdownIt().utils;
 
 export type MarkdownFrontmatterInput = {
   docId: string;
@@ -103,13 +106,18 @@ function escapeMarkdownCharacter(character: string): string {
   return INLINE_MARKDOWN_SYNTAX.has(character) ? `\\${character}` : character;
 }
 
+function startsMarkdownEntity(value: string, offset: number): boolean {
+  const candidate = value.slice(offset).match(MARKDOWN_ENTITY)?.[0];
+  return candidate !== undefined && markdownUtils.unescapeAll(candidate) !== candidate;
+}
+
 /** Escape untrusted text while leaving generated Markdown structure untouched. */
 export function escapeMarkdownPlainText(value: string): string {
   let offset = 0;
   return Array.from(value, character => {
     const currentOffset = offset;
     offset += character.length;
-    return character === "&" && ENTITY_AFTER_AMPERSAND.test(value.slice(currentOffset + 1))
+    return character === "&" && startsMarkdownEntity(value, currentOffset)
       ? "\\&"
       : escapeMarkdownCharacter(character);
   })

--- a/src/markdown/safety.ts
+++ b/src/markdown/safety.ts
@@ -1,5 +1,6 @@
 const UNSAFE_LINK_SCHEMES = new Set(["data", "file", "javascript", "vbscript"]);
 const ENTITY_LIKE_AMPERSAND = /&(?=(?:#\d+|#x[0-9a-f]+|[a-z][a-z0-9]+);)/gi;
+const INLINE_MARKDOWN_SYNTAX = new Set(["\\", "`", "*", "_", "[", "]", "<", "&", "~"]);
 
 export type MarkdownFrontmatterInput = {
   docId: string;
@@ -90,11 +91,6 @@ export function hasUnsafeMarkdownLinkScheme(destination: string): boolean {
 
 function escapeMarkdownCharacter(character: string): string {
   const codePoint = character.codePointAt(0) as number;
-  const isAsciiPunctuation =
-    (codePoint >= 0x21 && codePoint <= 0x2f) ||
-    (codePoint >= 0x3a && codePoint <= 0x40) ||
-    (codePoint >= 0x5b && codePoint <= 0x60) ||
-    (codePoint >= 0x7b && codePoint <= 0x7e);
   const isStructuralWhitespace =
     codePoint <= 0x1f ||
     (codePoint >= 0x7f && codePoint <= 0x9f) ||
@@ -103,12 +99,21 @@ function escapeMarkdownCharacter(character: string): string {
   if (isStructuralWhitespace) {
     return `&#${codePoint};`;
   }
-  return isAsciiPunctuation ? `\\${character}` : character;
+  return INLINE_MARKDOWN_SYNTAX.has(character) ? `\\${character}` : character;
 }
 
 /** Escape untrusted text while leaving generated Markdown structure untouched. */
 export function escapeMarkdownPlainText(value: string): string {
-  return Array.from(value, escapeMarkdownCharacter).join("");
+  return Array.from(value, escapeMarkdownCharacter)
+    .join("")
+    .replace(/(\\<[^<>]*?)>/g, "$1\\>")
+    .replace(/(\\\])\(/g, "$1\\(")
+    .replace(/(\\\]\\\([a-z][a-z0-9+.-]*):/gi, "$1\\:")
+    .replace(/^([ \t]{0,3})(#{1,6})(?=[ \t]|$)/, "$1\\$2")
+    .replace(/^([ \t]{0,3})(>)/, "$1\\$2")
+    .replace(/^([ \t]{0,3})([-+])(?=[ \t]|$)/, "$1\\$2")
+    .replace(/^([ \t]{0,3})(\d{1,9})([.)])(?=[ \t]|$)/, "$1$2\\$3")
+    .replace(/^([ \t]{0,3})-(?=(?:[ \t]*-){2,}[ \t]*$)/, "$1\\-");
 }
 
 export function escapeMarkdownLinkLabel(value: string): string {
@@ -116,7 +121,7 @@ export function escapeMarkdownLinkLabel(value: string): string {
 }
 
 export function escapeMarkdownTableCell(value: string): string {
-  return escapeMarkdownPlainText(value);
+  return escapeMarkdownPlainText(value).replace(/\|/g, "\\|");
 }
 
 export function escapeMarkdownLinkDestination(value: string): string {

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -171,18 +171,28 @@ async function main() {
     });
     assertParentIdsAreNull(readAfterAppendParagraph, 'after append_block paragraph');
 
+    const punctuationMarkdown = [
+      '- [ ] second item (appended)',
+      '- [ ] Call the bank about a refund. notes are elsewhere',
+      '- [ ] Cancel the card; try to get the $95 annual fee waived',
+      '- [ ] Unlock the spare phone, then check email',
+    ].join('\n');
     const markdownDoc = await call('create_doc_from_markdown', {
       workspaceId: state.workspaceId,
       title: 'ParentId Markdown Structure Check',
-      markdown: '# Heading from markdown\n\nBody from markdown import.',
+      markdown: `# Heading from markdown\n\n${punctuationMarkdown}`,
     });
     if (!markdownDoc?.docId) throw new Error('create_doc_from_markdown did not return docId');
 
     const readMarkdownDoc = await call('read_doc', {
       workspaceId: state.workspaceId,
       docId: markdownDoc.docId,
+      includeMarkdown: true,
     });
     assertParentIdsAreNull(readMarkdownDoc, 'after create_doc_from_markdown');
+    if (!readMarkdownDoc?.markdown?.includes(punctuationMarkdown)) {
+      throw new Error(`read_doc over-escaped sentence punctuation: ${JSON.stringify(readMarkdownDoc?.markdown)}`);
+    }
 
     // 3. Create database block
     const dbBlock = await call('append_block', {

--- a/tests/test-markdown-output-safety.mjs
+++ b/tests/test-markdown-output-safety.mjs
@@ -232,6 +232,7 @@ function testSentencePunctuationIsNotOverEscaped() {
     'Unlock the spare phone, then check email',
     "Check the bank's reply",
     'AT&T account review',
+    'Preserve &MadeUpEntity; literally',
   ];
 
   for (const text of samples) {

--- a/tests/test-markdown-output-safety.mjs
+++ b/tests/test-markdown-output-safety.mjs
@@ -224,6 +224,58 @@ function testPlainAndDeltaTextCannotInjectBlocks() {
   }
 }
 
+function testSentencePunctuationIsNotOverEscaped() {
+  const samples = [
+    'second item (appended)',
+    'Call the bank about a refund. notes are elsewhere',
+    'Cancel the card; try to get the $95 annual fee waived',
+    'Unlock the spare phone, then check email',
+    "Check the bank's reply",
+  ];
+
+  for (const text of samples) {
+    const rendered = renderSingleBlock(markdownBlock({
+      flavour: 'affine:list',
+      type: 'todo',
+      checked: false,
+      text,
+    }));
+
+    assert.equal(rendered.markdown, `- [ ] ${text}`);
+    const parsed = parseMarkdownToOperations(rendered.markdown);
+    assert.equal(parsed.operations.length, 1);
+    assert.equal(parsed.operations[0]?.type, 'list');
+    assert.equal(parsed.operations[0]?.text, text);
+  }
+}
+
+function testStructuralMarkdownStillRoundTripsAsText() {
+  const samples = [
+    '# heading',
+    '> quote',
+    '- item',
+    '+ item',
+    '1. item',
+    '1) item',
+    '---',
+    '*emphasis*',
+    '_emphasis_',
+    '[link](https://example.com)',
+    '<script>alert(1)</script>',
+    '&copy;',
+    '`code`',
+    '~~strike~~',
+  ];
+
+  for (const text of samples) {
+    const rendered = renderSingleBlock(markdownBlock({ text }));
+    const parsed = parseMarkdownToOperations(rendered.markdown);
+    assert.equal(parsed.operations.length, 1, rendered.markdown);
+    assert.equal(parsed.operations[0]?.type, 'paragraph', rendered.markdown);
+    assert.equal(parsed.operations[0]?.text, text, rendered.markdown);
+  }
+}
+
 function testFormattedRichTextCannotInjectStructure() {
   const payload = '# heading\n- item\n](javascript:alert(1))\n<script>';
   const rendered = renderSingleBlock(markdownBlock({
@@ -352,6 +404,8 @@ testExportedFrontmatterDoesNotBecomeImportedBody();
 testCodeFenceSelectionAndRoundTrip();
 testLinkEscapingAndUnsafeSchemes();
 testPlainAndDeltaTextCannotInjectBlocks();
+testSentencePunctuationIsNotOverEscaped();
+testStructuralMarkdownStillRoundTripsAsText();
 testFormattedRichTextCannotInjectStructure();
 testUnsafeRichTextLinkDowngradesWithoutLosingText();
 testBookmarkBlockEscapingAndDowngrade();

--- a/tests/test-markdown-output-safety.mjs
+++ b/tests/test-markdown-output-safety.mjs
@@ -231,6 +231,7 @@ function testSentencePunctuationIsNotOverEscaped() {
     'Cancel the card; try to get the $95 annual fee waived',
     'Unlock the spare phone, then check email',
     "Check the bank's reply",
+    'AT&T account review',
   ];
 
   for (const text of samples) {

--- a/tests/test-markdown-roundtrip.mjs
+++ b/tests/test-markdown-roundtrip.mjs
@@ -325,7 +325,7 @@ function testYTextDeltaCollection() {
     text: value.toString(),
     textDeltas: deltas,
   }));
-  assert.equal(rendered.markdown, 'Plain **bold**[doc\\-2](LinkedPage:doc-2)');
+  assert.equal(rendered.markdown, 'Plain **bold**[doc-2](LinkedPage:doc-2)');
   assert.equal(rendered.lossy, false);
   assert.equal(rendered.stats.unsupportedInlineAttributeCount, 0);
   assert.deepEqual(rendered.warnings, []);


### PR DESCRIPTION
## Summary

- Escape plain text only where Markdown syntax is structurally active.
- Preserve link, HTML, block, and table-cell injection protections.
- Cover the reported todo sentences through a live AFFiNE read_doc round trip.

## Validation

- Node 24 CI: 27 fast tests passed, package smoke passed.
- Comprehensive AFFiNE suite: 15 focused tests and 109/109 tool checks passed.
- AFFiNE 0.27.4 E2E: 22 integration tests and 15 Chromium tests passed.

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown output safety while preserving normal punctuation and literal Markdown-like text.
  - Prevented entity-like ampersands and table-cell separators from being escaped or interpreted unexpectedly.
  - Fixed linked page identifiers so hyphens render normally.
  - Preserved inline code formatting and improved table-cell text rendering.

- **Tests**
  - Added coverage for safe Markdown round-tripping, punctuation, headings, checklists, and list content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->