### PR TITLE
fix: report markdown import losses accurately

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -414,6 +414,15 @@ type DatabaseIntentPreset = {
 };
 const DATABASE_COLUMN_TYPE_VALUES = ["rich-text", "select", "multi-select", "number", "checkbox", "link", "date"] as const;
 
+const MARKDOWN_IMPORT_KNOWN_LOSSES = [
+  "Nested markdown lists are flattened during import.",
+  "Markdown images are converted into bookmark blocks unless blobs are uploaded separately.",
+  "HTML blocks are imported as plain paragraph text.",
+  "Blank lines delimit Markdown blocks and do not create spacer paragraph blocks.",
+  "CommonMark parsing normalizes Markdown syntax and surrounding whitespace, including leading whitespace in list-item content.",
+] as const;
+const MARKDOWN_IMPORT_IS_LOSSY = MARKDOWN_IMPORT_KNOWN_LOSSES.length > 0;
+
 const MARKDOWN_EXPORT_SUPPORTED_FLAVOURS = new Set<string>([
   "affine:paragraph",
   "affine:list",
@@ -3741,6 +3750,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   }): Promise<{
     appendedCount: number;
     skippedCount: number;
+    removedCount: number;
+    removedEmptyParagraphCount: number;
     blockIds: string[];
   }> {
     const strict = parsed.strict !== false;
@@ -3764,6 +3775,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       let lastInsertedBlockId: string | undefined;
       let replaceParentId: string | undefined;
       let skippedCount = 0;
+      let removedCount = 0;
+      let removedEmptyParagraphCount = 0;
       const blockIds: string[] = [];
 
       if (replaceExisting) {
@@ -3776,6 +3789,16 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const existingChildren = childIdsFrom(noteChildren);
         const descendantBlockIds = collectDescendantBlockIds(blocks, existingChildren);
         for (const descendantId of descendantBlockIds) {
+          const descendant = findBlockById(blocks, descendantId);
+          if (descendant) {
+            removedCount += 1;
+            if (
+              descendant.get("sys:flavour") === "affine:paragraph" &&
+              asText(descendant.get("prop:text")).length === 0
+            ) {
+              removedEmptyParagraphCount += 1;
+            }
+          }
           blocks.delete(descendantId);
         }
         if (noteChildren.length > 0) {
@@ -3834,6 +3857,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       return {
         appendedCount: blockIds.length,
         skippedCount,
+        removedCount,
+        removedEmptyParagraphCount,
         blockIds,
       };
     } finally {
@@ -5547,12 +5572,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         legacyBlockAliases: Object.keys(APPEND_BLOCK_LEGACY_ALIAS_MAP),
         markdownImport: {
           supported: true,
-          lossy: true,
-          knownLosses: [
-            "Nested markdown lists are flattened during import.",
-            "Markdown images are converted into bookmark blocks unless blobs are uploaded separately.",
-            "HTML blocks are imported as plain paragraph text.",
-          ],
+          lossy: MARKDOWN_IMPORT_IS_LOSSY,
+          knownLosses: [...MARKDOWN_IMPORT_KNOWN_LOSSES],
         },
         markdownExport: {
           supportedFlavours: [...MARKDOWN_EXPORT_SUPPORTED_FLAVOURS].sort(),
@@ -6422,6 +6443,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     let applied = {
       appendedCount: 0,
       skippedCount: 0,
+      removedCount: 0,
+      removedEmptyParagraphCount: 0,
       blockIds: [] as string[],
     };
 
@@ -6463,11 +6486,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       parentDocId: placement.parentDocId,
       linkedToParent: placement.linkedToParent,
       warnings,
-      lossy: parsedMarkdown.lossy || applied.skippedCount > 0,
+      lossy: MARKDOWN_IMPORT_IS_LOSSY || parsedMarkdown.lossy || applied.skippedCount > 0,
       stats: {
         parsedBlocks: parsedMarkdown.operations.length,
         appliedBlocks: applied.appendedCount,
         skippedBlocks: applied.skippedCount,
+        removedBlocks: applied.removedCount,
+        removedEmptyParagraphs: applied.removedEmptyParagraphCount,
       },
     };
   };
@@ -6578,11 +6603,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       appendedCount: applied.appendedCount,
       blockIds: applied.blockIds,
       warnings: mergeWarnings(parsedMarkdown.warnings, applyWarnings),
-      lossy: parsedMarkdown.lossy || applied.skippedCount > 0,
+      lossy: MARKDOWN_IMPORT_IS_LOSSY || parsedMarkdown.lossy || applied.skippedCount > 0,
       stats: {
         parsedBlocks: parsedMarkdown.operations.length,
         appliedBlocks: applied.appendedCount,
         skippedBlocks: applied.skippedCount,
+        removedBlocks: applied.removedCount,
+        removedEmptyParagraphs: applied.removedEmptyParagraphCount,
       },
     });
   };
@@ -6636,21 +6663,27 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       replaceExisting: true,
     });
 
