### PR TITLE
feat: preserve block text inline attributes

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -61,7 +61,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | `find_doc_by_title` | Find documents whose title exactly matches a supplied title | Supports optional case-insensitive matching and a result limit |
 | `list_docs_by_tag` | List documents with a specific tag | |
 | `get_doc` | Read document metadata | |
-| `read_doc` | Read block content and plain text snapshot | WebSocket-backed; block rows include hierarchy-derived `parentId` values and `linkedDocIds` for inline LinkedPage references |
+| `read_doc` | Read block content and plain text snapshot | WebSocket-backed; block rows include formatting-preserving `deltas`, hierarchy-derived `parentId` values, and `linkedDocIds` for inline LinkedPage references |
 | `get_capabilities` | Inspect the server's high-level authoring and fidelity capabilities | Useful for adaptive clients |
 | `analyze_doc_fidelity` | Analyze how a document maps to Markdown and which native AFFiNE structures are lossy | Good before export or migration |
 | `list_children` | List direct child docs linked from a document | |
@@ -93,13 +93,27 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | `update_doc_title` | Rename a document in workspace metadata and in the page block | |
 | `update_doc_icon` | Set or clear a document's sidebar icon (emoji or named icon) | |
 | `get_doc_icon` | Read a document's current sidebar icon | |
-| `append_block` | Append canonical block types with validation and placement control | Supports text, media, embeds, database, and edgeless blocks. `frame`/`edgeless_text`/`note` accept `x`/`y`/`width`/`height`. `note` with `text` auto-creates a child paragraph. Bookmarks allow canonical web, mail, telephone, `affine://blob/<key>`, and `affine://doc/<id>` URLs; iframes require HTTP(S); provider embeds require HTTPS URLs on official hosts. URL validation does not make an outbound server fetch. Image and attachment `sourceId` values are exact opaque keys returned by `upload_blob`, including keys containing spaces or path separators. |
-| `update_block` | Partially update an existing text block without changing its id | Supports text, todo checked state, list style, and same-flavour paragraph/heading/quote conversions. Cross-flavour conversions are rejected because AFFiNE replaces the block id. |
+| `append_block` | Append canonical block types with validation and placement control | Inline-rich-text block content accepts a plain string or formatting-preserving delta array. Also supports media, embeds, database, and edgeless blocks. `frame`/`edgeless_text`/`note` accept `x`/`y`/`width`/`height`. `note` with `text` auto-creates a child paragraph. Bookmarks allow canonical web, mail, telephone, `affine://blob/<key>`, and `affine://doc/<id>` URLs; iframes require HTTP(S); provider embeds require HTTPS URLs on official hosts. URL validation does not make an outbound server fetch. Image and attachment `sourceId` values are exact opaque keys returned by `upload_blob`, including keys containing spaces or path separators. |
+| `update_block` | Partially update an existing text block without changing its id | `text` accepts a plain string or formatting-preserving delta array. Also supports todo checked state, list style, and same-flavour paragraph/heading/quote conversions. Cross-flavour conversions are rejected because AFFiNE replaces the block id. |
 | `move_block` | Move or reorder an existing block without changing its id | Reuses `append_block` placement (`parentId`, `beforeBlockId`, `afterBlockId`, or `index`) and rejects root moves and cycles. |
 | `create_semantic_page` | Create an AFFiNE-native page with an intentional section skeleton and native block composition | High-level authoring helper |
 | `append_semantic_section` | Append a semantic section to an existing page by heading title | High-level authoring helper |
 | `append_markdown` | Append Markdown content to an existing document | |
 | `replace_doc_with_markdown` | Replace the main note content with Markdown | Applies the replacement as an all-or-nothing local batch; empty output requires `allowEmpty: true` |
