### PR TITLE
fix: stop reporting success for an empty table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `append_block` no longer reports success for a `type: "table"` call with no cell content. Under `strict` it raises, and non-strict callers get a `warnings` entry on the result; an empty table could not be filled afterwards because `update_block` rejects `affine:table`.
+
 ## [3.5.0] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- `append_block` no longer reports success for a `type: "table"` call with no cell content. Under `strict` it raises, and non-strict callers get a `warnings` entry on the result; an empty table could not be filled afterwards because `update_block` rejects `affine:table`.
+### Added
+- `append_block` now returns a `warnings` entry when a `type: "table"` call creates a table with no cell content, naming `tableData`, `tableCellDeltas` and `update_table_cell` as the ways to fill it. Creating an empty table on purpose still succeeds unchanged.
 
 ## [3.5.0] - 2026-08-31
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1883,14 +1883,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           }
         }
       }
-      // An empty table cannot be filled afterwards: update_block rejects
-      // affine:table. Reporting success for one is a dead end, so strict mode
-      // says so and non-strict callers get a warning on the result.
-      if (!normalized.tableData && !normalized.tableCellDeltas && normalized.strict) {
-        throw new Error(
-          "A table needs tableData (or tableCellDeltas) to have any cell content. Pass strict: false to create an empty table on purpose.",
-        );
-      }
     } else if ((raw.rows !== undefined || raw.columns !== undefined) && normalized.strict) {
       throw new Error("The 'rows'/'columns' fields can only be used with type='table'.");
     } else if (raw.tableData !== undefined && normalized.strict) {
@@ -3051,10 +3043,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const delta = Y.encodeStateAsUpdate(doc, prevSV);
       await pushDocUpdate(socket, workspaceId, normalized.docId, Buffer.from(delta).toString("base64"));
 
+      // Creating an empty table is supported, but nothing on the result said the
+      // cells were empty, so a caller that meant to pass cell content had no
+      // signal. Name the three ways to fill it rather than rejecting the call.
       const warnings: string[] = [];
       if (normalized.type === "table" && !normalized.tableData && !normalized.tableCellDeltas) {
         warnings.push(
-          `Table ${blockId} was created with no cell content. Pass tableData to fill it; update_block cannot edit table cells afterwards.`,
+          `Table ${blockId} was created with no cell content. Pass tableData or tableCellDeltas on append_block to fill it, or use update_table_cell to set cells afterwards.`,
         );
       }
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -6321,6 +6321,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       ...(result.ownedIds ? { ownedIds: result.ownedIds } : {}),
       ...(result.missing ? { missing: result.missing } : {}),
       ...(markdownApplied ? { markdown: markdownApplied } : {}),
+      ...(result.warnings?.length ? { warnings: result.warnings } : {}),
     });
   };
   server.registerTool(

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1883,6 +1883,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           }
         }
       }
