### PR TITLE
Release v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `append_block` no longer reports success for a `type: "table"` call with no cell content. Under `strict` it raises, and non-strict callers get a `warnings` entry on the result; an empty table could not be filled afterwards because `update_block` rejects `affine:table`.
+
 ## [3.5.0] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- `append_block` no longer reports success for a `type: "table"` call with no cell content. Under `strict` it raises, and non-strict callers get a `warnings` entry on the result; an empty table could not be filled afterwards because `update_block` rejects `affine:table`.
+### Added
+- `append_block` now returns a `warnings` entry when a `type: "table"` call creates a table with no cell content, naming `tableData`, `tableCellDeltas` and `update_table_cell` as the ways to fill it. Creating an empty table on purpose still succeeds unchanged.
 
 ## [3.5.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-09-07
+
+### Security
+- Updated locked `fast-uri` to 3.1.7 and `qs` to 6.16.0 to address reported URI parsing and query-string parsing advisories, including the required `side-channel` dependency updates.
+
 ### Added
 - `append_block` now returns a `warnings` entry when a `type: "table"` call creates a table with no cell content, naming `tableData`, `tableCellDeltas` and `update_table_cell` as the ways to fill it. Creating an empty table on purpose still succeeds unchanged.
+
+### Dependencies
+- Updated locked `markdown-it` from 14.3.0 to 14.3.1, `@types/markdown-it` from 14.1.2 to 14.2.0, and `tsx` from 4.23.12 to 4.23.13.
+
+### Tests
+- Added integration coverage for empty-table warnings and filling an empty table with `update_table_cell`.
 
 ## [3.5.0] - 2026-08-31
 
@@ -735,6 +746,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.5.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.5.1
 [3.5.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.5.0
 [3.4.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.1
 [3.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.4.0
@@ -772,4 +784,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.5.1...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.5.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.5.1-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## Version 3.5.1 (2026-09-07)
+
+### Highlights
+- `append_block` now warns when a table is created without cell content and explains how to fill it with `tableData`, `tableCellDeltas`, or `update_table_cell`.
+- Intentional empty-table creation continues to succeed, and tables supplied with cell content do not receive this warning.
+
+### What Changed
+- Updated locked `fast-uri` to 3.1.7 and `qs` to 6.16.0 to address reported security advisories.
+- Returned the empty-table warning to callers and added integration coverage for creating an empty table and filling a cell afterwards.
+- Updated locked `markdown-it` to 14.3.1, `@types/markdown-it` to 14.2.0, and `tsx` to 4.23.13.
+
+### Compatibility
+- The canonical MCP surface remains at 97 tools; existing required inputs and successful empty-table creation remain compatible.
+- Node.js 20.18.1 or newer remains required.
+
+### Validation Evidence
+- Node.js 26.5.1: `npm run ci` passed (28 fast tests, 97-tool metadata, documentation, and package checks).
+- `npm audit --audit-level=low` reported zero vulnerabilities.
+- `AFFINE_REVISION=0.27.4 PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run test:e2e` passed (24 integration tests and 17 Chrome browser tests).
+- Linux/amd64 Docker build and runtime smoke passed: version 3.5.1, non-root UID 100, and healthy protected HTTP mode.
+
 ## Version 3.5.0 (2026-08-31)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -625,9 +625,9 @@
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1941,9 +1941,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+      "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.12",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
-      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,9 +1541,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2230,12 +2230,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2372,14 +2373,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2391,13 +2392,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1883,14 +1883,6 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           }
         }
       }
