### PR TITLE
chore: sync v3.5.0 release to develop

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,11 @@ jobs:
             fi
             HEALTH_STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER_ID")"
             if [ "$HEALTH_STATUS" = "healthy" ]; then
-              HEALTH_JSON="$(docker exec "$CONTAINER_ID" wget -qO- http://127.0.0.1:3000/healthz)"
+              if ! HEALTH_JSON="$(timeout 10s docker exec "$CONTAINER_ID" wget -qO- http://127.0.0.1:3000/healthz)"; then
+                echo "Container health endpoint probe failed"
+                docker logs "$CONTAINER_ID"
+                exit 1
+              fi
               if ! echo "$HEALTH_JSON" | grep -Eq '"protected"[[:space:]]*:[[:space:]]*true'; then
                 echo "Container health endpoint did not report protected mode"
                 docker logs "$CONTAINER_ID"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-31
+
 ### Added
 - Added `update_table_cell` for in-place updates to AFFiNE table cells with zero-based coordinates and formatting-preserving rich-text deltas.
 
 ### Fixed
 - `append_block` now accepts `tableData` and `tableCellDeltas`, so a table created with cell contents is no longer silently empty; previously the schema stripped both fields and only `append_markdown` could fill cells.
+
+### Dependencies
+- Updated `jose` from 6.2.9 to 6.2.10.
+
+### Tests
+- Hardened container startup smoke checks to fail immediately when the process exits and to require protected mode from the live health endpoint.
 
 ## [3.4.1] - 2026-08-27
 
@@ -724,6 +732,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.5.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.5.0
 [3.4.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.1
 [3.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.0
 [3.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.3.0
@@ -760,4 +769,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.4.1...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.5.0...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.4.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.5.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## Version 3.5.0 (2026-08-31)
+
+### Highlights
+- AFFiNE tables can now be created with cell content through `append_block` and edited one cell at a time through the new `update_table_cell` tool.
+- Direct rich-text cell updates preserve inline attributes, header bold formatting, literal pipes, and dotted code text without rebuilding the table through Markdown.
+- `read_doc` now exposes complete table text and delta matrices for lossless read-modify-write flows.
+
+### What Changed
+- Declared `tableData` and `tableCellDeltas` on the public `append_block` schema and added dimension checks for both matrices.
+- Added zero-based row and column addressing for cell updates, including bounds, block-flavour, no-op, and missing-block safeguards.
+- Preserved arbitrary rich-text delta attributes and enforced AFFiNE header-row bold formatting during direct cell writes.
+- Added exact table matrices to `read_doc` block rows and kept Markdown export compatible with links, inline code, and escaped pipes.
+- Added CRDT, contract, profile, Markdown, and Chromium coverage for table creation and cell editing.
+- Refreshed `jose` from 6.2.9 to 6.2.10 and strengthened the container startup smoke gate.
+
+### Compatibility
+- One tool was added, bringing the canonical MCP surface from 96 to 97 tools; no tools or existing required inputs were removed.
+- Existing plain-string table content remains supported, and rich-text delta arrays are additive.
+- Node.js 20.18.1 or newer remains required.
+- Release behavior is validated against AFFiNE 0.27.4.
+
+### Validation Evidence
+- Node.js 26.5.1: clean `npm ci && npm run ci` (28 fast tests; 97-tool metadata, documentation, and package checks)
+- `npm audit --audit-level=low` with zero vulnerabilities
+- `AFFINE_REVISION=0.27.4 npm run test:comprehensive` (16 focused integrations; 112/112 comprehensive checks)
+- `AFFINE_REVISION=0.27.4 npm run test:e2e` (24 integration tests; 17 Playwright tests)
+- Packed-tarball install, CLI, and 97-tool discovery smoke
+- `npm publish --dry-run --access public --ignore-scripts`
+- Linux/amd64 Docker build, version check, non-root UID check, protected health endpoint, and authenticated startup smoke
+
 ## Version 3.4.1 (2026-08-27)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2521,9 +2521,9 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           for (let columnIndex = 0; columnIndex < columnIds.length; columnIndex += 1) {
             const columnId = columnIds[columnIndex];
             const cellText = tableData[rowIndex]?.[columnIndex] ?? "";
-            const cellDeltas = normalized.tableCellDeltas?.[rowIndex]?.[columnIndex] ?? [];
+            const cellDeltas = normalized.tableCellDeltas?.[rowIndex]?.[columnIndex];
             const cellYText = makeTableCellText(
-              cellDeltas.length > 0 ? cellDeltas : cellText,
+              cellDeltas ?? cellText,
               isHeader,
             );
             block.set(`prop:cells.${rowId}:${columnId}.text`, cellYText);

--- a/tests/test-block-editing.mjs
+++ b/tests/test-block-editing.mjs
@@ -70,6 +70,7 @@ async function main() {
     quoteBlockId: null,
     codeBlockId: null,
     tableBlockId: null,
+    emptyOverrideTableBlockId: null,
     taskText: 'Ship the verified release',
     oldTaskText: 'Ship the draft release',
     inboxHeadingText: 'Inbox priority',
@@ -240,6 +241,18 @@ async function main() {
     });
     state.tableBlockId = table?.blockId;
     expectTruthy(state.tableBlockId, 'append_block 2x2 table id');
+
+    const emptyOverrideTable = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'table',
+      rows: 1,
+      columns: 1,
+      tableData: [['fallback text']],
+      tableCellDeltas: [[[]]],
+    });
+    state.emptyOverrideTableBlockId = emptyOverrideTable?.blockId;
+    expectTruthy(state.emptyOverrideTableBlockId, 'append_block empty table delta override id');
 
     const emptyDivider = await call('append_block', {
       workspaceId: state.workspaceId,
@@ -546,6 +559,10 @@ async function main() {
     );
     expectEqual(tableBlock.tableData[0][1], state.tableSiblingHeaderText, 'table header sibling unchanged');
     expectEqual(tableBlock.tableData[1][1], state.tableSiblingDataText, 'table data sibling unchanged');
+    const emptyOverrideTableBlock = blocks.find(block => block.id === state.emptyOverrideTableBlockId);
+    expectTruthy(emptyOverrideTableBlock, 'read_doc empty table delta override block');
+    assert.deepEqual(emptyOverrideTableBlock.tableData, [['']], 'empty table delta overrides fallback text');
+    assert.deepEqual(emptyOverrideTableBlock.tableCellDeltas, [[[]]], 'empty table delta remains empty');
     assert.deepEqual(
       blocks.find(block => block.id === state.inboxHeadingBlockId)?.deltas,
       state.inboxHeadingDeltas,

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1",
+  "version": "3.5.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
## Summary
- Sync the published v3.5.0 release metadata from `main` back to `develop`.
- Carry the empty table-cell delta correctness fix and bounded Docker health probe merged during release review.
- Keep `develop` aligned with the published merge commit and annotated release tag.

## Validation
- Local CI: 28 fast tests and 97-tool metadata, documentation, and package checks
- Comprehensive: 16/16 focused integrations and 112/112 MCP checks
- Release E2E: 24/24 integrations and 17/17 Chromium tests
- Packed artifact smoke and npm publish dry-run
- Linux/amd64 Docker build and protected runtime health smoke
- Published npm and GHCR workflows completed successfully for `v3.5.0`