### PR TITLE
fix: accept table cell contents on append_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `append_block` now accepts `tableData` and `tableCellDeltas`, so a table created with cell contents is no longer silently empty; previously the schema stripped both fields and only `append_markdown` could fill cells.
+
 ## [3.4.1] - 2026-08-27
 
 ### Fixed

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -6268,6 +6268,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         embed: z.boolean().optional().describe("Attachment embed mode"),
         rows: z.number().int().min(1).max(20).optional().describe("Table row count"),
         columns: z.number().int().min(1).max(20).optional().describe("Table column count"),
+        tableData: z.array(z.array(z.string())).optional().describe("Plain-text cell contents for type='table', as rows of columns. Row count must equal `rows` and every row length must equal `columns`. Omit to create an empty table."),
+        tableCellDeltas: z.array(z.array(z.array(TextDeltaInput))).optional().describe("Rich-text deltas per cell for type='table', parallel to `tableData` as [row][column][delta]. A cell with deltas here overrides the plain text at the same position in `tableData`."),
         latex: z.string().optional().describe("Latex expression"),
         level: z.number().int().min(1).max(6).optional().describe("Heading level for type=heading"),
         style: AppendBlockListStyle.optional().describe("List style for type=list"),

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1839,10 +1839,22 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           }
         }
       }
+      if (normalized.tableCellDeltas) {
+        if (!Array.isArray(normalized.tableCellDeltas) || normalized.tableCellDeltas.length !== normalized.rows) {
+          throw new Error("tableCellDeltas row count must match table rows.");
+        }
+        for (const row of normalized.tableCellDeltas) {
+          if (!Array.isArray(row) || row.length !== normalized.columns) {
+            throw new Error("tableCellDeltas column count must match table columns.");
+          }
+        }
+      }
     } else if ((raw.rows !== undefined || raw.columns !== undefined) && normalized.strict) {
       throw new Error("The 'rows'/'columns' fields can only be used with type='table'.");
     } else if (raw.tableData !== undefined && normalized.strict) {
       throw new Error("The 'tableData' field can only be used with type='table'.");
+    } else if (raw.tableCellDeltas !== undefined && normalized.strict) {
+      throw new Error("The 'tableCellDeltas' field can only be used with type='table'.");
     }
 
     if (normalized.type !== "database" && normalized.type !== "data_view" && raw.viewMode !== undefined && normalized.strict) {

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -124,6 +124,32 @@ for (const [name, required] of [
   }
 }
 
+const appendBlockSchema = toolSchema("append_block");
+const tableCell = { docId: "doc-1", type: "table", rows: 1, columns: 2 };
+const tableData = [["left", "right"]];
+const tableCellDeltas = [[[{ insert: "left" }], [{ insert: "right", attributes: { bold: true } }]]];
+const parsedTable = appendBlockSchema.safeParse({ ...tableCell, tableData, tableCellDeltas });
+assert.equal(parsedTable.success, true, "append_block must accept table cell contents");
+assert.deepEqual(parsedTable.data.tableData, tableData, "append_block must preserve tableData");
+assert.deepEqual(
+  parsedTable.data.tableCellDeltas,
+  tableCellDeltas,
+  "append_block must preserve per-cell rich-text deltas",
+);
+for (const invalidTable of [
+  { tableData: "not-an-array" },
+  { tableData: ["not-a-row"] },
+  { tableData: [[42]] },
+  { tableCellDeltas: [[[{ insert: 42 }]]] },
+  { tableCellDeltas: [[[{ insert: "bad attributes", attributes: [] }]]] },
+]) {
+  assert.equal(
+    appendBlockSchema.safeParse({ ...tableCell, ...invalidTable }).success,
+    false,
+    `append_block must reject ${JSON.stringify(invalidTable)}`,
+  );
+}
+
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);
 assert.equal(toolSchema("search_docs").safeParse({ query: "x", limit: -1 }).success, false);
 assert.equal(toolSchema("list_workspace_tree").safeParse({ depth: 21 }).success, false);

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -150,6 +150,24 @@ for (const invalidTable of [
   );
 }
 