-      // An empty table cannot be filled afterwards: update_block rejects
-      // affine:table. Reporting success for one is a dead end, so strict mode
-      // says so and non-strict callers get a warning on the result.
-      if (!normalized.tableData && !normalized.tableCellDeltas && normalized.strict) {
-        throw new Error(
-          "A table needs tableData (or tableCellDeltas) to have any cell content. Pass strict: false to create an empty table on purpose.",
-        );
-      }
     } else if ((raw.rows !== undefined || raw.columns !== undefined) && normalized.strict) {
       throw new Error("The 'rows'/'columns' fields can only be used with type='table'.");
     } else if (raw.tableData !== undefined && normalized.strict) {
@@ -3051,10 +3043,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const delta = Y.encodeStateAsUpdate(doc, prevSV);
       await pushDocUpdate(socket, workspaceId, normalized.docId, Buffer.from(delta).toString("base64"));
 
+      // Creating an empty table is supported, but nothing on the result said the
+      // cells were empty, so a caller that meant to pass cell content had no
+      // signal. Name the three ways to fill it rather than rejecting the call.
       const warnings: string[] = [];
       if (normalized.type === "table" && !normalized.tableData && !normalized.tableCellDeltas) {
         warnings.push(
-          `Table ${blockId} was created with no cell content. Pass tableData to fill it; update_block cannot edit table cells afterwards.`,
+          `Table ${blockId} was created with no cell content. Pass tableData or tableCellDeltas on append_block to fill it, or use update_table_cell to set cells afterwards.`,
         );
       }
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -6321,6 +6321,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       ...(result.ownedIds ? { ownedIds: result.ownedIds } : {}),
       ...(result.missing ? { missing: result.missing } : {}),
       ...(markdownApplied ? { markdown: markdownApplied } : {}),
+      ...(result.warnings?.length ? { warnings: result.warnings } : {}),
     });
   };
   server.registerTool(

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1883,6 +1883,14 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
           }
         }
       }
