### PR TITLE
fix: harden session recovery and cookie expiry before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Share email/password login attempts, retry failures after a cooldown, and renew managed cookies before expiry across long-lived transport sessions.
 - Close native stdio sessions on EOF and bound proxy signal shutdown and HTTP response reads.
 - Return JSON-RPC parse and invalid-request errors for malformed proxy input, allowing subsequent valid requests to continue.
+- Discard restored session IDs when the initialized notification fails, and preserve expired login-cookie deadlines without treating unrelated cleared cookies as expired sessions.
 
 ### Security
 - Updated locked `hono` from 4.13.0 to 4.13.7 to address reported static-output path traversal, form nesting, and query parsing advisories.
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 - Verify malformed-input recovery, session expiration, ambiguous writes, response timeouts, and EOF cleanup.
 - Exercise the installed proxy executable against the packaged HTTP listener and verify a live authenticated AFFiNE request through the bridge.
+- Cover failed initialized notifications, expired cookies, and bounded test polling.
 
 ## [3.6.0] - 2026-09-08
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,12 +11,14 @@
 - Explicitly expired MCP sessions can be recreated before a rejected request is replayed. Network failures, timeouts, ordinary HTTP 404 responses, and failed reinitialization never trigger automatic write replay.
 - Concurrent email/password logins share one attempt. Failed logins can retry after five seconds, and managed cookies renew before expiry, with a twelve-hour fallback when no expiry is supplied.
 - Native stdio processes close on EOF. Proxy shutdown and response reads are bounded, and malformed input receives a JSON-RPC error without preventing later requests.
+- Failed initialized notifications clear the restored session ID before another request can use it. Already expired login cookies retain their deadlines, while unrelated cleared cookies do not force premature renewal.
 - Updated the locked Hono dependency to 4.13.7 to address reported security advisories.
 - Added packed-proxy and real-listener coverage alongside authentication and session recovery regressions.
 
 ### Compatibility
 - The canonical MCP surface remains at 105 tools. No tool names or existing required inputs changed.
 - The bridge is opt-in and requires a loopback HTTP listener and an inherited `AFFINE_MCP_HTTP_TOKEN`. See the private stdio bridge section in the deployment guide.
+- Default loopback HTTP assumes a trusted host or container. Use isolation or authenticated TLS when untrusted local processes can replace the listener; loopback alone does not authenticate the server.
 - Explicit cookies and bearer tokens remain caller-managed. Automatic renewal applies only to sessions established with email/password.
 - Node.js 20.18.1 or newer remains required. Release validation targets AFFiNE 0.27.4.
 

--- a/docs/configuration-and-deployment.md
+++ b/docs/configuration-and-deployment.md
@@ -221,6 +221,13 @@ token in the host/container environment: do not put it in a command line or
 copy it to the client. `AFFINE_MCP_HTTP_PROXY_URL` defaults to
 `http://127.0.0.1:${PORT:-3000}/mcp` and accepts loopback URLs only.
 