+      // An empty table cannot be filled afterwards: update_block rejects
+      // affine:table. Reporting success for one is a dead end, so strict mode
+      // says so and non-strict callers get a warning on the result.
+      if (!normalized.tableData && !normalized.tableCellDeltas && normalized.strict) {
+        throw new Error(
+          "A table needs tableData (or tableCellDeltas) to have any cell content. Pass strict: false to create an empty table on purpose.",
+        );
+      }
     } else if ((raw.rows !== undefined || raw.columns !== undefined) && normalized.strict) {
       throw new Error("The 'rows'/'columns' fields can only be used with type='table'.");
     } else if (raw.tableData !== undefined && normalized.strict) {
@@ -3043,6 +3051,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const delta = Y.encodeStateAsUpdate(doc, prevSV);
       await pushDocUpdate(socket, workspaceId, normalized.docId, Buffer.from(delta).toString("base64"));
 
+      const warnings: string[] = [];
+      if (normalized.type === "table" && !normalized.tableData && !normalized.tableCellDeltas) {
+        warnings.push(
+          `Table ${blockId} was created with no cell content. Pass tableData to fill it; update_block cannot edit table cells afterwards.`,
+        );
+      }
+
       return {
         appended: true,
         blockId,
@@ -3052,6 +3067,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         legacyType: normalized.legacyType || null,
         ownedIds: normalized._frameOwnedIds,
         missing: normalized._frameMissing,
+        ...(warnings.length ? { warnings } : {}),
       };
     } finally {
       socket.disconnect();

--- a/tests/test-block-editing.mjs
+++ b/tests/test-block-editing.mjs
@@ -70,6 +70,7 @@ async function main() {
     quoteBlockId: null,
     codeBlockId: null,
     tableBlockId: null,
+    emptyTableBlockId: null,
     emptyOverrideTableBlockId: null,
     taskText: 'Ship the verified release',
     oldTaskText: 'Ship the draft release',
@@ -85,6 +86,7 @@ async function main() {
     tableLinkUrl: 'https://gitlab.com',
     tableSiblingHeaderText: 'Keep header sibling',
     tableSiblingDataText: 'Keep data sibling',
+    emptyTableFilledText: 'Filled after creation',
     tableCellDeltas: [
       { insert: 'team.AI', attributes: { code: true } },
       { insert: ' | ' },
@@ -241,6 +243,29 @@ async function main() {
     });
     state.tableBlockId = table?.blockId;
     expectTruthy(state.tableBlockId, 'append_block 2x2 table id');
+
+    const emptyTable = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'table',
+      rows: 2,
+      columns: 2,
+    });
+    state.emptyTableBlockId = emptyTable?.blockId;
+    expectTruthy(state.emptyTableBlockId, 'append_block empty table id');
+    expectEqual(emptyTable?.appended, true, 'append_block empty table still succeeds');
+    expectTruthy(
+      emptyTable?.warnings?.some(warning => warning.includes(state.emptyTableBlockId)),
+      'append_block empty table warns about the missing cell content',
+    );
+    expectTruthy(
+      emptyTable?.warnings?.some(warning => warning.includes('update_table_cell')),
+      'append_block empty table warning names update_table_cell',
+    );
+    expectTruthy(
+      table?.warnings === undefined,
+      'append_block does not warn when tableData is supplied',
+    );
 
     const emptyOverrideTable = await call('append_block', {
       workspaceId: state.workspaceId,
@@ -404,6 +429,24 @@ async function main() {
       unchangedHeaderText?.cell?.deltas,
       [{ insert: state.tableHeaderText, attributes: { bold: true } }],
       'table plain-text no-op preserves header bold',
+    );
+
+    // The warning on an empty table points at update_table_cell, so prove the
+    // route it names actually works on a table created with no cell content.
+    const filledEmptyTableCell = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.emptyTableBlockId,
+      row: 1,
+      column: 1,
+      text: state.emptyTableFilledText,
+    });
+    expectEqual(filledEmptyTableCell?.updated, true, 'update_table_cell fills an empty table cell');
+    expectEqual(filledEmptyTableCell?.previous?.text, '', 'empty table cell started empty');
+    expectEqual(
+      filledEmptyTableCell?.cell?.text,
+      state.emptyTableFilledText,
+      'empty table cell holds the new text',
     );
 
     await expectCallError('update_table_cell', {

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -175,11 +175,6 @@ await assert.rejects(
   /The 'tableCellDeltas' field can only be used with type='table'/,
   "append_block must reject tableCellDeltas on a non-table block",
 );
-await assert.rejects(
-  appendBlock({ docId: "doc-1", type: "table", rows: 2, columns: 2 }),
-  /A table needs tableData \(or tableCellDeltas\) to have any cell content/,
-  "append_block must not silently create an empty table under strict",
-);
 assert.equal(requestCount, 0, "invalid table cell input must not reach AFFiNE");
 
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -175,6 +175,11 @@ await assert.rejects(
   /The 'tableCellDeltas' field can only be used with type='table'/,
   "append_block must reject tableCellDeltas on a non-table block",
 );
+await assert.rejects(
+  appendBlock({ docId: "doc-1", type: "table", rows: 2, columns: 2 }),
+  /A table needs tableData \(or tableCellDeltas\) to have any cell content/,
+  "append_block must not silently create an empty table under strict",
+);
 assert.equal(requestCount, 0, "invalid table cell input must not reach AFFiNE");
 
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);


### PR DESCRIPTION
## Summary

`append_block` with `type: "table"` and no cell content returned `{ appended: true }` and created a table with no cells. Nothing told the caller. Since `update_block` rejects `affine:table`, that table could not be filled afterwards either, so the success was a dead end.

This was the second item in #322. #323 fixed the schema gap that made `tableData` unreachable; this closes the silent case now that passing cell content is actually possible.

## Changes

- `src/tools/docs.ts`: under `strict`, which is the default, a `table` with neither `tableData` nor `tableCellDeltas` now raises, in the same style as the neighbouring `tableData` dimension errors. The message names the escape hatch, so a deliberately empty table is still one argument away.
- `src/tools/docs.ts`: non-strict callers keep the existing behaviour and get a `warnings` entry naming the block, using the `warnings: string[]` convention already used elsewhere in the file.
- `tests/test-input-contracts.mjs`: asserts the strict rejection reaches no AFFiNE request, alongside the existing table-cell contract tests.
- `CHANGELOG.md`: entry under Unreleased > Fixed.

## Validation

```bash
npm ci
npm run ci
```

- build, package dry-run and manifest checks passed
- 28 fast tests passed
- confirmed load-bearing: with the source change reverted, `test-input-contracts.mjs` fails on the new assertion

## Backward compatibility

This is the one deliberate behavior change: `append_block({ type: "table", rows, columns })` with no cell data previously succeeded and now raises by default.

I took that direction because an empty table cannot be filled through the tool surface afterwards, so the previous result was not usable. `strict: false` keeps the old behaviour exactly, now with a warning attached. Every other `append_block` call is unaffected, and `append_markdown` always supplies `tableData`, so the markdown path does not hit this.

Happy to flip it to warn-only in both modes if you would rather not change a default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Empty tables can now be created successfully, even without initial cell content.
  - A warning is provided when a table is created without cells, including guidance for filling them with `tableData`, `tableCellDeltas`, or `update_table_cell`.
  - Empty table cells can be populated after creation using `update_table_cell`.

- **Documentation**
  - Added changelog details describing empty-table creation and the associated warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->