-    const applyWarnings =
-      applied.skippedCount > 0
+    const applyWarnings = [
+      ...(applied.skippedCount > 0
         ? [`${applied.skippedCount} markdown block(s) could not be applied to AFFiNE and were skipped.`]
-        : [];
+        : []),
+      ...(applied.removedEmptyParagraphCount > 0
+        ? [`Replacement removed ${applied.removedEmptyParagraphCount} existing empty paragraph block(s), which Markdown cannot represent.`]
+        : []),
+    ];
 
     return receipt("doc.replace_with_markdown", {
       workspaceId,
       docId: parsed.docId,
       replaced: true,
       warnings: mergeWarnings(parsedMarkdown.warnings, applyWarnings),
-      lossy: parsedMarkdown.lossy || applied.skippedCount > 0,
+      lossy: MARKDOWN_IMPORT_IS_LOSSY || parsedMarkdown.lossy || applied.skippedCount > 0,
       stats: {
         parsedBlocks: parsedMarkdown.operations.length,
         appliedBlocks: applied.appendedCount,
         skippedBlocks: applied.skippedCount,
+        removedBlocks: applied.removedCount,
+        removedEmptyParagraphs: applied.removedEmptyParagraphCount,
       },
     });
   };

--- a/tests/test-capabilities-fidelity.mjs
+++ b/tests/test-capabilities-fidelity.mjs
@@ -102,6 +102,11 @@ async function main() {
     expectEqual(capabilities?.server?.name, 'affine-mcp', 'capabilities server name');
     expectArray(capabilities?.docs?.canonicalBlockTypes, 'canonical block types');
     expectTruthy(capabilities.docs.canonicalBlockTypes.includes('attachment'), 'attachment block advertised');
+    expectEqual(capabilities?.docs?.markdownImport?.lossy, true, 'markdown import lossy flag');
+    expectArray(capabilities?.docs?.markdownImport?.knownLosses, 'markdown import known losses');
+    const markdownLosses = capabilities.docs.markdownImport.knownLosses.join(' ').toLowerCase();
+    expectTruthy(markdownLosses.includes('whitespace'), 'markdown whitespace normalization advertised');
+    expectTruthy(markdownLosses.includes('blank lines'), 'markdown blank-line handling advertised');
     expectEqual(capabilities?.docs?.highLevelAuthoring?.semanticPageComposer, true, 'semantic page composer flag');
     expectEqual(capabilities?.docs?.highLevelAuthoring?.nativeTemplateInstantiation, true, 'native template instantiation flag');
     expectEqual(capabilities?.docs?.highLevelAuthoring?.createDocWithPlacement, true, 'create doc placement flag');
@@ -117,6 +122,63 @@ async function main() {
     const workspace = await call('create_workspace', { name: testResourceName('cap-fidelity') });
     const workspaceId = workspace?.id;
     expectTruthy(workspaceId, 'create_workspace id');
+
+    const markdownInput = [
+      'First paragraph.',
+      '',
+      'Second paragraph after a blank line.',
+      '',
+      '- [ ]    item with four leading spaces in its text',
+      '- [ ] plain item',
+      '',
+      'Third paragraph.',
+    ].join('\n');
+    const imported = await call('create_doc_from_markdown', {
+      workspaceId,
+      title: 'Markdown Loss Reporting',
+      markdown: markdownInput,
+    });
+    expectTruthy(imported?.docId, 'create_doc_from_markdown docId');
+    expectEqual(imported?.lossy, true, 'create_doc_from_markdown lossy');
+    expectEqual(imported?.stats?.skippedBlocks, 0, 'create_doc_from_markdown skippedBlocks');
+    expectEqual(imported?.stats?.removedBlocks, 0, 'create_doc_from_markdown removedBlocks');
+
+    const importedRead = await call('read_doc', {
+      workspaceId,
+      docId: imported.docId,
+      includeMarkdown: true,
+    });
+    expectTruthy(
+      importedRead?.markdown?.includes('- [ ] item with four leading spaces in its text'),
+      'read_doc should expose normalized list-item whitespace',
+    );
+
+    const replacementDoc = await call('create_doc', {
+      workspaceId,
+      title: 'Markdown Replacement Loss Reporting',
+      content: '',
+    });
+    expectTruthy(replacementDoc?.docId, 'replacement create_doc docId');
+    const replaced = await call('replace_doc_with_markdown', {
+      workspaceId,
+      docId: replacementDoc.docId,
+      markdown: 'Replacement paragraph.',
+    });
+    expectEqual(replaced?.lossy, true, 'replace_doc_with_markdown lossy');
+    expectEqual(replaced?.stats?.skippedBlocks, 0, 'replace skippedBlocks');
+    expectTruthy(replaced?.stats?.removedBlocks >= 1, 'replace removedBlocks');
+    expectTruthy(replaced?.stats?.removedEmptyParagraphs >= 1, 'replace removedEmptyParagraphs');
+    expectTruthy(
+      replaced?.warnings?.some(warning => warning.includes('empty paragraph')),
+      'replace empty-paragraph warning',
+    );
+
+    const appended = await call('append_markdown', {
+      workspaceId,
+      docId: replacementDoc.docId,
+      markdown: 'Appended paragraph.',
+    });
+    expectEqual(appended?.lossy, true, 'append_markdown lossy');
 
     const doc = await call('create_doc', {
       workspaceId,

--- a/tests/test-suites.json
+++ b/tests/test-suites.json
@@ -95,6 +95,7 @@
     ],
     "e2e": [
       "test-database-creation.mjs",
+      "test-capabilities-fidelity.mjs",
       "test-database-cells.mjs",
       "test-database-linked-doc.mjs",
       "test-http-email-password.mjs",


### PR DESCRIPTION
## Summary
- align create, append, and replace Markdown receipts with the advertised lossy import capability
- document whitespace and blank-line normalization
- report replaced blocks and warn when empty paragraphs are removed

## Validation
- Node 24 CI (27/27 + package)
- comprehensive AFFiNE integration (15/15 + 109/109 tool checks)
- AFFiNE 0.27.4 E2E (23/23)
- Chromium UI verification (15/15)

Closes #303