### PR TITLE
feat: add single table cell updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `update_table_cell` for in-place updates to AFFiNE table cells with zero-based coordinates and formatting-preserving rich-text deltas.
+
 ### Fixed
 - `append_block` now accepts `tableData` and `tableCellDeltas`, so a table created with cell contents is no longer silently empty; previously the schema stripped both fields and only `append_markdown` could fill cells.
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -95,6 +95,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 | `get_doc_icon` | Read a document's current sidebar icon | |
 | `append_block` | Append canonical block types with validation and placement control | Inline-rich-text block content accepts a plain string or formatting-preserving delta array. Also supports media, embeds, database, and edgeless blocks. `frame`/`edgeless_text`/`note` accept `x`/`y`/`width`/`height`. `note` with `text` auto-creates a child paragraph. Bookmarks allow canonical web, mail, telephone, `affine://blob/<key>`, and `affine://doc/<id>` URLs; iframes require HTTP(S); provider embeds require HTTPS URLs on official hosts. URL validation does not make an outbound server fetch. Image and attachment `sourceId` values are exact opaque keys returned by `upload_blob`, including keys containing spaces or path separators. |
 | `update_block` | Partially update an existing text block without changing its id | `text` accepts a plain string or formatting-preserving delta array. Also supports todo checked state, list style, and same-flavour paragraph/heading/quote conversions. Cross-flavour conversions are rejected because AFFiNE replaces the block id. |
+| `update_table_cell` | Replace one cell in an existing AFFiNE table | Uses zero-based row/column coordinates, preserves arbitrary inline attributes, and keeps the first row bold. Plain-text updates preserve existing cell formatting when the text is unchanged. |
 | `move_block` | Move or reorder an existing block without changing its id | Reuses `append_block` placement (`parentId`, `beforeBlockId`, `afterBlockId`, or `index`) and rejects root moves and cycles. |
 | `create_semantic_page` | Create an AFFiNE-native page with an intentional section skeleton and native block composition | High-level authoring helper |
 | `append_semantic_section` | Append a semantic section to an existing page by heading title | High-level authoring helper |
@@ -103,7 +104,7 @@ Use this document as a grouped catalog. For exact schemas, your MCP client shoul
 
 #### Formatting-preserving block text
 
-For inline-rich-text blocks, `append_block.text` and `update_block.text` accept either a string or a delta array. Each delta requires a string `insert` and may contain arbitrary `attributes`; the server passes attributes through without restricting them to a fixed formatting vocabulary.
+For inline-rich-text blocks, `append_block.text`, `update_block.text`, and `update_table_cell.text` accept either a string or a delta array. Each delta requires a string `insert` and may contain arbitrary `attributes`; the server passes attributes through without restricting them to a fixed formatting vocabulary.
 
 ```json
 [
@@ -113,7 +114,7 @@ For inline-rich-text blocks, `append_block.text` and `update_block.text` accept 
 ]
 ```
 
-`read_doc` block rows and block snapshots returned by editing tools include both flattened `text` and formatting-preserving `deltas`. Markdown export still reports and drops inline attributes it cannot represent; use `deltas` for lossless block-level read/modify/write flows.
+`read_doc` block rows and block snapshots returned by editing tools include both flattened `text` and formatting-preserving `deltas`; table rows additionally include the full `tableData` matrix and `tableCellDeltas`. Markdown export still reports and drops inline attributes it cannot represent; use `deltas` for lossless block-level read/modify/write flows.
 
 ### Tags
 

--- a/src/toolOutputSchemas.ts
+++ b/src/toolOutputSchemas.ts
@@ -133,6 +133,7 @@ const OUTPUT_SPECS = {
   update_profile: fallible(spec({ id: "string", name: "string", avatarUrl: "nullableString", error: "string" }, true)),
   update_settings: fallible(spec({ success: "boolean", error: "string" }, true)),
   update_surface_element: spec({ updated: "boolean", elementId: "string", type: "nullableString", changed: "stringArray", ignored: "stringArray" }),
+  update_table_cell: spec({ updated: "boolean", blockId: "string", row: "number", column: "number", rowId: "string", columnId: "string", previous: "object", cell: "object" }),
   update_workspace: fallible(spec({ kind: "string", ok: "boolean", workspaceId: "string", id: "string", error: "string" }, true)),
   upload_blob: fallible(spec({ id: "string", key: "string", workspaceId: "string", filename: "string", contentType: "string", encoding: "string", size: "number", uploadedAt: "string", error: "string" }, true)),
 } satisfies Record<ToolName, OutputSpec>;