+
+#### Formatting-preserving block text
+
+For inline-rich-text blocks, `append_block.text` and `update_block.text` accept either a string or a delta array. Each delta requires a string `insert` and may contain arbitrary `attributes`; the server passes attributes through without restricting them to a fixed formatting vocabulary.
+
+```json
+[
+  { "insert": "plain " },
+  { "insert": "colored", "attributes": { "color": "var(--affine-text-highlight-foreground-blue)" } },
+  { "insert": " highlighted", "attributes": { "background": "var(--affine-text-highlight-yellow)" } }
+]
+```
+
+`read_doc` block rows and block snapshots returned by editing tools include both flattened `text` and formatting-preserving `deltas`. Markdown export still reports and drops inline attributes it cannot represent; use `deltas` for lossless block-level read/modify/write flows.
 
 ### Tags
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { generateKeyBetween, generateNKeysBetween } from "fractional-indexing";
@@ -335,6 +337,11 @@ export function removeEmbeddedLinkedDocumentBlocks(
 
 const WorkspaceId = z.string().min(1, "workspaceId required").describe("AFFiNE workspace id. Omit only when AFFINE_WORKSPACE_ID is configured.");
 const DocId = z.string().min(1, "docId required").describe("AFFiNE document id.");
+const TextDeltaInput = z.object({
+  insert: z.string(),
+  attributes: z.record(z.unknown()).optional(),
+});
+const RichTextInput = z.union([z.string(), z.array(TextDeltaInput)]);
 const MarkdownContent = z.string().min(1, "markdown required").describe("Markdown content to import, append, replace, or export-roundtrip.");
 const TagName = z.string().trim().min(1, "tag required").describe("Workspace tag name.");
 const TagIdOrName = z.string().trim().min(1, "tag required").describe("Workspace tag id or tag name.");
@@ -484,7 +491,7 @@ type AppendBlockInput = {
   workspaceId?: string;
   docId: string;
   type: string;
-  text?: string;
+  text?: string | TextDelta[];
   deltas?: TextDelta[];
   url?: string;
   pageId?: string;
@@ -1007,6 +1014,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       offset += delta.insert.length;
     }
     return yText;
+  }
+
+  function canonicalTextDeltas(content: TextDelta[]): TextDelta[] {
+    const doc = new Y.Doc();
+    const value = makeText(content);
+    doc.getMap("root").set("text", value);
+    return richTextValueToDeltas(value) ?? [];
   }
 
   /**
@@ -1885,6 +1899,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const latex = (parsed.latex ?? "").trim();
     const tableData = Array.isArray(parsed.tableData) ? parsed.tableData : undefined;
     const tableCellDeltas = Array.isArray(parsed.tableCellDeltas) ? parsed.tableCellDeltas : undefined;
+    const textDeltas = Array.isArray(parsed.text) ? parsed.text : parsed.deltas;
+    const plainText = Array.isArray(parsed.text)
+      ? parsed.text.map(delta => delta.insert).join("")
+      : parsed.text ?? "";
 
     const normalized: NormalizedAppendBlockInput = {
       workspaceId: parsed.workspaceId,
@@ -1892,7 +1910,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       type: typeInfo.type,
       strict,
       placement,
-      text: parsed.text ?? "",
+      text: plainText,
       url,
       pageId,
       iframeUrl,
@@ -1922,7 +1940,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       caption: parsed.caption,
       legacyType: typeInfo.legacyType,
       tableData,
-      deltas: parsed.deltas,
+      deltas: textDeltas,
       tableCellDeltas,
       childElementIds: Array.isArray(parsed.childElementIds) ? parsed.childElementIds : undefined,
       stackAfter: parsed.stackAfter,
@@ -2104,12 +2122,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const rawChecked = block.get("prop:checked");
     const rawLanguage = block.get("prop:language");
     const rawFlavour = block.get("sys:flavour");
+    const hasRichText = rawText instanceof Y.Text || typeof rawText === "string";
     return {
       id: blockId,
       parentId: resolveBlockParentId(blocks, blockId),
       flavour: typeof rawFlavour === "string" ? rawFlavour : null,
       type: typeof rawType === "string" ? rawType : null,
-      text: rawText instanceof Y.Text || typeof rawText === "string" ? asText(rawText) : null,
+      text: hasRichText ? asText(rawText) : null,
+      deltas: hasRichText ? richTextValueToDeltas(rawText) ?? [] : [],
       checked: typeof rawChecked === "boolean" ? rawChecked : null,
       language: typeof rawLanguage === "string" ? rawLanguage : null,
       childIds: childIdsFrom(block.get("sys:children")),
@@ -2376,7 +2396,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         if (normalized.caption) {
           block.set("prop:caption", normalized.caption);
         }
-        block.set("prop:text", makeText(content));
+        block.set("prop:text", makeText(normalized.deltas ?? content));
         return { blockId, block, flavour: "affine:code" };
       }
       case "divider": {
@@ -2752,7 +2772,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         block.set("prop:fontWeight", "regular");
         block.set("prop:textAlign", "left");
         const edgelessTextExtraBlocks: Array<{ blockId: string; block: Y.Map<any> }> = [];
-        if (content) {
+        if (content || normalized.deltas?.some(delta => delta.insert.length > 0)) {
           const paraId = generateId();
           const para = new Y.Map<any>();
           setSysFields(para, paraId, "affine:paragraph");
@@ -2796,7 +2816,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         block.set("prop:edgeless", edgeless);
         block.set("prop:comments", undefined);
         const noteExtraBlocks: Array<{ blockId: string; block: Y.Map<any> }> = [];
-        if (content) {
+        if (content || normalized.deltas?.some(delta => delta.insert.length > 0)) {
           const paraId = generateId();
           const para = new Y.Map<any>();
           setSysFields(para, paraId, "affine:paragraph");
@@ -5514,6 +5534,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         flavour: string | null;
         type: string | null;
         text: string | null;
+        deltas: TextDelta[];
         linkedDocIds: string[];
         checked: boolean | null;
         language: string | null;
@@ -5534,6 +5555,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const type = raw.get("prop:type");
         const propText = raw.get("prop:text");
         const textValue = asText(propText);
+        const deltas = richTextValueToDeltas(propText) ?? [];
         const linkedDocIds = extractLinkedPageRefs(propText);
         const language = raw.get("prop:language");
         const checked = raw.get("prop:checked");
@@ -5552,6 +5574,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           flavour: typeof flavour === "string" ? flavour : null,
           type: typeof type === "string" ? type : null,
           text: textValue.length > 0 ? textValue : null,
+          deltas,
           linkedDocIds,
           checked: typeof checked === "boolean" ? checked : null,
           language: typeof language === "string" ? language : null,
@@ -5604,7 +5627,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     "read_doc",
     {
       title: "Read Document Content",
-      description: "Read document block content via WebSocket snapshot (blocks + plain text). Set includeMarkdown: true to also get the rendered markdown — useful when you need to read content without a separate export_doc_markdown call.",
+      description: "Read document block content via WebSocket snapshot. Each block includes plain text and formatting-preserving deltas. Set includeMarkdown: true to also get rendered markdown, which can be lossy for unsupported inline attributes.",
       inputSchema: {
         workspaceId: WorkspaceId.optional(),
         docId: DocId,
@@ -6129,7 +6152,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     workspaceId?: string;
     docId: string;
     type: string;
-    text?: string;
+    text?: string | TextDelta[];
     url?: string;
     pageId?: string;
     iframeUrl?: string;
@@ -6217,7 +6240,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         workspaceId: WorkspaceId.optional(),
         docId: DocId,
         type: z.string().min(1).describe("Block type. Canonical: paragraph|heading|quote|list|code|divider|callout|latex|table|bookmark|image|attachment|embed_youtube|embed_github|embed_figma|embed_loom|embed_html|embed_linked_doc|embed_synced_doc|embed_iframe|database|data_view|surface_ref|frame|edgeless_text|note. Legacy aliases remain supported."),
-        text: z.string().optional().describe("Block content text"),
+        text: RichTextInput.optional().describe("Block content as plain text or a delta array that preserves inline attributes."),
         url: z.string()
           .refine(isSafeUrlInput, "url must be a safe absolute URL without control characters or embedded credentials")
           .optional()
@@ -9560,7 +9583,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     workspaceId?: string;
     docId: string;
     blockId: string;
-    text?: string;
+    text?: string | TextDelta[];
     checked?: boolean;
     type?: BlockEditType;
     style?: AppendBlockListStyle;
@@ -9669,9 +9692,15 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         }
       }
 
-      if (params.text !== undefined && asText(block.get("prop:text")) !== params.text) {
-        block.set("prop:text", makeText(params.text));
-        markChanged("text");
+      if (params.text !== undefined) {
+        const rawText = block.get("prop:text");
+        const textMatches = typeof params.text === "string"
+          ? asText(rawText) === params.text
+          : isDeepStrictEqual(richTextValueToDeltas(rawText) ?? [], canonicalTextDeltas(params.text));
+        if (!textMatches) {
+          block.set("prop:text", makeText(params.text));
+          markChanged("text");
+        }
       }
 
       if (changed.length > 0) {
@@ -10317,7 +10346,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         workspaceId: WorkspaceId.optional(),
         docId: DocId,
         blockId: z.string().min(1).describe("Block id to update."),
-        text: z.string().optional().describe("Replacement block text. Omit to preserve the current text."),
+        text: RichTextInput.optional().describe("Replacement block text. A delta array preserves inline attributes. Omit to preserve the current text."),
         checked: z.boolean().optional().describe("Todo checked state. Only valid for a list whose resulting style is todo."),
         type: BlockEditType.optional().describe("Resulting logical block type."),
         style: AppendBlockListStyle.optional().describe("Resulting list style. Only valid for list blocks."),

--- a/tests/playwright/verify-block-editing.pw.ts
+++ b/tests/playwright/verify-block-editing.pw.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -17,6 +17,9 @@ interface TestState {
   taskBlockId: string;
   taskText: string;
   oldTaskText: string;
+  inboxHeadingText: string;
+  coloredSegment: string;
+  highlightedSegment: string;
   doneHeadingText: string;
   deletedText: string;
   error?: string;
@@ -25,6 +28,34 @@ interface TestState {
 let state: TestState;
 const password = process.env.AFFINE_ADMIN_PASSWORD!;
 if (!password) throw new Error('AFFINE_ADMIN_PASSWORD env var required');
+
+async function segmentStyles(block: Locator, segment: string) {
+  return block.evaluate((root, target) => {
+    const walker = root.ownerDocument.createTreeWalker(root, 4);
+    let textNode = walker.nextNode();
+    while (textNode && !textNode.textContent?.includes(target)) {
+      textNode = walker.nextNode();
+    }
+    if (!textNode) return null;
+
+    const rootColor = getComputedStyle(root).color;
+    let color = rootColor;
+    let backgroundColor = 'rgba(0, 0, 0, 0)';
+    const inlineStyles: string[] = [];
+    let element = textNode.parentElement;
+    while (element && element !== root) {
+      const computed = getComputedStyle(element);
+      const inlineStyle = element.getAttribute('style');
+      if (inlineStyle) inlineStyles.push(inlineStyle);
+      if (computed.color !== rootColor) color = computed.color;
+      if (computed.backgroundColor !== 'rgba(0, 0, 0, 0)' && computed.backgroundColor !== 'transparent') {
+        backgroundColor = computed.backgroundColor;
+      }
+      element = element.parentElement;
+    }
+    return { rootColor, color, backgroundColor, inlineStyles };
+  }, segment);
+}
 
 test.beforeAll(() => {
   if (!fs.existsSync(STATE_PATH)) {
@@ -59,6 +90,17 @@ test.describe.serial('AFFiNE block editing verification', () => {
       await expect(taskBlock.locator('.affine-list--checked')).toHaveCount(1);
       await expect(page.getByText(state.oldTaskText, { exact: true })).toHaveCount(0);
       await expect(page.getByText(state.deletedText, { exact: true })).toHaveCount(0);
+
+      const inboxHeading = page.locator('affine-paragraph').filter({ hasText: state.inboxHeadingText }).first();
+      await expect(inboxHeading).toBeVisible({ timeout: 30_000 });
+      const coloredStyles = await segmentStyles(inboxHeading, state.coloredSegment);
+      expect(coloredStyles, 'colored text segment was not rendered').not.toBeNull();
+      expect(coloredStyles?.color).not.toBe(coloredStyles?.rootColor);
+
+      const highlightedStyles = await segmentStyles(taskBlock, state.highlightedSegment);
+      expect(highlightedStyles, 'highlighted text segment was not rendered').not.toBeNull();
+      expect(highlightedStyles?.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+      expect(highlightedStyles?.backgroundColor).not.toBe('transparent');
 
       const renderedText = await page.locator('affine-paragraph, affine-list').allTextContents();
       const doneIndex = renderedText.findIndex(value => value.includes(state.doneHeadingText));

--- a/tests/test-block-editing.mjs
+++ b/tests/test-block-editing.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { testResourceName, testTempPath } from './require-destructive-test-safety.mjs';
 
+import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -64,11 +65,54 @@ async function main() {
     email: EMAIL,
     workspaceId: null,
     docId: null,
+    inboxHeadingBlockId: null,
     taskBlockId: null,
+    quoteBlockId: null,
+    codeBlockId: null,
     taskText: 'Ship the verified release',
     oldTaskText: 'Ship the draft release',
+    inboxHeadingText: 'Inbox priority',
+    quoteText: 'Review the highlighted contract',
+    codeText: 'const status = "highlighted";',
+    coloredSegment: 'priority',
+    highlightedSegment: 'verified',
     doneHeadingText: 'Done',
     deletedText: 'Remove this temporary note',
+    inboxHeadingDeltas: [
+      { insert: 'Inbox ' },
+      { insert: 'priority', attributes: { color: 'var(--affine-text-highlight-foreground-blue)' } },
+    ],
+    oldTaskDeltas: [
+      { insert: 'Ship the ' },
+      { insert: 'draft', attributes: { background: 'var(--affine-text-highlight-yellow)' } },
+      { insert: ' release' },
+    ],
+    taskDeltas: [
+      { insert: 'Ship the ' },
+      {
+        insert: 'verified',
+        attributes: {
+          color: 'var(--affine-text-highlight-foreground-blue)',
+          background: 'var(--affine-text-highlight-purple)',
+        },
+      },
+      { insert: ' release' },
+    ],
+    quoteDeltas: [
+      { insert: 'Review the ' },
+      { insert: 'highlighted', attributes: { background: 'var(--affine-text-highlight-yellow)' } },
+      { insert: ' contract' },
+    ],
+    codeDeltas: [
+      { insert: 'const status = ' },
+      { insert: '"highlighted"', attributes: { futureInlineAttribute: { version: 1 } } },
+      { insert: ';' },
+    ],
+    deletedDeltas: [
+      { insert: 'Remove this ' },
+      { insert: 'temporary', attributes: { color: 'var(--affine-text-highlight-foreground-red)' } },
+      { insert: ' note' },
+    ],
   };
   const client = new Client({ name: 'affine-mcp-block-editing-test', version: '1.0.0' });
   const transport = new StdioClientTransport({
@@ -135,22 +179,42 @@ async function main() {
     state.docId = document?.docId;
     expectTruthy(state.docId, 'create_doc docId');
 
-    await call('append_block', {
+    const inboxHeading = await call('append_block', {
       workspaceId: state.workspaceId,
       docId: state.docId,
       type: 'heading',
       level: 2,
-      text: 'Inbox',
+      text: state.inboxHeadingDeltas,
     });
+    state.inboxHeadingBlockId = inboxHeading?.blockId;
+    expectTruthy(state.inboxHeadingBlockId, 'append_block rich-text heading id');
     const task = await call('append_block', {
       workspaceId: state.workspaceId,
       docId: state.docId,
       type: 'list',
       style: 'bulleted',
-      text: state.oldTaskText,
+      text: state.oldTaskDeltas,
     });
     state.taskBlockId = task?.blockId;
     expectTruthy(state.taskBlockId, 'append_block task id');
+
+    const quote = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'quote',
+      text: state.quoteDeltas,
+    });
+    state.quoteBlockId = quote?.blockId;
+    expectTruthy(state.quoteBlockId, 'append_block rich-text quote id');
+
+    const code = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'code',
+      text: state.codeDeltas,
+    });
+    state.codeBlockId = code?.blockId;
+    expectTruthy(state.codeBlockId, 'append_block rich-text code id');
 
     const doneHeading = await call('append_block', {
       workspaceId: state.workspaceId,
@@ -165,7 +229,7 @@ async function main() {
       workspaceId: state.workspaceId,
       docId: state.docId,
       type: 'paragraph',
-      text: state.deletedText,
+      text: state.deletedDeltas,
     });
     expectTruthy(temporary?.blockId, 'append_block temporary id');
 
@@ -193,6 +257,7 @@ async function main() {
     });
     expectEqual(checked?.blockId, state.taskBlockId, 'update_block checked id');
     expectEqual(checked?.block?.text, state.oldTaskText, 'update_block preserves omitted text');
+    assert.deepEqual(checked?.block?.deltas, state.oldTaskDeltas, 'update_block preserves omitted text deltas');
     expectEqual(checked?.block?.type, 'todo', 'update_block list style');
     expectEqual(checked?.block?.checked, true, 'update_block checked state');
 
@@ -200,11 +265,31 @@ async function main() {
       workspaceId: state.workspaceId,
       docId: state.docId,
       blockId: state.taskBlockId,
-      text: state.taskText,
+      text: state.taskDeltas,
     });
     expectEqual(renamed?.blockId, state.taskBlockId, 'update_block text id');
     expectEqual(renamed?.block?.text, state.taskText, 'update_block text');
+    assert.deepEqual(renamed?.previous?.deltas, state.oldTaskDeltas, 'update_block previous text deltas');
+    assert.deepEqual(renamed?.block?.deltas, state.taskDeltas, 'update_block replacement text deltas');
     expectEqual(renamed?.block?.checked, true, 'update_block preserves omitted checked state');
+
+    const unchangedDeltas = await call('update_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.taskBlockId,
+      text: state.taskDeltas,
+    });
+    expectEqual(unchangedDeltas?.updated, false, 'update_block identical deltas no-op');
+    assert.deepEqual(unchangedDeltas?.changed, [], 'update_block identical deltas changed fields');
+
+    const unchangedPlainText = await call('update_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.taskBlockId,
+      text: state.taskText,
+    });
+    expectEqual(unchangedPlainText?.updated, false, 'update_block identical plain text no-op');
+    assert.deepEqual(unchangedPlainText?.block?.deltas, state.taskDeltas, 'plain-text no-op preserves existing attributes');
 
     await expectCallError('update_block', {
       workspaceId: state.workspaceId,
@@ -219,6 +304,7 @@ async function main() {
     const unchangedTask = afterRejectedUpdate?.blocks?.find(block => block.id === state.taskBlockId);
     expectTruthy(unchangedTask, 'rejected update preserves block id');
     expectEqual(unchangedTask.text, state.taskText, 'rejected update preserves text');
+    assert.deepEqual(unchangedTask.deltas, state.taskDeltas, 'rejected update preserves text deltas');
     expectEqual(unchangedTask.type, 'todo', 'rejected update preserves type');
     expectEqual(unchangedTask.checked, true, 'rejected update preserves checked state');
 
@@ -264,6 +350,7 @@ async function main() {
     expectEqual(converted?.blockId, temporary.blockId, 'update_block type id');
     expectEqual(converted?.block?.type, 'h3', 'update_block heading level');
     expectEqual(converted?.block?.text, state.deletedText, 'update_block preserves text during type change');
+    assert.deepEqual(converted?.block?.deltas, state.deletedDeltas, 'update_block preserves deltas during type change');
 
     const moved = await call('move_block', {
       workspaceId: state.workspaceId,
@@ -274,6 +361,7 @@ async function main() {
     expectEqual(moved?.blockId, state.taskBlockId, 'move_block id');
     expectEqual(moved?.moved, true, 'move_block moved');
     expectEqual(moved?.block?.parentId, moved?.toParentId, 'move_block parent receipt');
+    assert.deepEqual(moved?.block?.deltas, state.taskDeltas, 'move_block snapshot preserves text deltas');
 
     const deleted = await call('delete_block', {
       workspaceId: state.workspaceId,
@@ -284,6 +372,7 @@ async function main() {
     expectEqual(deleted?.deletedBlock?.id, temporary.blockId, 'delete_block snapshot id');
     expectEqual(deleted?.deletedBlock?.type, 'h3', 'delete_block snapshot type');
     expectEqual(deleted?.deletedBlock?.text, state.deletedText, 'delete_block snapshot text');
+    assert.deepEqual(deleted?.deletedBlock?.deltas, state.deletedDeltas, 'delete_block snapshot deltas');
     expectEqual(deleted?.deletedBlocks?.length, 1, 'delete_block snapshot count');
 
     const read = await call('read_doc', {
@@ -295,12 +384,28 @@ async function main() {
     const taskBlock = blocks.find(block => block.id === state.taskBlockId);
     expectTruthy(taskBlock, 'read_doc task block');
     expectEqual(taskBlock.text, state.taskText, 'read_doc updated text');
+    assert.deepEqual(taskBlock.deltas, state.taskDeltas, 'read_doc updated text deltas');
     expectEqual(taskBlock.checked, true, 'read_doc updated checked state');
     expectEqual(taskBlock.type, 'todo', 'read_doc todo type');
     expectEqual(blocks.some(block => block.id === temporary.blockId), false, 'read_doc deleted block absence');
 
     const doneBlock = blocks.find(block => block.id === doneHeading.blockId);
     expectTruthy(doneBlock, 'read_doc done heading');
+    assert.deepEqual(
+      blocks.find(block => block.id === state.inboxHeadingBlockId)?.deltas,
+      state.inboxHeadingDeltas,
+      'read_doc heading deltas',
+    );
+    assert.deepEqual(
+      blocks.find(block => block.id === state.quoteBlockId)?.deltas,
+      state.quoteDeltas,
+      'read_doc quote deltas',
+    );
+    assert.deepEqual(
+      blocks.find(block => block.id === state.codeBlockId)?.deltas,
+      state.codeDeltas,
+      'read_doc code deltas with arbitrary future attributes',
+    );
     expectEqual(taskBlock.parentId, doneBlock.parentId, 'moved task and heading parent');
     const parent = blocks.find(block => block.id === taskBlock.parentId);
     expectTruthy(parent, 'read_doc moved task parent');

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -90,6 +90,38 @@ function toolSchema(name) {
   return z.object(fields);
 }
 
+const highlightedText = [
+  { insert: "plain " },
+  {
+    insert: "colored",
+    attributes: {
+      color: "var(--affine-text-highlight-foreground-blue)",
+      background: "var(--affine-text-highlight-yellow)",
+      futureAttribute: { enabled: true },
+    },
+  },
+];
+for (const [name, required] of [
+  ["append_block", { docId: "doc-1", type: "paragraph" }],
+  ["update_block", { docId: "doc-1", blockId: "block-1" }],
+]) {
+  const schema = toolSchema(name);
+  const parsed = schema.safeParse({ ...required, text: highlightedText });
+  assert.equal(parsed.success, true, `${name} must accept formatting-preserving text deltas`);
+  assert.deepEqual(parsed.data.text, highlightedText, `${name} must preserve arbitrary inline attributes`);
+  for (const invalidText of [
+    { insert: "not-an-array" },
+    [{ insert: 42 }],
+    [{ insert: "invalid attributes", attributes: [] }],
+  ]) {
+    assert.equal(
+      schema.safeParse({ ...required, text: invalidText }).success,
+      false,
+      `${name} must reject malformed text deltas`,
+    );
+  }
+}
+
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);
 assert.equal(toolSchema("search_docs").safeParse({ query: "x", limit: -1 }).success, false);
 assert.equal(toolSchema("list_workspace_tree").safeParse({ depth: 21 }).success, false);


### PR DESCRIPTION
## Summary
- accept plain strings or formatting-preserving delta arrays in `append_block` and `update_block`
- preserve arbitrary inline attributes through BlockSuite Y.Text storage and expose canonical `deltas` in `read_doc` and block-editing snapshots
- cover color, background, future attributes, malformed input, idempotent updates, move/delete receipts, and real AFFiNE UI rendering
- document the lossless delta workflow and the intentionally lossy Markdown boundary

## Root cause
BlockSuite already stores block text as Y.Text with arbitrary delta attributes, but the MCP write schemas accepted strings only and the main read and receipt paths flattened rich text to plain text.

## Validation
- `npm run build`
- `npm run test:input-contracts`
- `npm run test:e2e` — 24 integration tests and 17 Playwright tests passed
- `npm run test:comprehensive` — 16 focused tests and 111/111 comprehensive checks passed
- all 26 fast tests other than the known baseline case passed
- `npm run pack:check`
- `git diff --check`
- repository Hangul scan

## Known baseline failure
`npm run ci` stops in `test-http-runtime-safety.mjs` because the session activity request returns 404 instead of the test expectation of 200. The same test and response were reproduced from an unchanged `origin/develop` worktree, so this is not introduced by this PR.

Fixes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for formatting-preserving rich text when creating and updating document blocks.
  * Document reads now include both plain text and formatting details.
  * Added support for inline colors, highlights, and other text attributes.

* **Documentation**
  * Added guidance and examples for using formatting-preserving block text.
  * Clarified how formatting appears in document reads and Markdown exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->