### PR TITLE
fix: harden the stdio bridge and prepare 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-09-10
+
+### Added
+- Added `affine-mcp-http-proxy` to connect a local stdio client to an existing loopback Streamable HTTP listener without starting another full server.
+
+### Fixed
+- Recover explicitly expired HTTP MCP sessions without replaying ambiguous writes after network failures or timeouts.
+- Share email/password login attempts, retry failures after a cooldown, and renew managed cookies before expiry across long-lived transport sessions.
+- Close native stdio sessions on EOF and bound proxy signal shutdown and HTTP response reads.
+- Return JSON-RPC parse and invalid-request errors for malformed proxy input, allowing subsequent valid requests to continue.
+
+### Security
+- Updated locked `hono` from 4.13.0 to 4.13.7 to address reported static-output path traversal, form nesting, and query parsing advisories.
+
+### Tests
+- Verify malformed-input recovery, session expiration, ambiguous writes, response timeouts, and EOF cleanup.
+- Exercise the installed proxy executable against the packaged HTTP listener and verify a live authenticated AFFiNE request through the bridge.
+
 ## [3.6.0] - 2026-09-08
 
 ### Added
@@ -768,6 +786,7 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 - User management
 - Access tokens
 
+[3.7.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.7.0
 [3.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.6.0
 [3.5.1]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.5.1
 [3.5.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v3.5.0
@@ -807,4 +826,4 @@ Document create/edit/delete is now supported. These are synchronized to real AFF
 [1.4.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.4.0
 [1.3.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.3.0
 [1.6.0]: https://github.com/dawncr0w/affine-mcp-server/releases/tag/v1.6.0
-[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.6.0...HEAD
+[Unreleased]: https://github.com/dawncr0w/affine-mcp-server/compare/v3.7.0...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Model Context Protocol (MCP) server for AFFiNE. It exposes AFFiNE workspaces and documents to AI assistants over stdio (default) or HTTP (`/mcp`) and supports both AFFiNE Cloud and self-hosted deployments.
 
-[![Version](https://img.shields.io/badge/version-3.6.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
+[![Version](https://img.shields.io/badge/version-3.7.0-blue)](https://github.com/dawncr0w/affine-mcp-server/releases)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.30.0-green)](https://github.com/modelcontextprotocol/typescript-sdk)
 [![CI](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/dawncr0w/affine-mcp-server/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](LICENSE)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## Version 3.7.0 (2026-09-10)
+
+### Highlights
+- Added an opt-in `affine-mcp-http-proxy` command for local stdio clients that share an existing HTTP server.
+- Improved session recovery and managed authentication renewal for long-running clients.
+
+### What Changed
+- The bridge forwards one stdio session to a loopback `/mcp` listener, uses the host's `AFFINE_MCP_HTTP_TOKEN`, and deletes its HTTP session on EOF.
+- Explicitly expired MCP sessions can be recreated before a rejected request is replayed. Network failures, timeouts, ordinary HTTP 404 responses, and failed reinitialization never trigger automatic write replay.
+- Concurrent email/password logins share one attempt. Failed logins can retry after five seconds, and managed cookies renew before expiry, with a twelve-hour fallback when no expiry is supplied.
+- Native stdio processes close on EOF. Proxy shutdown and response reads are bounded, and malformed input receives a JSON-RPC error without preventing later requests.
+- Updated the locked Hono dependency to 4.13.7 to address reported security advisories.
+- Added packed-proxy and real-listener coverage alongside authentication and session recovery regressions.
+
+### Compatibility
+- The canonical MCP surface remains at 105 tools. No tool names or existing required inputs changed.
+- The bridge is opt-in and requires a loopback HTTP listener and an inherited `AFFINE_MCP_HTTP_TOKEN`. See the private stdio bridge section in the deployment guide.
+- Explicit cookies and bearer tokens remain caller-managed. Automatic renewal applies only to sessions established with email/password.
+- Node.js 20.18.1 or newer remains required. Release validation targets AFFiNE 0.27.4.
+
 ## Version 3.6.0 (2026-09-08)
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "affine-mcp-server",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "affine-mcp": "bin/affine-mcp"
+        "affine-mcp": "bin/affine-mcp",
+        "affine-mcp-http-proxy": "bin/affine-mcp-http-proxy"
       },
       "devDependencies": {
         "@playwright/test": "^1.50.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "affine-mcp-server",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": false,
   "type": "module",
   "description": "Model Context Protocol server for AFFiNE - enables AI assistants to interact with AFFiNE workspaces, documents, and collaboration features.",

--- a/src/stdioHttpProxy.ts
+++ b/src/stdioHttpProxy.ts
@@ -1,5 +1,6 @@
 import { createInterface } from "node:readline";
 import process from "node:process";
+import { JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
 import { fetchResponseBody } from "./util/httpResponse.js";
 
 const DEFAULT_ENDPOINT = `http://127.0.0.1:${process.env.PORT || "3000"}/mcp`;
@@ -51,12 +52,12 @@ function shutdownDeadline(): Promise<void> {
   });
 }
 
-function protocolError(id: JsonRpcId | undefined, message: string): void {
+function protocolError(id: JsonRpcId | undefined, message: string, code = -32603): void {
   if (id === undefined) return;
   writeMessage({
     jsonrpc: "2.0",
     id,
-    error: { code: -32603, message },
+    error: { code, message },
   });
 }
 
@@ -221,19 +222,19 @@ async function main(): Promise<void> {
 
   input.on("line", (line) => {
     if (!line.trim()) return;
-    let message: JsonRpcMessage;
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(line);
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        throw new Error("MCP stdio message must be a JSON object");
-      }
-      message = parsed as JsonRpcMessage;
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : "invalid JSON";
-      protocolError(undefined, detail);
+      parsed = JSON.parse(line);
+    } catch {
+      protocolError(null, "Parse error: invalid JSON", -32700);
       return;
     }
-    proxy.forward(message);
+    const message = JSONRPCMessageSchema.safeParse(parsed);
+    if (!message.success) {
+      protocolError(null, "Invalid Request: expected an MCP JSON-RPC message", -32600);
+      return;
+    }
+    proxy.forward(message.data);
   });
 
   input.once("close", () => {

--- a/tests/test-http-bearer.mjs
+++ b/tests/test-http-bearer.mjs
@@ -18,6 +18,7 @@ import { setTimeout as delay } from "node:timers/promises";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_DIR = path.resolve(__dirname, "..");
@@ -180,6 +181,25 @@ async function main() {
       expectEqual(currentUser?.email, EMAIL, "current_user via http bearer");
     } finally {
       await transport.close();
+    }
+
+    const proxyClient = new Client({ name: "http-proxy-client", version: "1.0.0" });
+    const proxyTransport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(PROJECT_DIR, "bin", "affine-mcp-http-proxy")],
+      cwd: PROJECT_DIR,
+      env: {
+        AFFINE_MCP_HTTP_TOKEN: staticToken,
+        AFFINE_MCP_HTTP_PROXY_URL: server.mcpUrl,
+      },
+      stderr: "pipe",
+    });
+    try {
+      await proxyClient.connect(proxyTransport);
+      const currentUser = parseContent(await proxyClient.callTool({ name: "current_user", arguments: {} }));
+      expectEqual(currentUser?.email, EMAIL, "current_user via stdio HTTP proxy");
+    } finally {
+      await proxyTransport.close();
     }
 
     console.log();

--- a/tests/test-package-smoke.mjs
+++ b/tests/test-package-smoke.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -28,6 +31,21 @@ const expectedManifest = JSON.parse(
   fs.readFileSync(path.join(rootDirectory, "tool-manifest.json"), "utf8")
 );
 const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "affine-mcp-package-smoke-"));
+const serverEnvironment = {
+  ...process.env,
+  AFFINE_BASE_URL: "http://127.0.0.1:9",
+  AFFINE_API_TOKEN: "package-smoke-token",
+  AFFINE_COOKIE: "",
+  AFFINE_EMAIL: "",
+  AFFINE_PASSWORD: "",
+  AFFINE_HEADERS_JSON: "",
+  AFFINE_MCP_AUTH_MODE: "bearer",
+  AFFINE_TOOL_PROFILE: "full",
+  AFFINE_DISABLED_GROUPS: "",
+  AFFINE_DISABLED_TOOLS: "",
+  MCP_TRANSPORT: "stdio",
+  XDG_CONFIG_HOME: path.join(temporaryDirectory, "config"),
+};
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -57,21 +75,7 @@ async function verifyServerSurface(installedDirectory, installedManifest) {
     command: process.execPath,
     args: [entryPoint],
     cwd: temporaryDirectory,
-    env: {
-      ...process.env,
-      AFFINE_BASE_URL: "http://127.0.0.1:9",
-      AFFINE_API_TOKEN: "package-smoke-token",
-      AFFINE_COOKIE: "",
-      AFFINE_EMAIL: "",
-      AFFINE_PASSWORD: "",
-      AFFINE_HEADERS_JSON: "",
-      AFFINE_MCP_AUTH_MODE: "bearer",
-      AFFINE_TOOL_PROFILE: "full",
-      AFFINE_DISABLED_GROUPS: "",
-      AFFINE_DISABLED_TOOLS: "",
-      MCP_TRANSPORT: "stdio",
-      XDG_CONFIG_HOME: path.join(temporaryDirectory, "config"),
-    },
+    env: serverEnvironment,
     stderr: "pipe",
   });
 
@@ -92,6 +96,73 @@ async function verifyServerSurface(installedDirectory, installedManifest) {
     );
   } finally {
     await transport.close();
+  }
+}
+
+async function verifyProxySurface(installedDirectory, installedManifest) {
+  const reservation = createServer();
+  reservation.listen(0, "127.0.0.1");
+  await once(reservation, "listening");
+  const port = reservation.address().port;
+  await new Promise((resolve, reject) => reservation.close(error => error ? reject(error) : resolve()));
+  const endpoint = `http://127.0.0.1:${port}`;
+  const token = "package-smoke-http-token";
+  const server = spawn(process.execPath, [path.join(installedDirectory, "dist", "index.js")], {
+    cwd: temporaryDirectory,
+    env: {
+      ...serverEnvironment,
+      MCP_TRANSPORT: "http",
+      PORT: String(port),
+      AFFINE_MCP_HTTP_HOST: "127.0.0.1",
+      AFFINE_MCP_HTTP_TOKEN: token,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let logs = "";
+  server.stderr.on("data", chunk => { logs += chunk; });
+  const exited = once(server, "exit");
+  const proxyBin = path.join(installedDirectory, "bin", "affine-mcp-http-proxy");
+  const installedBin = path.join(temporaryDirectory, "node_modules", ".bin", "affine-mcp-http-proxy");
+  const client = new Client({ name: "packed-proxy-smoke", version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.platform === "win32" ? process.execPath : installedBin,
+    args: process.platform === "win32" ? [proxyBin] : [],
+    cwd: temporaryDirectory,
+    env: {
+      ...serverEnvironment,
+      AFFINE_MCP_HTTP_TOKEN: token,
+      AFFINE_MCP_HTTP_PROXY_URL: `${endpoint}/mcp`,
+      AFFINE_MCP_HTTP_PROXY_TIMEOUT_MS: "10000",
+    },
+    stderr: "pipe",
+  });
+  try {
+    assert.ok(fs.existsSync(proxyBin), "packed proxy executable must exist");
+    assert.ok(fs.existsSync(path.join(installedDirectory, "dist", "stdioHttpProxy.js")),
+      "packed proxy implementation must exist");
+    let healthy = false;
+    for (let attempt = 0; attempt < 100; attempt++) {
+      assert.equal(server.exitCode, null, `packed HTTP server exited: ${logs}`);
+      try {
+        const response = await fetch(`${endpoint}/healthz`, { signal: AbortSignal.timeout(1000) });
+        healthy = response.ok;
+        await response.body?.cancel();
+      } catch { /* Wait for the listener to bind. */ }
+      if (healthy) break;
+      await delay(100);
+    }
+    assert.ok(healthy, `packed HTTP server did not become healthy: ${logs}`);
+    await client.connect(transport);
+    const { tools } = await client.listTools();
+    assert.deepEqual(tools.map(tool => tool.name).sort(), [...installedManifest.tools].sort(),
+      "installed proxy must expose the real packaged HTTP listener's tool surface");
+  } finally {
+    await transport.close();
+    if (server.exitCode === null) server.kill("SIGTERM");
+    if (!await Promise.race([exited.then(() => true), delay(5000).then(() => false)])) {
+      server.kill("SIGKILL");
+      await exited;
+    }
   }
 }
 
@@ -138,13 +209,14 @@ try {
   assert.match(help.stdout, /affine-mcp login/);
 
   await verifyServerSurface(installedDirectory, installedManifest);
+  await verifyProxySurface(installedDirectory, installedManifest);
 
   console.log(JSON.stringify({
     ok: true,
     tarball: tarballPath,
     package: `${installedPackage.name}@${installedPackage.version}`,
     tools: installedManifest.tools.length,
-    checks: ["installed package", "bin version", "dist version", "CLI help", "MCP tools/list"],
+    checks: ["installed package", "bin version", "dist version", "CLI help", "MCP tools/list", "installed proxy to HTTP tools/list"],
   }, null, 2));
 } finally {
   fs.rmSync(temporaryDirectory, { recursive: true, force: true });

--- a/tests/test-stdio-http-proxy.mjs
+++ b/tests/test-stdio-http-proxy.mjs
@@ -131,6 +131,7 @@ async function main() {
   });
   child.stderr.on("data", (chunk) => { stderr += chunk; });
 
+  child.stdin.write('{\nnull\n[]\n{"jsonrpc":"2.0","id":50,"method":123}\n');
   child.stdin.write(`${JSON.stringify({
     jsonrpc: "2.0",
     id: 1,
@@ -141,7 +142,10 @@ async function main() {
   child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })}\n`);
 
   try {
-    await waitFor(() => responses.length === 2);
+    await waitFor(() => responses.length === 6);
+    assert.deepEqual(responses.splice(0, 4).map(({ id, error }) => [id, error.code]), [
+      [null, -32700], [null, -32600], [null, -32600], [null, -32600],
+    ], "invalid input must return protocol errors without blocking later requests");
     assert.deepEqual(responses.map((response) => response.id), [1, 2], "proxy must preserve JSON-RPC response ids");
     assert.equal(responses[1].result.tools[0].name, "example", "proxy must parse streamable HTTP SSE responses");
 

--- a/tool-manifest.json
+++ b/tool-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "tools": [
     "add_database_column",
     "add_database_row",


### PR DESCRIPTION
Malformed stdio input was silently discarded by the new HTTP bridge. It now returns JSON-RPC parse or invalid-request errors and continues processing valid messages. This also prepares the backward-compatible 3.7.0 release of the bridge introduced in #340.

- Verify the installed proxy executable against the real packaged HTTP listener and an authenticated live AFFiNE request.
- Update locked Hono from 4.13.0 to 4.13.7 for the reported security advisories and align the proxy bin metadata.
- Synchronize package, manifest, README, changelog, and release notes at 3.7.0. The MCP surface remains 105 tools.

Validation on Node.js 26.5.1 and isolated AFFiNE 0.27.4:
- `npm run ci`: passed, including 34 fast test files, metadata/docs checks, and package sanity.
- `npm audit --audit-level=low`: zero vulnerabilities.
- `npm run test:comprehensive`: 16 focused integrations and 121/121 comprehensive checks passed.
- `PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run test:e2e`: 24 integration test files and 17 Chrome browser tests passed.
- Packed-tarball install/CLI/tool discovery and installed-proxy-to-HTTP smoke passed.
- Linux/amd64 Docker build and runtime smoke passed: version 3.7.0, non-root UID 100, healthy protected HTTP mode.

Release route: merge this preparation into `develop`, then create `release/3.7.0` from the validated tree for a separate PR into `main`. Tagging and publication follow that main merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in HTTP proxy that connects local stdio clients to an existing loopback MCP server.
  * Added session recovery and automatic email/password authentication renewal for long-lived connections.
  * Added graceful handling for standard input closure and proxy shutdown signals.

* **Bug Fixes**
  * Malformed JSON-RPC input now returns standard parse or invalid-request errors without blocking later requests.
  * Improved recovery of explicitly expired sessions without replaying uncertain writes.
  * Updated the web framework to address security and request-parsing advisories.

* **Tests**
  * Expanded coverage for proxy connectivity, session handling, authentication renewal, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->