### PR TITLE
Release v3.4.1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,21 @@ jobs:
           CONTAINER_UID="$(docker run --rm --entrypoint id affine-mcp-server:pr-smoke -u)"
           test -n "$CONTAINER_UID"
           test "$CONTAINER_UID" != "0"
+          CONTAINER_ID="$(docker run -d affine-mcp-server:pr-smoke)"
+          trap 'docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
+          for attempt in {1..40}; do
+            STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$CONTAINER_ID")"
+            if [ "$STATUS" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$STATUS" = "unhealthy" ] || [ "$STATUS" = "exited" ]; then
+              docker logs "$CONTAINER_ID"
+              exit 1
+            fi
+            sleep 2
+          done
+          docker inspect "$CONTAINER_ID"
+          exit 1
 
   build-and-push-release:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,8 @@ jobs:
           CONTAINER_UID="$(docker run --rm --entrypoint id affine-mcp-server:pr-smoke -u)"
           test -n "$CONTAINER_UID"
           test "$CONTAINER_UID" != "0"
-          CONTAINER_ID="$(docker run -d affine-mcp-server:pr-smoke)"
+          SMOKE_TOKEN="$(openssl rand -hex 32)"
+          CONTAINER_ID="$(docker run -d -e AFFINE_MCP_HTTP_TOKEN="$SMOKE_TOKEN" affine-mcp-server:pr-smoke)"
           trap 'docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true' EXIT
           for attempt in {1..40}; do
             STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$CONTAINER_ID")"
@@ -67,6 +68,7 @@ jobs:
             fi
             sleep 2
           done
+          echo "Container did not become healthy after $attempt attempts"
           docker inspect "$CONTAINER_ID"
           exit 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Markdown rich-text operations now use one canonical content input, so strict divider validation cannot accept and then discard non-empty delta content.
-- The container now starts the HTTP server when run without arguments instead of inheriting the Node base image command and exiting; PR image checks now wait for a healthy container.
+- The container now starts the HTTP server when run without arguments instead of inheriting the Node base image command and exiting; PR image checks now supply the required bearer token and wait for a healthy container.
 
 ## [3.4.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Markdown rich-text operations now use one canonical content input, so strict divider validation cannot accept and then discard non-empty delta content.
+- The container now starts the HTTP server when run without arguments instead of inheriting the Node base image command and exiting; PR image checks now wait for a healthy container.
 
 ## [3.4.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-08-27
+
+### Fixed
+- Markdown rich-text operations now use one canonical content input, so strict divider validation cannot accept and then discard non-empty delta content.
+
 ## [3.4.0] - 2026-08-27
 
 ### Added
@@ -712,6 +717,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.4.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.1
 [3.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.0
 [3.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.3.0
 [3.2.2]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.2.2
@@ -747,4 +753,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.4.1...HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget -qO- http://127.0.0.1:${PORT}/healthz || exit 1
 
 ENTRYPOINT ["node", "bin/affine-mcp"]
+CMD ["--"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.4.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.4.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## Version 3.4.1 (2026-08-27)
+
+### Highlights
+- Strict divider validation now evaluates the same canonical rich-text content that block creation would use, preventing non-empty internal delta content from being silently discarded.
+
+### What Changed
+- Removed the redundant internal delta input alongside `AppendBlockInput.text`.
+- Markdown operations now pass formatting-preserving deltas through the canonical text input whenever deltas are available.
+- Existing rich-text import and divider validation paths cover the unified contract without adding a second public input.
+
+### Compatibility
+- The canonical MCP surface remains at 96 tools; no public input or output contract changed.
+- Plain-string and formatting-preserving delta inputs remain supported through `append_block.text` and `update_block.text`.
+- Node.js 20.18.1 or newer remains required.
+- Release behavior is validated against AFFiNE 0.27.4.
+
+### Validation Evidence
+- Node.js 20.20.2, 22.23.2, 24.20.0, and 26.7.0: clean `npm ci && npm run ci`
+- `npm audit --audit-level=low` with zero vulnerabilities
+- `AFFINE_REVISION=0.27.4 npm run test:comprehensive` (16 focused integrations; 111/111 comprehensive checks)
+- `AFFINE_REVISION=0.27.4 npm run test:e2e` (24 integration tests; 17 Playwright tests)
+- Isolated database UI row integration coverage
+- Packed-tarball install, CLI, and 96-tool discovery smoke on Node.js 20 and 26
+- `npm publish --dry-run --access public --ignore-scripts`
+- Linux/amd64 Docker build, version check, non-root UID check, and healthcheck smoke
+
 ## Version 3.4.0 (2026-08-27)
 
 ### Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,14 +4,14 @@
 
 ### Highlights
 - Strict divider validation now evaluates the same canonical rich-text content that block creation would use, preventing non-empty internal delta content from being silently discarded.
-- The published container now starts correctly with the documented argument-free `docker run` command and is covered by a real healthcheck smoke test.
+- The published container now starts correctly with the documented argument-free `docker run` command and required bearer token, and is covered by a real healthcheck smoke test.
 
 ### What Changed
 - Removed the redundant internal delta input alongside `AppendBlockInput.text`.
 - Markdown operations now pass formatting-preserving deltas through the canonical text input whenever deltas are available.
 - Existing rich-text import and divider validation paths cover the unified contract without adding a second public input.
 - Reset the Node base image command so the MCP HTTP server starts by default, while preserving explicit CLI commands such as `--version`.
-- Extended Docker PR validation from build, version, and UID checks to a healthy default-start container check.
+- Extended Docker PR validation from build, version, and UID checks to an authenticated, healthy default-start container check.
 
 ### Compatibility
 - The canonical MCP surface remains at 96 tools; no public input or output contract changed.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,14 @@
 
 ### Highlights
 - Strict divider validation now evaluates the same canonical rich-text content that block creation would use, preventing non-empty internal delta content from being silently discarded.
+- The published container now starts correctly with the documented argument-free `docker run` command and is covered by a real healthcheck smoke test.
 
 ### What Changed
 - Removed the redundant internal delta input alongside `AppendBlockInput.text`.
 - Markdown operations now pass formatting-preserving deltas through the canonical text input whenever deltas are available.
 - Existing rich-text import and divider validation paths cover the unified contract without adding a second public input.
+- Reset the Node base image command so the MCP HTTP server starts by default, while preserving explicit CLI commands such as `--version`.
+- Extended Docker PR validation from build, version, and UID checks to a healthy default-start container check.
 
 ### Compatibility
 - The canonical MCP surface remains at 96 tools; no public input or output contract changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -492,7 +492,6 @@ type AppendBlockInput = {
   docId: string;
   type: string;
   text?: string | TextDelta[];
-  deltas?: TextDelta[];
   url?: string;
   pageId?: string;
   iframeUrl?: string;
@@ -1896,7 +1895,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const latex = (parsed.latex ?? "").trim();
     const tableData = Array.isArray(parsed.tableData) ? parsed.tableData : undefined;
     const tableCellDeltas = Array.isArray(parsed.tableCellDeltas) ? parsed.tableCellDeltas : undefined;
-    const textDeltas = Array.isArray(parsed.text) ? parsed.text : parsed.deltas;
+    const textDeltas = Array.isArray(parsed.text) ? parsed.text : undefined;
     const plainText = Array.isArray(parsed.text)
       ? parsed.text.map(delta => delta.insert).join("")
       : parsed.text ?? "";
@@ -3051,9 +3050,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           workspaceId,
           docId,
           type: "heading",
-          text: operation.text,
+          text: operation.deltas ?? operation.text,
           level: operation.level,
-          deltas: operation.deltas,
           strict,
           placement,
         };
@@ -3062,8 +3060,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           workspaceId,
           docId,
           type: "paragraph",
-          text: operation.text,
-          deltas: operation.deltas,
+          text: operation.deltas ?? operation.text,
           strict,
           placement,
         };
@@ -3072,8 +3069,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           workspaceId,
           docId,
           type: "quote",
-          text: operation.text,
-          deltas: operation.deltas,
+          text: operation.deltas ?? operation.text,
           strict,
           placement,
         };
@@ -3082,8 +3078,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           workspaceId,
           docId,
           type: "callout",
-          text: operation.text,
-          deltas: operation.deltas,
+          text: operation.deltas ?? operation.text,
           strict,
           placement,
         };
@@ -3092,10 +3087,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           workspaceId,
           docId,
           type: "list",
-          text: operation.text,
+          text: operation.deltas ?? operation.text,
           style: operation.style,
           checked: operation.checked,
-          deltas: operation.deltas,
           strict,
           placement,
         };

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "3.4.1",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary

