### PR TITLE
feat: support minimal databases with title columns

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -130,7 +130,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | Tool | Purpose | Notes |
 | --- | --- | --- |
 | `compose_database_from_intent` | Create or enrich a database block from a high-level schema intent | Useful for project boards and structured tables |
-| `add_database_column` | Add a column to a database block | Supports `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date` |
+| `add_database_column` | Add a column to a database block | Supports one `title` column plus `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date` |
 | `add_database_row` | Add a row to a database block | Rich-text and title values accept strings or delta arrays |
 | `delete_database_row` | Delete a row by row block id | Destructive |
 | `read_database_columns` | Read schema metadata, types, options, and view mappings | Useful before edits |

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -130,7 +130,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | Tool | Purpose | Notes |
 | --- | --- | --- |
 | `compose_database_from_intent` | Create or enrich a database block from a high-level schema intent | Useful for project boards and structured tables |
-| `add_database_column` | Add a column to a database block | Supports one `title` column plus `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date` |
+| `add_database_column` | Add a column to a database block | Supports `title`, `rich-text`, `select`, `multi-select`, `number`, `checkbox`, `link`, and `date`; rejects a title addition when the current snapshot already contains one |
 | `add_database_row` | Add a row to a database block | Rich-text and title values accept strings or delta arrays |
 | `delete_database_row` | Delete a row by row block id | Destructive |
 | `read_database_columns` | Read schema metadata, types, options, and view mappings | Useful before edits |

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -7503,6 +7503,11 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const columnsRaw = view instanceof Y.Map ? view.get("columns") : view?.columns;
       const headerRaw = view instanceof Y.Map ? view.get("header") : view?.header;
       const groupByRaw = view instanceof Y.Map ? view.get("groupBy") : view?.groupBy;
+      const titleColumn = databaseRecordValue(headerRaw, "titleColumn");
+      const iconColumn = databaseRecordValue(headerRaw, "iconColumn");
+      const groupByColumnId = databaseRecordValue(groupByRaw, "columnId");
+      const groupByName = databaseRecordValue(groupByRaw, "name");
+      const groupByType = databaseRecordValue(groupByRaw, "type");
       const columns: DatabaseViewColumnDef[] = databaseArrayValues(columnsRaw)
         .map((entry: any) => {
           const columnId = entry instanceof Y.Map ? entry.get("id") : entry?.id;
@@ -7531,14 +7536,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         columnIds: columns.map(column => column.id),
         groupBy: groupByRaw
           ? {
-              columnId: typeof (groupByRaw as any)?.columnId === "string" ? (groupByRaw as any).columnId : null,
-              name: typeof (groupByRaw as any)?.name === "string" ? (groupByRaw as any).name : null,
-              type: typeof (groupByRaw as any)?.type === "string" ? (groupByRaw as any).type : null,
+              columnId: typeof groupByColumnId === "string" ? groupByColumnId : null,
+              name: typeof groupByName === "string" ? groupByName : null,
+              type: typeof groupByType === "string" ? groupByType : null,
             }
           : null,
         header: {
-          titleColumn: typeof (headerRaw as any)?.titleColumn === "string" ? (headerRaw as any).titleColumn : null,
-          iconColumn: typeof (headerRaw as any)?.iconColumn === "string" ? (headerRaw as any).iconColumn : null,
+          titleColumn: typeof titleColumn === "string" ? titleColumn : null,
+          iconColumn: typeof iconColumn === "string" ? iconColumn : null,
         },
       });
     });
@@ -7709,6 +7714,16 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       return value;
     }
     return [];