--- a/src/toolSurface.ts
+++ b/src/toolSurface.ts
@@ -93,6 +93,7 @@ export const ALL_TOOLS = [
   "update_profile",
   "update_settings",
   "update_surface_element",
+  "update_table_cell",
   "update_workspace",
   "upload_blob",
 ] as const;
@@ -201,6 +202,7 @@ const TOOL_GROUPS: Record<ToolName, readonly string[]> = {
   update_profile: ["users", "users.write", "admin", "write"],
   update_settings: ["users", "users.write", "admin", "write"],
   update_surface_element: ["docs", "docs.edgeless", "docs.surface", "docs.write", "write"],
+  update_table_cell: ["docs", "docs.write", "write"],
   update_workspace: ["workspaces", "workspaces.write", "admin", "write"],
   upload_blob: ["blobs", "blobs.write", "write"],
 };
@@ -274,6 +276,7 @@ const CORE_TOOLS = new Set<ToolName>([
   "update_database_row",
   "update_doc_icon",
   "update_doc_title",
+  "update_table_cell",
 ]);
 
 const AUTHORING_EXCLUDED_GROUPS = new Set([

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -533,6 +533,15 @@ type AppendBlockInput = {
   padding?: number;
 };
 
+type UpdateTableCellInput = {
+  workspaceId?: string;
+  docId: string;
+  blockId: string;
+  row: number;
+  column: number;
+  text: string | TextDelta[];
+};
+
 type NormalizedAppendBlockInput = {
   workspaceId?: string;
   docId: string;
@@ -1012,11 +1021,36 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     return yText;
   }
 
-  function canonicalTextDeltas(content: TextDelta[]): TextDelta[] {
+  function makeTableCellText(content: string | TextDelta[], isHeader: boolean): Y.Text {
+    const yText = new Y.Text();
+    if (typeof content === "string") {
+      if (content.length > 0) {
+        yText.insert(0, content, isHeader ? { bold: true } : {});
+      }
+      return yText;
+    }
+
+    let offset = 0;
+    for (const delta of content) {
+      if (!delta.insert) continue;
+      const attributes = isHeader
+        ? { ...(delta.attributes ?? {}), bold: true }
+        : (delta.attributes ? { ...delta.attributes } : {});
+      yText.insert(offset, delta.insert, attributes);
+      offset += delta.insert.length;
+    }
+    return yText;
+  }
+
+  function canonicalDeltas(content: string | TextDelta[], isHeader = false): TextDelta[] {
     const doc = new Y.Doc();
-    const value = makeText(content);
+    const value = isHeader ? makeTableCellText(content, true) : makeText(content);
     doc.getMap("root").set("text", value);
     return richTextValueToDeltas(value) ?? [];
+  }
+
+  function canonicalTextDeltas(content: TextDelta[]): TextDelta[] {
+    return canonicalDeltas(content);
   }
 
   /**
@@ -2488,25 +2522,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
             const columnId = columnIds[columnIndex];
             const cellText = tableData[rowIndex]?.[columnIndex] ?? "";
             const cellDeltas = normalized.tableCellDeltas?.[rowIndex]?.[columnIndex] ?? [];
-            const cellYText = new Y.Text();
-            // First row is always rendered bold (header row convention)
-            if (cellDeltas.length > 0) {
-              let offset = 0;
-              for (const delta of cellDeltas) {
-                if (!delta.insert) {
-                  continue;
-                }
-                const attrs = isHeader
-                  ? { ...(delta.attributes ?? {}), bold: true }
-                  : (delta.attributes ? { ...delta.attributes } : {});
-                cellYText.insert(offset, delta.insert, attrs);
-                offset += delta.insert.length;
-              }
-            } else if (isHeader && cellText) {
-              cellYText.insert(0, cellText, { bold: true });
-            } else {
-              cellYText.insert(0, cellText);
-            }
+            const cellYText = makeTableCellText(
+              cellDeltas.length > 0 ? cellDeltas : cellText,
+              isHeader,
+            );
             block.set(`prop:cells.${rowId}:${columnId}.text`, cellYText);
           }
         }
@@ -3201,6 +3220,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
   function extractTableData(block: Y.Map<any>): {
     tableData: string[][];
     tableCellDeltas: TextDelta[][][];
+    rowIds: string[];
+    columnIds: string[];
   } | null {
     const compareOrder = (left: string, right: string) => {
       if (left < right) return -1;
@@ -3210,13 +3231,18 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     const rowsValue = block.get("prop:rows");
     const columnsValue = block.get("prop:columns");
     const cellsValue = block.get("prop:cells");
+    const mapField = (payload: unknown, field: string): unknown => {
+      if (payload instanceof Y.Map) return payload.get(field);
+      if (payload && typeof payload === "object") return (payload as any)[field];
+      return undefined;
+    };
 
     let rowEntries = mapEntries(rowsValue)
       .map(([rowId, payload]) => ({
         rowId,
         order:
-          payload && typeof payload === "object" && typeof (payload as any).order === "string"
-            ? (payload as any).order
+          typeof mapField(payload, "order") === "string"
+            ? mapField(payload, "order") as string
             : rowId,
       }))
       .sort((a, b) => compareOrder(a.order, b.order));
@@ -3225,8 +3251,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       .map(([columnId, payload]) => ({
         columnId,
         order:
-          payload && typeof payload === "object" && typeof (payload as any).order === "string"
-            ? (payload as any).order
+          typeof mapField(payload, "order") === "string"
+            ? mapField(payload, "order") as string
             : columnId,
       }))
       .sort((a, b) => compareOrder(a.order, b.order));
@@ -3282,6 +3308,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           });
           continue;
         }
+        if (payload instanceof Y.Text || typeof payload === "string") {
+          cells.set(cellKey, {
+            text: richTextValueToString(payload),
+            deltas: richTextValueToDeltas(payload) ?? [],
+          });
+          continue;
+        }
         if (payload && typeof payload === "object" && "text" in payload) {
           const textValue = (payload as any).text;
           cells.set(cellKey, {
@@ -3310,7 +3343,40 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       tableCellDeltas.push(rowDeltas);
     }
 
-    return { tableData, tableCellDeltas };
+    return {
+      tableData,
+      tableCellDeltas,
+      rowIds: rowEntries.map(({ rowId }) => rowId),
+      columnIds: columnEntries.map(({ columnId }) => columnId),
+    };
+  }
+
+  function writeTableCellText(
+    block: Y.Map<any>,
+    rowId: string,
+    columnId: string,
+    nextText: Y.Text,
+  ): void {
+    const currentCells = block.get("prop:cells");
+    const rowsAreNested = block.get("prop:rows") instanceof Y.Map;
+    const columnsAreNested = block.get("prop:columns") instanceof Y.Map;
+    if (!rowsAreNested && !columnsAreNested && !(currentCells instanceof Y.Map)) {
+      block.set(`prop:cells.${rowId}:${columnId}.text`, nextText);
+      return;
+    }
+
+    const cells = currentCells instanceof Y.Map
+      ? currentCells
+      : ensureYMap(block, "prop:cells");
+    const cellKey = `${rowId}:${columnId}`;
+    const existing = cells.get(cellKey);
+    if (existing instanceof Y.Map) {
+      existing.set("text", nextText);
+    } else {
+      const cell = new Y.Map<any>();
+      cell.set("text", nextText);
+      cells.set(cellKey, cell);
+    }
   }
 
   function collectDocForMarkdown(
@@ -5538,6 +5604,8 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         type: string | null;
         text: string | null;
         deltas: TextDelta[];
+        tableData?: string[][];
+        tableCellDeltas?: TextDelta[][][];
         linkedDocIds: string[];
         checked: boolean | null;
         language: string | null;
@@ -5559,6 +5627,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         const propText = raw.get("prop:text");
         const textValue = asText(propText);
         const deltas = richTextValueToDeltas(propText) ?? [];
+        const table = flavour === "affine:table" ? extractTableData(raw) : null;
         const linkedDocIds = extractLinkedPageRefs(propText);
         const language = raw.get("prop:language");
         const checked = raw.get("prop:checked");
@@ -5578,6 +5647,10 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           type: typeof type === "string" ? type : null,
           text: textValue.length > 0 ? textValue : null,
           deltas,
+          ...(table ? {
+            tableData: table.tableData,
+            tableCellDeltas: table.tableCellDeltas,
+          } : {}),
           linkedDocIds,
           checked: typeof checked === "boolean" ? checked : null,
           language: typeof language === "string" ? language : null,
@@ -9734,6 +9807,102 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
     }
   };
 
+  const updateTableCellHandler = async (params: UpdateTableCellInput) => {
+    const workspaceId = params.workspaceId || defaults.workspaceId;
+    if (!workspaceId) {
+      throw new Error(
+        "workspaceId is required. Provide it as a parameter or set AFFINE_WORKSPACE_ID in environment."
+      );
+    }
+    if (!Number.isInteger(params.row) || params.row < 0) {
+      throw new Error("row must be a non-negative integer.");
+    }
+    if (!Number.isInteger(params.column) || params.column < 0) {
+      throw new Error("column must be a non-negative integer.");
+    }
+
+    const { endpoint, cookie, bearer } = await getCookieAndEndpoint();
+    const wsUrl = wsUrlFromGraphQLEndpoint(endpoint);
+    const socket = await connectWorkspaceSocket(wsUrl, cookie, bearer);
+    try {
+      await joinWorkspace(socket, workspaceId);
+      const doc = new Y.Doc();
+      const snapshot = await loadDoc(socket, workspaceId, params.docId);
+      if (!snapshot.missing) {
+        throw new Error(`Document '${params.docId}' not found or has no content.`);
+      }
+      Y.applyUpdate(doc, Buffer.from(snapshot.missing, "base64"));
+      const prevSV = Y.encodeStateVector(doc);
+      const blocks = doc.getMap("blocks") as Y.Map<any>;
+      const block = findBlockById(blocks, params.blockId);
+      if (!block) {
+        throw new Error(`Block '${params.blockId}' not found.`);
+      }
+      const flavour = block.get("sys:flavour");
+      if (flavour !== "affine:table") {
+        throw new Error(
+          `Block '${params.blockId}' has flavour '${String(flavour)}' — update_table_cell only mutates affine:table blocks.`
+        );
+      }
+
+      const table = extractTableData(block);
+      if (!table) {
+        throw new Error(`Table block '${params.blockId}' has no readable row/column layout.`);
+      }
+      if (params.row >= table.rowIds.length) {
+        throw new Error(
+          `Table row ${params.row} is out of range (row count: ${table.rowIds.length}).`
+        );
+      }
+      if (params.column >= table.columnIds.length) {
+        throw new Error(
+          `Table column ${params.column} is out of range (column count: ${table.columnIds.length}).`
+        );
+      }
+
+      const rowId = table.rowIds[params.row];
+      const columnId = table.columnIds[params.column];
+      const previousText = table.tableData[params.row][params.column];
+      const previousDeltas = table.tableCellDeltas[params.row][params.column];
+      const isHeader = params.row === 0;
+      const nextText = makeTableCellText(params.text, isHeader);
+      const nextDeltas = canonicalDeltas(params.text, isHeader);
+      const changed = typeof params.text === "string"
+        ? previousText !== params.text
+        : !isDeepStrictEqual(previousDeltas, nextDeltas);
+
+      if (changed) {
+        writeTableCellText(block, rowId, columnId, nextText);
+        const delta = Y.encodeStateAsUpdate(doc, prevSV);
+        await pushDocUpdate(
+          socket,
+          workspaceId,
+          params.docId,
+          Buffer.from(delta).toString("base64")
+        );
+      }
+
+      return text({
+        updated: changed,
+        blockId: params.blockId,
+        row: params.row,
+        column: params.column,
+        rowId,
+        columnId,
+        previous: {
+          text: previousText,
+          deltas: previousDeltas,
+        },
+        cell: {
+          text: changed ? richTextValueToString(nextText) : previousText,
+          deltas: changed ? nextDeltas : previousDeltas,
+        },
+      });
+    } finally {
+      socket.disconnect();
+    }
+  };
+
   const moveBlockHandler = async (params: {
     workspaceId?: string;
     docId: string;
@@ -10363,6 +10532,24 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       },
     },
     updateBlockHandler as any
+  );
+
+  server.registerTool(
+    "update_table_cell",
+    {
+      title: "Update Table Cell",
+      description:
+        "Replace one cell in an AFFiNE table by zero-based row and column while preserving rich-text attributes and the table's header bold formatting.",
+      inputSchema: {
+        workspaceId: WorkspaceId.optional(),
+        docId: DocId,
+        blockId: z.string().min(1).describe("Table block id (flavour affine:table)."),
+        row: z.number().int().min(0).describe("Zero-based table row."),
+        column: z.number().int().min(0).describe("Zero-based table column."),
+        text: RichTextInput.describe("Replacement cell text as plain text or a delta array that preserves inline attributes."),
+      },
+    },
+    updateTableCellHandler as any
   );
 
   server.registerTool(

--- a/test-comprehensive.mjs
+++ b/test-comprehensive.mjs
@@ -65,6 +65,7 @@ const FOCUSED_TOOL_COVERAGE = new Map([
   ['update_doc_icon', 'test-icons.mjs'],
   ['update_doc_title', 'test-create-placement.mjs'],
   ['update_folder_icon', 'test-icons.mjs'],
+  ['update_table_cell', 'test-block-editing.mjs'],
 ]);
 
 if (!PASSWORD) {

--- a/tests/playwright/verify-block-editing.pw.ts
+++ b/tests/playwright/verify-block-editing.pw.ts
@@ -15,6 +15,7 @@ interface TestState {
   workspaceId: string;
   docId: string;
   taskBlockId: string;
+  tableBlockId: string;
   taskText: string;
   oldTaskText: string;
   inboxHeadingText: string;
@@ -22,6 +23,11 @@ interface TestState {
   highlightedSegment: string;
   doneHeadingText: string;
   deletedText: string;
+  tableHeaderText: string;
+  tableCellText: string;
+  tableLinkUrl: string;
+  tableSiblingHeaderText: string;
+  tableSiblingDataText: string;
   error?: string;
 }
 
@@ -63,8 +69,8 @@ test.beforeAll(() => {
   }
   state = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
   if (state.error) throw new Error(`State file contains an integration-test error: ${state.error}`);
-  if (!state.workspaceId || !state.docId || !state.taskBlockId) {
-    throw new Error('State file is missing workspaceId, docId, or taskBlockId');
+  if (!state.workspaceId || !state.docId || !state.taskBlockId || !state.tableBlockId) {
+    throw new Error('State file is missing workspaceId, docId, taskBlockId, or tableBlockId');
   }
 });
 
@@ -107,6 +113,33 @@ test.describe.serial('AFFiNE block editing verification', () => {
       const taskIndex = renderedText.findIndex(value => value.includes(state.taskText));
       expect(doneIndex).toBeGreaterThanOrEqual(0);
       expect(taskIndex).toBe(doneIndex + 1);
+
+      let tableBlock: Locator = page
+        .locator('affine-table, [data-block-flavour="affine:table"]')
+        .filter({ hasText: state.tableHeaderText })
+        .first();
+      if (await tableBlock.count() === 0) {
+        tableBlock = page.locator(`[data-block-id="${state.tableBlockId}"]`).filter({ hasText: state.tableHeaderText }).first();
+      }
+      await expect(tableBlock).toBeVisible({ timeout: 30_000 });
+      const tableHeader = tableBlock.getByText(state.tableHeaderText, { exact: true });
+      await expect(tableHeader).toHaveCount(1);
+      await expect(tableBlock.getByText(state.tableSiblingHeaderText, { exact: true })).toHaveCount(1);
+      await expect(tableBlock.getByText(state.tableCellText, { exact: true })).toHaveCount(1);
+      await expect(tableBlock.getByText(state.tableSiblingDataText, { exact: true })).toHaveCount(1);
+
+      const headerFontWeight = Number.parseInt(
+        await tableHeader.evaluate(element => getComputedStyle(element).fontWeight),
+        10,
+      );
+      expect(headerFontWeight).toBeGreaterThanOrEqual(600);
+
+      const tableLink = tableBlock.locator(`a[href="${state.tableLinkUrl}"]`).filter({ hasText: 'GitLab' }).first();
+      await expect(tableLink).toHaveAttribute('href', state.tableLinkUrl);
+      await expect(tableLink).toHaveText('GitLab');
+
+      const inlineCode = tableBlock.locator('code').filter({ hasText: 'team.AI' }).first();
+      await expect(inlineCode).toBeVisible();
     } finally {
       await context.close();
     }

--- a/tests/test-block-editing.mjs
+++ b/tests/test-block-editing.mjs
@@ -69,6 +69,7 @@ async function main() {
     taskBlockId: null,
     quoteBlockId: null,
     codeBlockId: null,
+    tableBlockId: null,
     taskText: 'Ship the verified release',
     oldTaskText: 'Ship the draft release',
     inboxHeadingText: 'Inbox priority',
@@ -78,6 +79,16 @@ async function main() {
     highlightedSegment: 'verified',
     doneHeadingText: 'Done',
     deletedText: 'Remove this temporary note',
+    tableHeaderText: 'Updated Header',
+    tableCellText: 'team.AI | GitLab',
+    tableLinkUrl: 'https://gitlab.com',
+    tableSiblingHeaderText: 'Keep header sibling',
+    tableSiblingDataText: 'Keep data sibling',
+    tableCellDeltas: [
+      { insert: 'team.AI', attributes: { code: true } },
+      { insert: ' | ' },
+      { insert: 'GitLab', attributes: { link: 'https://gitlab.com' } },
+    ],
     inboxHeadingDeltas: [
       { insert: 'Inbox ' },
       { insert: 'priority', attributes: { color: 'var(--affine-text-highlight-foreground-blue)' } },
@@ -216,6 +227,20 @@ async function main() {
     state.codeBlockId = code?.blockId;
     expectTruthy(state.codeBlockId, 'append_block rich-text code id');
 
+    const table = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'table',
+      rows: 2,
+      columns: 2,
+      tableData: [
+        ['Original Header', state.tableSiblingHeaderText],
+        ['Original data', state.tableSiblingDataText],
+      ],
+    });
+    state.tableBlockId = table?.blockId;
+    expectTruthy(state.tableBlockId, 'append_block 2x2 table id');
+
     const emptyDivider = await call('append_block', {
       workspaceId: state.workspaceId,
       docId: state.docId,
@@ -304,6 +329,102 @@ async function main() {
     });
     expectEqual(unchangedPlainText?.updated, false, 'update_block identical plain text no-op');
     assert.deepEqual(unchangedPlainText?.block?.deltas, state.taskDeltas, 'plain-text no-op preserves existing attributes');
+
+    const updatedHeader = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 0,
+      column: 0,
+      text: state.tableHeaderText,
+    });
+    expectEqual(updatedHeader?.updated, true, 'update_table_cell header changed');
+    expectEqual(updatedHeader?.row, 0, 'update_table_cell header row');
+    expectEqual(updatedHeader?.column, 0, 'update_table_cell header column');
+    expectEqual(updatedHeader?.previous?.text, 'Original Header', 'update_table_cell header previous text');
+    assert.deepEqual(
+      updatedHeader?.previous?.deltas,
+      [{ insert: 'Original Header', attributes: { bold: true } }],
+      'update_table_cell header previous deltas',
+    );
+    expectEqual(updatedHeader?.cell?.text, state.tableHeaderText, 'update_table_cell header current text');
+    assert.deepEqual(
+      updatedHeader?.cell?.deltas,
+      [{ insert: state.tableHeaderText, attributes: { bold: true } }],
+      'update_table_cell header remains bold',
+    );
+
+    const updatedCell = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 1,
+      column: 0,
+      text: state.tableCellDeltas,
+    });
+    expectEqual(updatedCell?.updated, true, 'update_table_cell rich-text cell changed');
+    expectEqual(updatedCell?.previous?.text, 'Original data', 'update_table_cell cell previous text');
+    expectEqual(updatedCell?.cell?.text, state.tableCellText, 'update_table_cell cell current text');
+    assert.deepEqual(updatedCell?.cell?.deltas, state.tableCellDeltas, 'update_table_cell cell deltas');
+
+    const unchangedCellDeltas = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 1,
+      column: 0,
+      text: state.tableCellDeltas,
+    });
+    expectEqual(unchangedCellDeltas?.updated, false, 'update_table_cell identical deltas no-op');
+    assert.deepEqual(unchangedCellDeltas?.cell?.deltas, state.tableCellDeltas, 'table delta no-op preserves attributes');
+
+    const unchangedHeaderText = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 0,
+      column: 0,
+      text: state.tableHeaderText,
+    });
+    expectEqual(unchangedHeaderText?.updated, false, 'update_table_cell identical plain text no-op');
+    assert.deepEqual(
+      unchangedHeaderText?.cell?.deltas,
+      [{ insert: state.tableHeaderText, attributes: { bold: true } }],
+      'table plain-text no-op preserves header bold',
+    );
+
+    await expectCallError('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.taskBlockId,
+      row: 0,
+      column: 0,
+      text: 'wrong flavour',
+    }, /only mutates affine:table/);
+    await expectCallError('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: 'missing-table-block',
+      row: 0,
+      column: 0,
+      text: 'missing',
+    }, /Block 'missing-table-block' not found/);
+    await expectCallError('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 2,
+      column: 0,
+      text: 'out of range',
+    }, /Table row 2 is out of range/);
+    await expectCallError('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.tableBlockId,
+      row: 0,
+      column: 2,
+      text: 'out of range',
+    }, /Table column 2 is out of range/);
 
     await expectCallError('update_block', {
       workspaceId: state.workspaceId,
@@ -405,6 +526,26 @@ async function main() {
 
     const doneBlock = blocks.find(block => block.id === doneHeading.blockId);
     expectTruthy(doneBlock, 'read_doc done heading');
+    const tableBlock = blocks.find(block => block.id === state.tableBlockId);
+    expectTruthy(tableBlock, 'read_doc table block');
+    assert.deepEqual(
+      tableBlock.tableData,
+      [[state.tableHeaderText, state.tableSiblingHeaderText], [state.tableCellText, state.tableSiblingDataText]],
+      'read_doc table full matrix',
+    );
+    assert.deepEqual(
+      tableBlock.tableCellDeltas,
+      [
+        [
+          [{ insert: state.tableHeaderText, attributes: { bold: true } }],
+          [{ insert: state.tableSiblingHeaderText, attributes: { bold: true } }],
+        ],
+        [state.tableCellDeltas, [{ insert: state.tableSiblingDataText }]],
+      ],
+      'read_doc table exact cell deltas',
+    );
+    expectEqual(tableBlock.tableData[0][1], state.tableSiblingHeaderText, 'table header sibling unchanged');
+    expectEqual(tableBlock.tableData[1][1], state.tableSiblingDataText, 'table data sibling unchanged');
     assert.deepEqual(
       blocks.find(block => block.id === state.inboxHeadingBlockId)?.deltas,
       state.inboxHeadingDeltas,
@@ -428,6 +569,19 @@ async function main() {
     if (doneIndex < 0 || taskIndex !== doneIndex + 1) {
       throw new Error(`move_block order mismatch: doneIndex=${doneIndex}, taskIndex=${taskIndex}`);
     }
+
+    const markdown = await call('export_doc_markdown', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+    });
+    expectEqual(
+      markdown.warnings.some(warning => warning.includes(`Table block '${state.tableBlockId}'`)),
+      false,
+      'export_doc_markdown table warnings',
+    );
+    expectEqual(markdown.markdown.includes('`team.AI`'), true, 'export_doc_markdown inline code');
+    expectEqual(markdown.markdown.includes('[GitLab](https://gitlab.com)'), true, 'export_doc_markdown link');
+    expectEqual(markdown.markdown.includes('\\|'), true, 'export_doc_markdown escaped table pipe');
 
     fs.writeFileSync(STATE_OUTPUT_PATH, JSON.stringify(state, null, 2));
     console.log();

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -106,6 +106,7 @@ const highlightedText = [
 for (const [name, required] of [
   ["append_block", { docId: "doc-1", type: "paragraph" }],
   ["update_block", { docId: "doc-1", blockId: "block-1" }],
+  ["update_table_cell", { docId: "doc-1", blockId: "table-1", row: 0, column: 0 }],
 ]) {
   const schema = toolSchema(name);
   const parsed = schema.safeParse({ ...required, text: highlightedText });
@@ -123,6 +124,14 @@ for (const [name, required] of [
     );
   }
 }
+
+const updateTableCellSchema = toolSchema("update_table_cell");
+expectSchemaRejects(updateTableCellSchema, [
+  { docId: "doc-1", blockId: "table-1", row: -1, column: 0, text: "x" },
+  { docId: "doc-1", blockId: "table-1", row: 0, column: -1, text: "x" },
+  { docId: "doc-1", blockId: "table-1", row: 1.5, column: 0, text: "x" },
+  { docId: "doc-1", blockId: "table-1", row: 0, column: 1.5, text: "x" },
+]);
 
 const appendBlockSchema = toolSchema("append_block");
 const tableCell = { docId: "doc-1", type: "table", rows: 1, columns: 2 };

--- a/tests/test-tool-filtering.mjs
+++ b/tests/test-tool-filtering.mjs
@@ -263,6 +263,7 @@ async function run() {
       "trash_doc",
       "restore_doc",
       "update_block",
+      "update_table_cell",
       "update_database_row",
       "add_surface_element",
       "read_all_notifications",
@@ -289,7 +290,7 @@ async function run() {
       "add_organize_link",
     ];
     const unexpectedlyVisible = trimmed.filter(t => tools7.includes(t));
-    const coreExpected = ["create_doc", "append_block", "move_block", "read_doc", "trash_doc", "restore_doc", "update_block", "update_database_row"];
+    const coreExpected = ["create_doc", "append_block", "move_block", "read_doc", "trash_doc", "restore_doc", "update_block", "update_table_cell", "update_database_row"];
     const coreMissing = coreExpected.filter(t => !tools7.includes(t));
     if (unexpectedlyVisible.length === 0 && coreMissing.length === 0) {
       console.log("✅ Success: Core profile exposes the compact everyday surface.");
@@ -310,7 +311,7 @@ async function run() {
       "update_profile",
     ];
     const visibleRestricted = hiddenAuthoring.filter(t => tools8.includes(t));
-    const expectedAuthoring = ["create_semantic_page", "instantiate_template_native", "add_surface_element", "move_block", "trash_doc", "restore_doc", "update_block", "update_surface_element"];
+    const expectedAuthoring = ["create_semantic_page", "instantiate_template_native", "add_surface_element", "move_block", "trash_doc", "restore_doc", "update_block", "update_table_cell", "update_surface_element"];
     const missingAuthoring = expectedAuthoring.filter(t => !tools8.includes(t));
     if (visibleRestricted.length === 0 && missingAuthoring.length === 0) {
       console.log("✅ Success: Authoring profile keeps editing tools while hiding restricted tools.");

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -95,6 +95,7 @@
     "update_profile",
     "update_settings",
     "update_surface_element",
+    "update_table_cell",
     "update_workspace",
     "upload_blob"
   ]


### PR DESCRIPTION
## Summary

- add `update_table_cell` with zero-based row and column addressing
- preserve rich-text deltas and header formatting, including no-op and error safeguards
- expose table matrices in `read_doc` and cover CRDT, Markdown, and browser behavior

## Validation

- `npm run ci` (28 fast tests, metadata/docs checks, package dry run)
- package install smoke: CLI version/help and MCP `tools/list` with 97 tools
- `AFFINE_REVISION=0.27.4 npm run test:comprehensive` (16 focused tests and 112/112 broad checks)
- `AFFINE_REVISION=0.27.4 npm run test:e2e` (24 integration tests and 17 Chromium tests)
- Linux/amd64 Docker build and runtime smoke: version, non-root user, and protected health endpoint

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `update_table_cell` for editing individual AFFiNE table cells using row and column coordinates.
  - Supports plain text and rich-text updates while preserving existing formatting.
  - Table data now exposes complete cell content and formatting details.
  - Header-row formatting and inline elements such as links and code are preserved.

- **Documentation**
  - Added tool reference and changelog documentation for table-cell updates.

- **Tests**
  - Added coverage for successful edits, formatting preservation, validation errors, and table export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->