+const appendBlock = registry.tools.get("append_block").handler;
+for (const [invalidCells, expected] of [
+  [{ rows: 2, columns: 2, tableCellDeltas: [[[{ insert: "only-one-row" }], []]] }, /tableCellDeltas row count must match table rows/],
+  [{ rows: 1, columns: 2, tableCellDeltas: [[[{ insert: "only-one-column" }]]] }, /tableCellDeltas column count must match table columns/],
+]) {
+  await assert.rejects(
+    appendBlock({ docId: "doc-1", type: "table", ...invalidCells }),
+    expected,
+    "append_block must reject tableCellDeltas that do not match the table shape",
+  );
+}
+await assert.rejects(
+  appendBlock({ docId: "doc-1", type: "paragraph", tableCellDeltas: [[[{ insert: "x" }]]] }),
+  /The 'tableCellDeltas' field can only be used with type='table'/,
+  "append_block must reject tableCellDeltas on a non-table block",
+);
+assert.equal(requestCount, 0, "invalid table cell input must not reach AFFiNE");
+
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);
 assert.equal(toolSchema("search_docs").safeParse({ query: "x", limit: -1 }).success, false);
 assert.equal(toolSchema("list_workspace_tree").safeParse({ depth: 21 }).success, false);


### PR DESCRIPTION
## Summary

`append_block` accepts a `type: "table"` call carrying cell contents, returns `appended: true`, and creates an empty table. No error, no warning. The same table fills correctly through `append_markdown`.

The implementation behind it is already complete: `normalizeAppendBlockInput()` reads `tableData` and `tableCellDeltas`, validation for their shape exists, and the builder writes each cell. But the public `inputSchema` for `append_block` declares only `rows` and `columns` and never calls `.passthrough()`, so Zod strips both fields before the normalizer runs. The only caller that reaches the working path is `markdownOperationToAppendInput()`, which sets `tableData` itself — which is why Markdown import is currently the sole way to fill a table.

This declares the two missing fields so the existing path is reachable from the tool surface. Fixes #322.

## Changes

- `src/tools/docs.ts`: declare `tableData` and `tableCellDeltas` on the `append_block` input schema, reusing the existing `TextDeltaInput` for per-cell deltas rather than introducing a new shape.
- `tests/test-input-contracts.mjs`: assert `append_block` accepts and preserves both fields, and rejects malformed cell data — mirroring the existing rich-text delta contract block for `append_block`/`update_block` directly above it.
- `CHANGELOG.md`: entry under Unreleased > Fixed.

## Validation

Commands executed:

```bash
npm ci
npm run ci
```

Results:

- build, package dry-run, and tool-manifest checks passed
- all 28 fast tests passed, including the new `append_block` table-cell contract assertions
- documentation drift and PR route checks passed

The new assertions were confirmed to be load-bearing: with the schema change reverted and the suite re-run, `test-input-contracts.mjs` fails on the `tableData` deep-equality check, because Zod strips the field before it is observed.

## Backward compatibility

Additive. Both fields are optional, so every existing `append_block` call parses and behaves exactly as before. No tool was added or removed, so `tool-manifest.json` is unchanged. Callers that already pass `tableData` — today silently discarded — will begin getting the filled table they asked for; that is the bug being fixed. The pre-existing strict-mode guard rejecting `tableData` on a non-table block is untouched.

## Notes

Two follow-ups from #322 are deliberately left out to keep this focused on the schema gap:

- `append_block` still reports `appended: true` for a table created with no cell data. Making that loud (a warning, or a `strict`-mode rejection) would mirror the existing strict error path.
- `update_block` still rejects `affine:table`, so a single cell cannot be edited after creation. That is a larger design question and worth settling in the issue first.

Happy to take either one on in a separate PR if you'd like them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables created with `append_block` can include plain-text cell contents and rich-text formatting.
  * Supports row and column alignment with formatting overrides.

* **Bug Fixes**
  * Fixed table cell contents being silently discarded.
  * Added validation to reject table data with mismatched rows or columns and prevent table-only content on other block types.

* **Tests**
  * Added coverage for valid table content and malformed table input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->