- unify the internal append-block rich-text input so divider validation and persisted content use the same canonical value
- reset the inherited Node image command so the container starts the HTTP MCP server when no CLI command is supplied
- extend Docker PR validation to require an authenticated, healthy default-start container
- prepare package, manifest, changelog, README, and release notes for v3.4.1

This patch release supersedes #317.

## Validation

- Node.js 20.20.2, 22.23.2, 24.20.0, and 26.7.0: clean `npm ci && npm run ci`
- `npm audit --audit-level=low`: zero vulnerabilities
- `actionlint .github/workflows/docker.yml`
- `AFFINE_REVISION=0.27.4 npm run test:e2e`: 24 integrations and 17 Playwright tests
- `AFFINE_REVISION=0.27.4 npm run test:comprehensive`: 16 focused integrations and 111/111 MCP checks
- isolated database UI row regression
- packed-tarball install, CLI, and 96-tool discovery on Node.js 20.20.2 and 26.7.0
- `npm publish --dry-run --access public --ignore-scripts`
- Linux/amd64 Docker build, v3.4.1 version, non-root UID, authenticated default startup, and healthy container smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containers now start the HTTP server by default when launched without arguments.
  * Container health checks verify authenticated startup and report failures with diagnostic logs.

* **Bug Fixes**
  * Improved Markdown rich-text handling to preserve formatting and enforce strict divider validation.
  * Removed inconsistent handling of duplicate rich-text inputs.

* **Documentation**
  * Added Version 3.4.1 release notes and updated version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->