+The default HTTP connection assumes a trusted host or container where untrusted
+processes cannot replace the listener or claim its port. Loopback limits network
+reachability; it does not authenticate the listener to the bridge. On a shared
+host with untrusted processes, use an `https://` loopback endpoint with a trusted
+certificate and an authenticated TLS terminator, or isolate the bridge and
+listener together. Do not disable TLS certificate verification.
+
 The bridge reinitializes an expired HTTP session only when the listener explicitly
 rejects its session ID before dispatch. It never retries an ambiguous request
 after a network failure or timeout, which avoids duplicating document writes.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,14 +16,18 @@ function extractCookiePairs(setCookies: string[]): string {
 
 function cookieExpiresAt(setCookies: string[]): number | undefined {
   const now = Date.now();
-  const deadlines = setCookies.flatMap(cookie => {
+  const deadlines = setCookies.map(cookie => {
     const maxAge = cookie.match(/;\s*max-age=(-?\d+)(?:;|$)/i);
     const expires = cookie.match(/;\s*expires=([^;]+)/i);
     const deadline = maxAge ? now + Number(maxAge[1]) * 1000
       : expires ? Date.parse(expires[1]) : NaN;
-    return Number.isFinite(deadline) && deadline > now ? [deadline] : [];
+    return Number.isFinite(deadline) ? deadline : undefined;
   });
-  return deadlines.length ? Math.min(...deadlines) : undefined;
+  // A cleared cookie must not expire another usable cookie from the same login.
+  const active = deadlines.filter(deadline => deadline === undefined || deadline > now);
+  const finite = (active.length ? active : deadlines)
+    .filter((deadline): deadline is number => deadline !== undefined);
+  return finite.length ? Math.min(...finite) : undefined;
 }
 
 /** Reject cookie values containing CR/LF to prevent header injection. */

--- a/src/stdioHttpProxy.ts
+++ b/src/stdioHttpProxy.ts
@@ -160,12 +160,16 @@ class StdioHttpProxy {
     this.sessionId = undefined;
     if (!this.initializeMessage) throw new Error("MCP session is not initialized");
     await this.forwardOne(this.initializeMessage, false, false);
-    const { response } = await this.exchange({
-      jsonrpc: "2.0", method: "notifications/initialized",
-    });
-    if (!response.ok) {
+    try {
+      const { response } = await this.exchange({
+        jsonrpc: "2.0", method: "notifications/initialized",
+      });
+      if (!response.ok) {
+        throw new Error(`MCP reinitialization failed with status ${response.status}`);
+      }
+    } catch (error) {
       this.sessionId = undefined;
-      throw new Error(`MCP reinitialization failed with status ${response.status}`);
+      throw error;
     }
   }
 

--- a/tests/test-auth-session.mjs
+++ b/tests/test-auth-session.mjs
@@ -100,7 +100,10 @@ async function startMockAffine(options = {}) {
           return;
         }
         state.loginCompletedAt = Date.now();
-        jsonResponse(res, 200, { ok: true }, { "Set-Cookie": `${COOKIE}; Path=/; HttpOnly${options.cookieAttributes || ""}` });
+        jsonResponse(res, 200, { ok: true }, { "Set-Cookie": [
+          `${COOKIE}; Path=/; HttpOnly${options.cookieAttributes || ""}`,
+          ...(options.additionalCookies || []),
+        ] });
         return;
       }
 
@@ -464,6 +467,57 @@ async function testCookieRenewal() {
   }
 }
 
+async function testExpiredCookieRenewal() {
+  for (const cookieAttributes of [
+    "; Max-Age=0", "; Max-Age=-1", "; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+  ]) {
+    const mock = await startMockAffine({ cookieAttributes });
+    try {
+      const result = await loginWithPassword(mock.baseUrl, EMAIL, PASSWORD);
+      assert(Number.isFinite(result.expiresAt) && result.expiresAt <= Date.now(),
+        `${cookieAttributes} must retain an expired deadline`);
+      let calls = 0;
+      const session = new AuthSession({
+        baseUrl: mock.baseUrl, email: EMAIL, password: PASSWORD,
+        login: async () => ++calls === 1 ? result : { cookieHeader: "session=renewed" },
+      });
+      await session.ready();
+      assertEqual((await session.ready()).cookie, "session=renewed", "expired cookie renews on the next request");
+      assertEqual(calls, 2, "expired cookie must not receive the no-expiry fallback");
+    } finally {
+      await mock.close();
+    }
+  }
+
+  for (const cookieAttributes of ["", "; Max-Age=120"]) {
+    const mock = await startMockAffine({
+      cookieAttributes, additionalCookies: ["obsolete=; Max-Age=0; Path=/"],
+    });
+    try {
+      const result = await loginWithPassword(mock.baseUrl, EMAIL, PASSWORD);
+      if (cookieAttributes) assert(result.expiresAt > Date.now(), "cleared cookie must not expire a live cookie");
+      else assertEqual(result.expiresAt, undefined, "cleared cookie must not change a session cookie's fallback");
+    } finally {
+      await mock.close();
+    }
+  }
+
+  let now = 0;
+  let calls = 0;
+  const session = new AuthSession({
+    baseUrl: "http://127.0.0.1:1", email: EMAIL, password: PASSWORD,
+    now: () => now,
+    login: async () => ({ cookieHeader: `session=${++calls}` }),
+  });
+  await session.ready();
+  now = 11 * 60 * 60 * 1000;
+  await session.ready();
+  assertEqual(calls, 1, "no-expiry cookies retain the twelve-hour fallback");
+  now = 12 * 60 * 60 * 1000;
+  await session.ready();
+  assertEqual(calls, 2, "no-expiry cookies renew by twelve hours");
+}
+
 async function testFailureNeverFallsBack() {
   const mock = await startMockAffine({ failLogin: true });
   try {
@@ -620,6 +674,7 @@ async function main() {
   await testConfiguredAuthResolution();
   await testTransientLoginRecovery();
   await testCookieRenewal();
+  await testExpiredCookieRenewal();
   await testExclusiveAuthState();
   await testFailureNeverFallsBack();
   await testEnvironmentCredentialsOverrideSavedAuthentication();

--- a/tests/test-proxy-recovery.mjs
+++ b/tests/test-proxy-recovery.mjs
@@ -9,6 +9,7 @@ const requests = [];
 let generation = 1;
 let writes = 0;
 let failInitialize = false;
+let failInitialized = "";
 const server = createServer(async (req, res) => {
   if (req.method === "DELETE") {
     res.writeHead(204).end();
@@ -35,6 +36,19 @@ const server = createServer(async (req, res) => {
     return;
   }
   if (message.method === "notifications/initialized") {
+    if (failInitialized === "disconnect") {
+      req.socket.destroy();
+      return;
+    }
+    if (failInitialized === "timeout") {
+      res.writeHead(202);
+      res.flushHeaders();
+      return;
+    }
+    if (failInitialized === "status") {
+      res.writeHead(503).end();
+      return;
+    }
     res.writeHead(202).end();
     return;
   }
@@ -110,6 +124,19 @@ try {
   failInitialize = false;
   assert((await call("tools/call", { name: "write", arguments: {} })).result);
   assert.equal(writes, 3, "a later request can recover after failed initialization");
+  for (const failure of ["disconnect", "timeout", "status"]) {
+    generation++;
+    const previousWrites = writes;
+    const previousInitializations = requests.filter(method => method === "initialize").length;
+    failInitialized = failure;
+    assert((await call("tools/call", { name: "write", arguments: {} })).error);
+    assert.equal(writes, previousWrites, `${failure}: incomplete initialization must not dispatch a write`);
+    failInitialized = "";
+    assert((await call("tools/call", { name: "write", arguments: {} })).result);
+    assert.equal(writes, previousWrites + 1, `${failure}: a later request executes once`);
+    assert.equal(requests.filter(method => method === "initialize").length, previousInitializations + 2,
+      `${failure}: a later request must establish a fully initialized session`);
+  }
   child.stdin.end();
   const [code] = await once(child, "exit");
   assert.equal(code, 0, "EOF cleans up after recovery");

--- a/tests/test-stdio-http-proxy.mjs
+++ b/tests/test-stdio-http-proxy.mjs
@@ -6,6 +6,7 @@ import { existsSync } from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_DIR = path.resolve(__dirname, "..");
@@ -89,19 +90,12 @@ async function startServer() {
   };
 }
 
-function waitFor(predicate, timeoutMs = 4_000) {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("timed out waiting for proxy output")), timeoutMs);
-    const poll = () => {
-      if (predicate()) {
-        clearTimeout(timer);
-        resolve();
-        return;
-      }
-      setTimeout(poll, 10);
-    };
-    poll();
-  });
+async function waitFor(predicate, timeoutMs = 4_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for proxy output");
+    await delay(10);
+  }
 }
 
 async function main() {
@@ -194,6 +188,12 @@ async function testNativeStdioEof() {
     if (child.exitCode === null) child.kill("SIGKILL");
   }
 }
+
+let polls = 0;
+await assert.rejects(waitFor(() => { polls++; return false; }, 20), /timed out/);
+const completedPolls = polls;
+await delay(30);
+assert.equal(polls, completedPolls, "timed-out waits must stop polling");
 
 await main();
 await testNativeStdioEof();


### PR DESCRIPTION
Expired login cookies could receive the twelve-hour fallback, and a failed initialized notification could leave a partially restored MCP session in use. Preserve expired cookie deadlines while ignoring unrelated cleared cookies, and clear restored sessions on transport, timeout, or HTTP failures.

Stop test polling after timeout and document the trusted-host boundary of default loopback HTTP, with isolation or authenticated TLS required when local processes are untrusted. These corrections are also included in release PR #342; merge this maintenance branch into develop before the release is merged into main.

Validation on this exact source tree: npm run ci (34 fast test files, build, metadata, docs, package checks), 16 focused integration files and 121 comprehensive checks against AFFiNE 0.27.4, 24 E2E integration files and 17 Chrome browser tests, packed installation and proxy smoke, and a Linux amd64 Docker build with non-root healthy protected HTTP. npm audit reports zero vulnerabilities. Independent review found no remaining actionable defects.