+  }
+
+  function databaseRecordValue(value: unknown, key: string): unknown {
+    if (value instanceof Y.Map) {
+      return value.get(key);
+    }
+    if (value && typeof value === "object") {
+      return (value as Record<string, unknown>)[key];
+    }
+    return undefined;
   }
 
   /** Find or create a select option for a column, mutating the column's data in place */

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -8463,15 +8463,28 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       // Also add the column to all existing views so it's visible
       const views = dbBlock.get("prop:views");
       if (views instanceof Y.Array) {
-        views.forEach((view: any) => {
+        const width = parsed.width || 200;
+        const plainViewColumn = { id: columnId, hide: false, width };
+        for (let viewIndex = 0; viewIndex < views.length; viewIndex += 1) {
+          const view = views.get(viewIndex);
           if (view instanceof Y.Map) {
             const viewColumns = view.get("columns");
             if (viewColumns instanceof Y.Array) {
               const viewCol = new Y.Map<any>();
               viewCol.set("id", columnId);
               viewCol.set("hide", false);
-              viewCol.set("width", parsed.width || 200);
+              viewCol.set("width", width);
               viewColumns.push([viewCol]);
+            } else if (Array.isArray(viewColumns)) {
+              view.set("columns", [...viewColumns, plainViewColumn]);
+            } else {
+              const createdColumns = new Y.Array<any>();
+              const viewCol = new Y.Map<any>();
+              viewCol.set("id", columnId);
+              viewCol.set("hide", false);
+              viewCol.set("width", width);
+              createdColumns.push([viewCol]);
+              view.set("columns", createdColumns);
             }
             if (parsed.type === "title") {
               const header = view.get("header");
@@ -8484,8 +8497,30 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
                 });
               }
             }
+            continue;
           }
-        });
+
+          if (view && typeof view === "object") {
+            const plainView = view as Record<string, any>;
+            const plainColumns = databaseArrayValues(plainView.columns).map(entry =>
+              entry instanceof Y.Map ? entry.toJSON() : entry
+            );
+            const header = plainView.header instanceof Y.Map
+              ? plainView.header.toJSON()
+              : plainView.header && typeof plainView.header === "object"
+                ? plainView.header
+                : {};
+            const updatedView = {
+              ...plainView,
+              columns: [...plainColumns, plainViewColumn],
+              ...(parsed.type === "title"
+                ? { header: { ...header, titleColumn: columnId } }
+                : {}),
+            };
+            views.delete(viewIndex, 1);
+            views.insert(viewIndex, [updatedView]);
+          }
+        }
       }
 
       const delta = Y.encodeStateAsUpdate(doc, prevSV);

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -8505,7 +8505,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "add_database_column",
     {
       title: "Add Database Column",
-      description: "Add a column to an existing AFFiNE database block. Supports title, rich-text, select, multi-select, number, checkbox, link, and date types. A database can have at most one title column.",
+      description: "Add a column to an existing AFFiNE database block. Supports title, rich-text, select, multi-select, number, checkbox, link, and date types. A title addition is rejected when the current database snapshot already has a title column.",
       inputSchema: {
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)"),
         docId: DocId.describe("Document ID containing the database"),

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -5599,7 +5599,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         supported: true,
         columnTypes: [...DATABASE_COLUMN_TYPE_VALUES],
         initialViewModes: [...APPEND_BLOCK_DATA_VIEW_MODE_VALUES],
-        advancedViewMutation: true,
+        advancedViewMutation: false,
         intentDrivenComposition: true,
         linkedDocRows: true,
       },

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -412,7 +412,7 @@ type DatabaseIntentPreset = {
   extraColumns: DatabaseIntentColumnSpec[];
   starterRows: DatabaseIntentSeedRow[];
 };
-const DATABASE_COLUMN_TYPE_VALUES = ["rich-text", "select", "multi-select", "number", "checkbox", "link", "date"] as const;
+const DATABASE_COLUMN_TYPE_VALUES = ["title", "rich-text", "select", "multi-select", "number", "checkbox", "link", "date"] as const;
 
 const MARKDOWN_IMPORT_KNOWN_LOSSES = [
   "Nested markdown lists are flattened during import.",
@@ -8417,6 +8417,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       if (existingDefs.some(c => c.name === parsed.name)) {
         throw new Error(`Column '${parsed.name}' already exists`);
       }
+      if (parsed.type === "title" && existingDefs.some(c => c.type === "title")) {
+        throw new Error("Database already has a title column");
+      }
 
       const columnId = generateId();
       const column = new Y.Map<any>();
@@ -8455,6 +8458,17 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
               viewCol.set("width", parsed.width || 200);
               viewColumns.push([viewCol]);
             }