+      // An empty table cannot be filled afterwards: update_block rejects
+      // affine:table. Reporting success for one is a dead end, so strict mode
+      // says so and non-strict callers get a warning on the result.
+      if (!normalized.tableData && !normalized.tableCellDeltas && normalized.strict) {
+        throw new Error(
+          "A table needs tableData (or tableCellDeltas) to have any cell content. Pass strict: false to create an empty table on purpose.",
+        );
+      }
     } else if ((raw.rows !== undefined || raw.columns !== undefined) && normalized.strict) {
       throw new Error("The 'rows'/'columns' fields can only be used with type='table'.");
     } else if (raw.tableData !== undefined && normalized.strict) {
@@ -3043,6 +3051,13 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
       const delta = Y.encodeStateAsUpdate(doc, prevSV);
       await pushDocUpdate(socket, workspaceId, normalized.docId, Buffer.from(delta).toString("base64"));
 
+      const warnings: string[] = [];
+      if (normalized.type === "table" && !normalized.tableData && !normalized.tableCellDeltas) {
+        warnings.push(
+          `Table ${blockId} was created with no cell content. Pass tableData to fill it; update_block cannot edit table cells afterwards.`,
+        );
+      }
+
       return {
         appended: true,
         blockId,
@@ -3052,6 +3067,7 @@ export function registerDocTools(server: McpServer, gql: GraphQLClient, defaults
         legacyType: normalized.legacyType || null,
         ownedIds: normalized._frameOwnedIds,
         missing: normalized._frameMissing,
+        ...(warnings.length ? { warnings } : {}),
       };
     } finally {
       socket.disconnect();

--- a/tests/test-block-editing.mjs
+++ b/tests/test-block-editing.mjs
@@ -70,6 +70,7 @@ async function main() {
     quoteBlockId: null,
     codeBlockId: null,
     tableBlockId: null,
+    emptyTableBlockId: null,
     emptyOverrideTableBlockId: null,
     taskText: 'Ship the verified release',
     oldTaskText: 'Ship the draft release',
@@ -85,6 +86,7 @@ async function main() {
     tableLinkUrl: 'https://gitlab.com',
     tableSiblingHeaderText: 'Keep header sibling',
     tableSiblingDataText: 'Keep data sibling',
+    emptyTableFilledText: 'Filled after creation',
     tableCellDeltas: [
       { insert: 'team.AI', attributes: { code: true } },
       { insert: ' | ' },
@@ -241,6 +243,29 @@ async function main() {
     });
     state.tableBlockId = table?.blockId;
     expectTruthy(state.tableBlockId, 'append_block 2x2 table id');
+
+    const emptyTable = await call('append_block', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      type: 'table',
+      rows: 2,
+      columns: 2,
+    });
+    state.emptyTableBlockId = emptyTable?.blockId;
+    expectTruthy(state.emptyTableBlockId, 'append_block empty table id');
+    expectEqual(emptyTable?.appended, true, 'append_block empty table still succeeds');
+    expectTruthy(
+      emptyTable?.warnings?.some(warning => warning.includes(state.emptyTableBlockId)),
+      'append_block empty table warns about the missing cell content',
+    );
+    expectTruthy(
+      emptyTable?.warnings?.some(warning => warning.includes('update_table_cell')),
+      'append_block empty table warning names update_table_cell',
+    );
+    expectTruthy(
+      table?.warnings === undefined,
+      'append_block does not warn when tableData is supplied',
+    );
 
     const emptyOverrideTable = await call('append_block', {
       workspaceId: state.workspaceId,
@@ -404,6 +429,24 @@ async function main() {
       unchangedHeaderText?.cell?.deltas,
       [{ insert: state.tableHeaderText, attributes: { bold: true } }],
       'table plain-text no-op preserves header bold',
+    );
+
+    // The warning on an empty table points at update_table_cell, so prove the
+    // route it names actually works on a table created with no cell content.
+    const filledEmptyTableCell = await call('update_table_cell', {
+      workspaceId: state.workspaceId,
+      docId: state.docId,
+      blockId: state.emptyTableBlockId,
+      row: 1,
+      column: 1,
+      text: state.emptyTableFilledText,
+    });
+    expectEqual(filledEmptyTableCell?.updated, true, 'update_table_cell fills an empty table cell');
+    expectEqual(filledEmptyTableCell?.previous?.text, '', 'empty table cell started empty');
+    expectEqual(
+      filledEmptyTableCell?.cell?.text,
+      state.emptyTableFilledText,
+      'empty table cell holds the new text',
     );
 
     await expectCallError('update_table_cell', {

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -175,11 +175,6 @@ await assert.rejects(
   /The 'tableCellDeltas' field can only be used with type='table'/,
   "append_block must reject tableCellDeltas on a non-table block",
 );
-await assert.rejects(
-  appendBlock({ docId: "doc-1", type: "table", rows: 2, columns: 2 }),
-  /A table needs tableData \(or tableCellDeltas\) to have any cell content/,
-  "append_block must not silently create an empty table under strict",
-);
 assert.equal(requestCount, 0, "invalid table cell input must not reach AFFiNE");
 
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);

--- a/tests/test-input-contracts.mjs
+++ b/tests/test-input-contracts.mjs
@@ -175,6 +175,11 @@ await assert.rejects(
   /The 'tableCellDeltas' field can only be used with type='table'/,
   "append_block must reject tableCellDeltas on a non-table block",
 );
+await assert.rejects(
+  appendBlock({ docId: "doc-1", type: "table", rows: 2, columns: 2 }),
+  /A table needs tableData \(or tableCellDeltas\) to have any cell content/,
+  "append_block must not silently create an empty table under strict",
+);
 assert.equal(requestCount, 0, "invalid table cell input must not reach AFFiNE");
 
 assert.equal(toolSchema("list_docs").safeParse({ workspaceId: "w", first: 201 }).success, false);

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.5.0",
+  "version": "3.5.1",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
Release v3.5.1 adds a caller-visible warning when `append_block` creates an empty table, while preserving successful empty-table creation and subsequent `update_table_cell` updates. It also refreshes Markdown tooling and vulnerable URI/query parsers, and aligns release metadata across the package and documentation.

Validation:
- `npm run ci`: 28 fast tests, 97-tool metadata, documentation, and package checks passed on Node.js 26.5.1.
- `npm audit --audit-level=low`: zero vulnerabilities after the targeted lockfile refresh.
- `AFFINE_REVISION=0.27.4 PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run test:e2e`: 24 integration tests and 17 Chrome browser tests passed.
- Packed-tarball installation, CLI version/help, and 97-tool discovery passed; npm publishing dry-run passed.
- Linux/amd64 Docker build and runtime smoke passed: version 3.5.1, non-root UID 100, healthy protected HTTP mode.
- Independent release diff review, release metadata validation, whitespace checks, and Hangul scan passed.

Release order: merge this release branch into main, verify ancestry, push the annotated v3.5.1 tag, confirm npm/Docker publication, and synchronize main back to develop through a dedicated branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Creating a table without cell content now returns a warning with guidance for adding content.
  - Intentionally empty tables continue to be created successfully.
  - Empty tables can be populated afterward using supported table-editing options.

- **Security**
  - Updated URI and query-string components to address security advisories.

- **Dependencies**
  - Refreshed Markdown parsing, type definitions, and runtime tooling components.

- **Tests**
  - Added coverage for empty-table warnings and subsequent cell updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->