+            if (parsed.type === "title") {
+              const header = view.get("header");
+              if (header instanceof Y.Map) {
+                header.set("titleColumn", columnId);
+              } else {
+                view.set("header", {
+                  ...(header && typeof header === "object" ? header : {}),
+                  titleColumn: columnId,
+                });
+              }
+            }
           }
         });
       }
@@ -8476,13 +8490,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "add_database_column",
     {
       title: "Add Database Column",
-      description: "Add a column to an existing AFFiNE database block. Supports rich-text, select, multi-select, number, checkbox, link, date types.",
+      description: "Add a column to an existing AFFiNE database block. Supports title, rich-text, select, multi-select, number, checkbox, link, and date types. A database can have at most one title column.",
       inputSchema: {
         workspaceId: z.string().optional().describe("Workspace ID (optional if default set)"),
         docId: DocId.describe("Document ID containing the database"),
         databaseBlockId: z.string().min(1).describe("Block ID of the affine:database block"),
         name: z.string().min(1).describe("Column display name"),
-        type: z.enum(["rich-text", "select", "multi-select", "number", "checkbox", "link", "date"]).default("rich-text").describe("Column type"),
+        type: z.enum(DATABASE_COLUMN_TYPE_VALUES).default("rich-text").describe("Column type"),
         options: z.array(z.string()).optional().describe("Predefined options for select/multi-select columns"),
         width: z.number().optional().describe("Column width in pixels (default 200)"),
       },

--- a/tests/playwright/verify-database.pw.ts
+++ b/tests/playwright/verify-database.pw.ts
@@ -146,13 +146,13 @@ test.describe.serial('AFFiNE Database Verification', () => {
       await expect(databaseBlock.first()).toBeVisible({ timeout: 30_000 });
 
       // Verify column headers
-      const columnNames = ['Name', 'Status', 'Priority', 'Done'];
+      const columnNames = ['Title', 'Status'];
       for (const colName of columnNames) {
         const colHeader = page.getByText(colName, { exact: true });
         await expect(colHeader.first()).toBeVisible({ timeout: 10_000 });
       }
 
-      // Verify row content — check that each row's Name value appears
+      // Verify row content — check that each row's title value appears
       const rowNames = ['Build feature', 'Write tests', 'Deploy release'];
       for (const name of rowNames) {
         const rowCell = page.getByText(name, { exact: true });

--- a/tests/test-capabilities-fidelity.mjs
+++ b/tests/test-capabilities-fidelity.mjs
@@ -116,7 +116,7 @@ async function main() {
     expectEqual(capabilities?.database?.intentDrivenComposition, true, 'intentDrivenComposition flag');
     expectArray(capabilities?.database?.columnTypes, 'database column types');
     expectTruthy(capabilities.database.columnTypes.includes('title'), 'database title column advertised');
-    expectEqual(capabilities?.database?.advancedViewMutation, true, 'advancedViewMutation flag');
+    expectEqual(capabilities?.database?.advancedViewMutation, false, 'advancedViewMutation flag');
     expectEqual(capabilities?.workspace?.ruleBackedCollections, true, 'ruleBackedCollections flag');
     expectEqual(capabilities?.workspace?.workspaceBlueprints, true, 'workspaceBlueprints flag');
     expectEqual(capabilities?.collaboration?.replyCreation, false, 'replyCreation flag');

--- a/tests/test-capabilities-fidelity.mjs
+++ b/tests/test-capabilities-fidelity.mjs
@@ -114,6 +114,8 @@ async function main() {
     expectEqual(capabilities?.docs?.edgelessCanvas?.surfaceElementMutation, true, 'surface element mutation flag');
     expectEqual(capabilities?.docs?.edgelessCanvas?.canvasReadback, true, 'edgeless canvas readback flag');
     expectEqual(capabilities?.database?.intentDrivenComposition, true, 'intentDrivenComposition flag');
+    expectArray(capabilities?.database?.columnTypes, 'database column types');
+    expectTruthy(capabilities.database.columnTypes.includes('title'), 'database title column advertised');
     expectEqual(capabilities?.database?.advancedViewMutation, true, 'advancedViewMutation flag');
     expectEqual(capabilities?.workspace?.ruleBackedCollections, true, 'ruleBackedCollections flag');
     expectEqual(capabilities?.workspace?.workspaceBlueprints, true, 'workspaceBlueprints flag');

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -40,7 +40,7 @@ function parseContent(result) {
   }
 }
 
-async function convertDatabaseHeadersToYMaps(workspaceId, docId, databaseBlockId) {
+async function mutateDatabaseViews(workspaceId, docId, databaseBlockId, mutate) {
   const { cookie } = await acquireCredentials(BASE_URL, EMAIL, PASSWORD);
   const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(`${BASE_URL}/graphql`), cookie, undefined);
   try {
@@ -67,6 +67,49 @@ async function convertDatabaseHeadersToYMaps(workspaceId, docId, databaseBlockId
 
     const views = databaseBlock.get('prop:views');
     if (!(views instanceof Y.Array)) throw new Error('Database views are not a Y.Array');
+    const changed = mutate(views);
+    if (changed === 0) throw new Error('Expected database views to change');
+
+    const delta = Y.encodeStateAsUpdate(doc, previousState);
+    await pushDocUpdate(socket, workspaceId, docId, Buffer.from(delta).toString('base64'));
+  } finally {
+    socket.disconnect();
+  }
+}
+
+async function seedDatabaseViewRepresentations(workspaceId, docId, databaseBlockId) {
+  await mutateDatabaseViews(workspaceId, docId, databaseBlockId, views => {
+    const yMapHeader = new Y.Map();
+    yMapHeader.set('titleColumn', null);
+    yMapHeader.set('iconColumn', null);
+
+    const yMapView = new Y.Map();
+    yMapView.set('id', `y-map-plain-columns-${databaseBlockId}`);
+    yMapView.set('name', 'Y.Map Plain Columns');
+    yMapView.set('mode', 'table');
+    yMapView.set('columns', []);
+    yMapView.set('filter', { type: 'group', op: 'and', conditions: [] });
+    yMapView.set('groupBy', null);
+    yMapView.set('sort', null);
+    yMapView.set('header', yMapHeader);
+
+    const plainView = {
+      id: `plain-view-${databaseBlockId}`,
+      name: 'Plain Object View',
+      mode: 'table',
+      columns: [],
+      filter: { type: 'group', op: 'and', conditions: [] },
+      groupBy: null,
+      sort: null,
+      header: { titleColumn: null, iconColumn: null },
+    };
+    views.push([yMapView, plainView]);
+    return 2;
+  });
+}
+
+async function convertDatabaseHeadersToYMaps(workspaceId, docId, databaseBlockId) {
+  await mutateDatabaseViews(workspaceId, docId, databaseBlockId, views => {
     let converted = 0;
     views.forEach(view => {
       if (!(view instanceof Y.Map)) return;
@@ -81,13 +124,8 @@ async function convertDatabaseHeadersToYMaps(workspaceId, docId, databaseBlockId
       view.set('header', yHeader);
       converted += 1;
     });
-    if (converted === 0) throw new Error('Expected at least one plain database header to convert');
-
-    const delta = Y.encodeStateAsUpdate(doc, previousState);
-    await pushDocUpdate(socket, workspaceId, docId, Buffer.from(delta).toString('base64'));
-  } finally {
-    socket.disconnect();
-  }
+    return converted;
+  });
 }
 
 async function main() {
@@ -258,6 +296,8 @@ async function main() {
     if (!state.databaseBlockId) throw new Error('append_block(database) did not return blockId');
     console.log(`  Database Block ID: ${state.databaseBlockId}`);
     await settle();
+    await seedDatabaseViewRepresentations(state.workspaceId, state.docId, state.databaseBlockId);
+    await settle();
 
     // 4. Add columns
     const columnDefs = [
@@ -313,16 +353,26 @@ async function main() {
       databaseBlockId: state.databaseBlockId,
     });
     const titleColumn = schema?.columns?.find(column => column.type === 'title');
+    const statusColumn = schema?.columns?.find(column => column.name === 'Status');
     if (!titleColumn?.id) throw new Error('read_database_columns did not return a title column');
+    if (statusColumn?.type !== 'select') {
+      throw new Error('read_database_columns did not return a select Status column');
+    }
     if (schema.titleColumnId !== titleColumn.id) {
       throw new Error(`titleColumnId mismatch: expected ${titleColumn.id}, got ${schema.titleColumnId}`);
     }
     if (schema.columnCount !== 2) {
       throw new Error(`expected a minimal two-column database, got ${schema.columnCount} columns`);
     }
-    for (const view of schema.views || []) {
+    if (!Array.isArray(schema.views) || schema.views.length !== 3) {
+      throw new Error(`expected all three database view representations, got ${JSON.stringify(schema.views)}`);
+    }
+    for (const view of schema.views) {
       if (view.header?.titleColumn !== titleColumn.id) {
         throw new Error(`view ${view.id} is not bound to title column ${titleColumn.id}`);
+      }
+      if (!view.columnIds?.includes(titleColumn.id) || !view.columnIds?.includes(statusColumn.id)) {
+        throw new Error(`view ${view.id} does not expose both minimal database columns`);
       }
     }
 

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -207,10 +207,8 @@ async function main() {
 
     // 4. Add columns
     const columnDefs = [
-      { name: 'Name', type: 'rich-text' },
+      { name: 'Title', type: 'title' },
       { name: 'Status', type: 'select', options: ['Active', 'Inactive', 'Pending'] },
-      { name: 'Priority', type: 'number' },
-      { name: 'Done', type: 'checkbox' },
     ];
 
     for (const colDef of columnDefs) {
@@ -233,11 +231,49 @@ async function main() {
       await settle();
     }
 
+    let duplicateTitleRejected = false;
+    try {
+      await call('add_database_column', {
+        workspaceId: state.workspaceId,
+        docId: state.docId,
+        databaseBlockId: state.databaseBlockId,
+        name: 'Another Title',
+        type: 'title',
+      });
+    } catch (err) {
+      if (!String(err?.message || err).includes('already has a title column')) {
+        throw err;
+      }
+      duplicateTitleRejected = true;
+    }
+    if (!duplicateTitleRejected) {
+      throw new Error('add_database_column accepted a second title column');
+    }
+
+    const schema = await call('read_database_columns', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      databaseBlockId: state.databaseBlockId,
+    });
+    const titleColumn = schema?.columns?.find(column => column.type === 'title');
+    if (!titleColumn?.id) throw new Error('read_database_columns did not return a title column');
+    if (schema.titleColumnId !== titleColumn.id) {
+      throw new Error(`titleColumnId mismatch: expected ${titleColumn.id}, got ${schema.titleColumnId}`);
+    }
+    if (schema.columnCount !== 2) {
+      throw new Error(`expected a minimal two-column database, got ${schema.columnCount} columns`);
+    }
+    for (const view of schema.views || []) {
+      if (view.header?.titleColumn !== titleColumn.id) {
+        throw new Error(`view ${view.id} is not bound to title column ${titleColumn.id}`);
+      }
+    }
+
     // 5. Add rows
     const rowDefs = [
-      { Name: 'Build feature', Status: 'Active', Priority: 1, Done: true },
-      { Name: 'Write tests', Status: 'Pending', Priority: 2, Done: false },
-      { Name: 'Deploy release', Status: 'Inactive', Priority: 3, Done: false },
+      { Title: 'Build feature', Status: 'Active' },
+      { Title: 'Write tests', Status: 'Pending' },
+      { Title: 'Deploy release', Status: 'Inactive' },
     ];
 
     for (const rowDef of rowDefs) {

--- a/tests/test-database-creation.mjs
+++ b/tests/test-database-creation.mjs
@@ -15,6 +15,10 @@ import { fileURLToPath } from 'node:url';
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import * as Y from 'yjs';
+
+import { acquireCredentials } from './acquire-credentials.mjs';
+import { connectWorkspaceSocket, joinWorkspace, loadDoc, pushDocUpdate, wsUrlFromGraphQLEndpoint } from '../dist/ws.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MCP_SERVER_PATH = path.resolve(__dirname, '..', 'dist', 'index.js');
@@ -33,6 +37,56 @@ function parseContent(result) {
     return JSON.parse(text);
   } catch {
     return text;
+  }
+}
+
+async function convertDatabaseHeadersToYMaps(workspaceId, docId, databaseBlockId) {
+  const { cookie } = await acquireCredentials(BASE_URL, EMAIL, PASSWORD);
+  const socket = await connectWorkspaceSocket(wsUrlFromGraphQLEndpoint(`${BASE_URL}/graphql`), cookie, undefined);
+  try {
+    await joinWorkspace(socket, workspaceId);
+    const snapshot = await loadDoc(socket, workspaceId, docId);
+    if (!snapshot.missing) throw new Error(`Document ${docId} not found`);
+
+    const doc = new Y.Doc();
+    Y.applyUpdate(doc, Buffer.from(snapshot.missing, 'base64'));
+    const previousState = Y.encodeStateVector(doc);
+    const blocks = doc.getMap('blocks');
+    let databaseBlock = blocks.get(databaseBlockId);
+    if (!(databaseBlock instanceof Y.Map)) {
+      for (const block of blocks.values()) {
+        if (block instanceof Y.Map && block.get('sys:id') === databaseBlockId) {
+          databaseBlock = block;
+          break;
+        }
+      }
+    }
+    if (!(databaseBlock instanceof Y.Map)) {
+      throw new Error(`Database block ${databaseBlockId} not found`);
+    }
+
+    const views = databaseBlock.get('prop:views');
+    if (!(views instanceof Y.Array)) throw new Error('Database views are not a Y.Array');
+    let converted = 0;
+    views.forEach(view => {
+      if (!(view instanceof Y.Map)) return;
+      const header = view.get('header');
+      if (header instanceof Y.Map) return;
+      const yHeader = new Y.Map();
+      if (header && typeof header === 'object') {
+        for (const [key, value] of Object.entries(header)) {
+          yHeader.set(key, value);
+        }
+      }
+      view.set('header', yHeader);
+      converted += 1;
+    });
+    if (converted === 0) throw new Error('Expected at least one plain database header to convert');
+
+    const delta = Y.encodeStateAsUpdate(doc, previousState);
+    await pushDocUpdate(socket, workspaceId, docId, Buffer.from(delta).toString('base64'));
+  } finally {
+    socket.disconnect();
   }
 }
 
@@ -249,6 +303,9 @@ async function main() {
     if (!duplicateTitleRejected) {
       throw new Error('add_database_column accepted a second title column');
     }
+
+    await convertDatabaseHeadersToYMaps(state.workspaceId, state.docId, state.databaseBlockId);
+    await settle();
 
     const schema = await call('read_database_columns', {
       workspaceId: state.workspaceId,


### PR DESCRIPTION
## Summary
- allow `add_database_column` to create one `title` column and bind it to every existing view
- reject duplicate title columns and advertise the supported type
- report `advancedViewMutation` as unsupported until a general view-mutation tool exists
- cover a minimal Title + Status database through AFFiNE readback and browser rendering

## Validation
- Node 24 CI (27/27 + package)
- comprehensive AFFiNE integration (15/15 + 109/109 tool checks)
- AFFiNE 0.27.4 E2E (23/23)
- Chromium UI verification (15/15)

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating a single `Title` column in databases.
  - Database views now use the title column for row headers.
  - Duplicate title columns are rejected with clear validation feedback.
  - Database capability details now accurately report supported column types.
  - Improved compatibility across database view formats and metadata representations.

- **Documentation**
  - Updated tool documentation to describe title-column support and duplicate-column restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->